### PR TITLE
feat: add execution command for listing and getting executions

### DIFF
--- a/.claude/skills/n8n-cli/SKILL.md
+++ b/.claude/skills/n8n-cli/SKILL.md
@@ -357,6 +357,79 @@ Config file search order:
 ./n8n-cli test ./definitions/my-workflow.json
 ```
 
+### 7. Execution (Logs & Errors)
+
+**List recent executions:**
+
+```bash
+# List all recent executions
+./n8n-cli execution list
+
+# Table format for readability
+./n8n-cli -o table execution list
+
+# Filter by status
+./n8n-cli execution list --status error
+./n8n-cli execution list --status success
+
+# Filter by workflow
+./n8n-cli execution list --workflow <workflow-id>
+
+# Limit results
+./n8n-cli execution list --limit 5
+
+# Combined filters
+./n8n-cli execution list --workflow <workflow-id> --status error --limit 10
+```
+
+**Get execution details:**
+
+```bash
+# Get execution by ID
+./n8n-cli execution get <execution-id>
+
+# Table format with error details
+./n8n-cli -o table execution get <execution-id>
+
+# Include node execution summary
+./n8n-cli -o table execution get <execution-id> --show-data
+```
+
+**Options for `execution list`:**
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workflow <id>` | Filter by workflow ID |
+| `-s, --status <status>` | Filter by status (success, error, running, waiting) |
+| `-l, --limit <n>` | Maximum number of executions (default: 20) |
+
+**Options for `execution get`:**
+
+| Option | Description |
+|--------|-------------|
+| `--show-data` | Include node execution summary in output |
+
+**Error information displayed:**
+
+| Field | Description |
+|-------|-------------|
+| Error Node | The node where the error occurred |
+| Error Message | The error message |
+| Error Details | Additional error description (if available) |
+| Last Node | The last executed node |
+
+**Typical debugging workflow:**
+
+```bash
+# 1. List recent errors
+./n8n-cli -o table execution list --status error --limit 5
+
+# 2. Get details of a specific failed execution
+./n8n-cli -o table execution get <execution-id> --show-data
+
+# 3. Review error details and fix the workflow
+```
+
 ## Typical Workflow Operations
 
 ### Editing Workflows

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Format** - Auto-organize node positions for cleaner workflow layouts
 - **Test** - Execute CLI tests against workflows via webhook endpoints
 - **Workflow management** - List, get, create, update, delete, activate, and deactivate workflows via the n8n API
+- **Execution management** - List executions, get execution details, and view error information for debugging
 - **Git integration** - Apply only workflows changed in a Git diff
 - **YAML support** - Work with YAML workflow definitions and external code/SQL files
 - **CLAUDE.md integration** - Read project settings (default project ID, auto tags, YAML mode) from CLAUDE.md
@@ -180,6 +181,47 @@ n8n-cli workflow <subcommand>
 | `delete <id>` | Delete a workflow |
 | `activate <id>` | Activate a workflow |
 | `deactivate <id>` | Deactivate a workflow |
+
+### `execution`
+
+Manage n8n workflow executions.
+
+```bash
+n8n-cli execution <subcommand>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List workflow executions |
+| `get <id>` | Get execution details by ID |
+
+#### `execution list`
+
+```bash
+n8n-cli execution list [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workflow <id>` | Filter by workflow ID |
+| `-s, --status <status>` | Filter by status (`success`, `error`, `running`, `waiting`) |
+| `-l, --limit <n>` | Maximum number of executions to return (default: 20) |
+
+#### `execution get`
+
+```bash
+n8n-cli execution get <id> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--show-data` | Include node execution summary in output |
+
+**Output includes:**
+- Execution ID, workflow ID, status, mode
+- Start and stop timestamps
+- Error details (node, message, description) if the execution failed
+- Node execution summary (with `--show-data`)
 
 ### `version`
 

--- a/src/cli/commands/execution-get.ts
+++ b/src/cli/commands/execution-get.ts
@@ -1,0 +1,99 @@
+import type { Command } from "commander";
+import type { Execution } from "../../api/execution-service.ts";
+import { formatJSON } from "../output/json.ts";
+import { formatKeyValue, formatTable } from "../output/table.ts";
+import { resolveContext } from "../root.ts";
+
+export function registerExecutionGetCommand(parent: Command): void {
+  parent
+    .command("get")
+    .description("Get an execution by ID")
+    .argument("<id>", "Execution ID")
+    .option("--show-data", "Include full execution data in output")
+    .action(async (id: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const execution = await ctx.executionService.getExecution(id);
+
+      outputExecution(execution, ctx.config.output, options.showData as boolean);
+    });
+}
+
+function outputExecution(execution: Execution, format: string, showData: boolean): void {
+  if (format === "table") {
+    const info: Record<string, string> = {
+      ID: execution.id,
+      "Workflow ID": execution.workflowId,
+      Status: formatStatus(execution.status),
+      Mode: execution.mode,
+      Started: execution.startedAt ? execution.startedAt.slice(0, 19).replace("T", " ") : "-",
+      Stopped: execution.stoppedAt ? execution.stoppedAt.slice(0, 19).replace("T", " ") : "-",
+    };
+
+    // Add error info if present
+    const error = execution.data?.resultData?.error;
+    if (error) {
+      info["Error Node"] = error.node ?? "-";
+      info["Error Message"] = error.message;
+      if (error.description) {
+        info["Error Details"] = truncate(error.description, 100);
+      }
+    }
+
+    // Add last executed node
+    const lastNode = execution.data?.resultData?.lastNodeExecuted;
+    if (lastNode) {
+      info["Last Node"] = lastNode;
+    }
+
+    formatKeyValue(info);
+
+    // Show node execution summary if data available
+    if (showData && execution.data?.resultData?.runData) {
+      console.log("\nNode Execution Summary:");
+      const runData = execution.data.resultData.runData;
+      const headers = ["NODE", "TIME (ms)", "STATUS"];
+      const rows: string[][] = [];
+
+      for (const [nodeName, executions] of Object.entries(runData)) {
+        for (const exec of executions) {
+          const status = exec.error ? `✗ ${exec.error.message}` : "✓ success";
+          rows.push([nodeName, String(exec.executionTime ?? 0), truncate(status, 40)]);
+        }
+      }
+
+      if (rows.length > 0) {
+        formatTable(headers, rows);
+      }
+    }
+  } else {
+    // For JSON output, optionally strip data for cleaner output
+    if (!showData && execution.data) {
+      const { data: _data, ...rest } = execution;
+      formatJSON(rest, true);
+    } else {
+      formatJSON(execution, true);
+    }
+  }
+}
+
+function formatStatus(status: string): string {
+  switch (status) {
+    case "success":
+      return "✓ success";
+    case "error":
+      return "✗ error";
+    case "running":
+      return "⋯ running";
+    case "waiting":
+      return "◌ waiting";
+    case "crashed":
+      return "! crashed";
+    default:
+      return status;
+  }
+}
+
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return `${s.slice(0, maxLen - 3)}...`;
+}

--- a/src/cli/commands/execution-get.ts
+++ b/src/cli/commands/execution-get.ts
@@ -1,8 +1,8 @@
 import type { Command } from "commander";
-import type { Execution } from "../../api/execution-service.ts";
-import { formatJSON } from "../output/json.ts";
-import { formatKeyValue, formatTable } from "../output/table.ts";
-import { resolveContext } from "../root.ts";
+import type { Execution } from "@/api/execution-service.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue, formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
 
 export function registerExecutionGetCommand(parent: Command): void {
   parent

--- a/src/cli/commands/execution-list.ts
+++ b/src/cli/commands/execution-list.ts
@@ -1,0 +1,77 @@
+import type { Command } from "commander";
+import type { Execution, ExecutionStatus } from "../../api/execution-service.ts";
+import { formatJSON } from "../output/json.ts";
+import { formatTable } from "../output/table.ts";
+import { resolveContext } from "../root.ts";
+
+export function registerExecutionListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List workflow executions")
+    .option("-w, --workflow <id>", "Filter by workflow ID")
+    .option("-s, --status <status>", "Filter by status (success, error, running, waiting)")
+    .option("-l, --limit <n>", "Maximum number of executions to return", "20")
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      const limit = Number.parseInt(options.limit as string, 10);
+      const opts: {
+        workflowId?: string;
+        status?: ExecutionStatus;
+        limit?: number;
+      } = {};
+
+      if (options.workflow) {
+        opts.workflowId = options.workflow as string;
+      }
+
+      if (options.status) {
+        opts.status = options.status as ExecutionStatus;
+      }
+
+      if (limit > 0) {
+        opts.limit = limit;
+      }
+
+      const response = await ctx.executionService.listExecutions(opts);
+      outputExecutions(response.data, ctx.config.output);
+    });
+}
+
+function outputExecutions(executions: Execution[], format: string): void {
+  if (format === "table") {
+    console.log(`Found ${executions.length} execution(s)\n`);
+
+    if (executions.length === 0) return;
+
+    const headers = ["ID", "WORKFLOW", "STATUS", "MODE", "STARTED", "STOPPED"];
+    const rows = executions.map((e) => [
+      e.id,
+      e.workflowId,
+      formatStatus(e.status),
+      e.mode,
+      e.startedAt ? e.startedAt.slice(0, 19).replace("T", " ") : "-",
+      e.stoppedAt ? e.stoppedAt.slice(0, 19).replace("T", " ") : "-",
+    ]);
+    formatTable(headers, rows);
+  } else {
+    formatJSON(executions, true);
+  }
+}
+
+function formatStatus(status: string): string {
+  switch (status) {
+    case "success":
+      return "✓ success";
+    case "error":
+      return "✗ error";
+    case "running":
+      return "⋯ running";
+    case "waiting":
+      return "◌ waiting";
+    case "crashed":
+      return "! crashed";
+    default:
+      return status;
+  }
+}

--- a/src/cli/commands/execution-list.ts
+++ b/src/cli/commands/execution-list.ts
@@ -1,8 +1,8 @@
 import type { Command } from "commander";
-import type { Execution, ExecutionStatus } from "../../api/execution-service.ts";
-import { formatJSON } from "../output/json.ts";
-import { formatTable } from "../output/table.ts";
-import { resolveContext } from "../root.ts";
+import type { Execution, ExecutionStatus } from "@/api/execution-service.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
 
 export function registerExecutionListCommand(parent: Command): void {
   parent

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -1,0 +1,9 @@
+import type { Command } from "commander";
+import { registerExecutionGetCommand } from "./execution-get.ts";
+import { registerExecutionListCommand } from "./execution-list.ts";
+
+export function registerExecutionCommand(program: Command): void {
+  const exec = program.command("execution").description("Manage n8n executions");
+  registerExecutionListCommand(exec);
+  registerExecutionGetCommand(exec);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { registerApplyCommand } from "./cli/commands/apply.ts";
+import { registerExecutionCommand } from "./cli/commands/execution.ts";
 import { registerFmtCommand } from "./cli/commands/fmt.ts";
 import { registerImportCommand } from "./cli/commands/import.ts";
 import { registerLintCommand } from "./cli/commands/lint.ts";
@@ -10,6 +11,7 @@ const program = createProgram();
 
 // Register commands
 registerWorkflowCommand(program);
+registerExecutionCommand(program);
 registerApplyCommand(program);
 registerImportCommand(program);
 registerLintCommand(program);


### PR DESCRIPTION
## Summary
- Add new `execution` subcommand to manage n8n executions
- Implement `execution list` command with workflow, status, and limit filters
- Implement `execution get` command for detailed execution information including error details

## Test plan
- [x] `execution list` returns executions in table format
- [x] `execution list --output json` returns valid JSON
- [x] `execution list --workflow <id>` filters by workflow
- [x] `execution list --status error` filters by status
- [x] `execution get <id>` shows execution details
- [x] `execution get <id> --show-data` shows node execution summary
- [x] Build passes with `make build`

## Usage

```bash
# List recent executions
n8n-cli execution list

# Filter by workflow
n8n-cli execution list --workflow abc123

# Filter by status
n8n-cli execution list --status error --limit 5

# Get execution details
n8n-cli execution get 1234

# Get execution with node summary
n8n-cli execution get 1234 --show-data
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)