### PR TITLE
feat: add execution delete, retry, stop commands

### DIFF
--- a/src/api/execution-service.ts
+++ b/src/api/execution-service.ts
@@ -144,4 +144,25 @@ export class ExecutionService {
 
     throw new Error(`timeout waiting for execution ${id} to complete`);
   }
+
+  /** DeleteExecution deletes an execution by ID */
+  async deleteExecution(id: string): Promise<Execution> {
+    const path = `/executions/${encodeURIComponent(id)}`;
+    const data = await this.client.delete(path);
+    return JSON.parse(data) as Execution;
+  }
+
+  /** RetryExecution retries a failed execution */
+  async retryExecution(id: string): Promise<Execution> {
+    const path = `/executions/${encodeURIComponent(id)}/retry`;
+    const data = await this.client.post(path);
+    return JSON.parse(data) as Execution;
+  }
+
+  /** StopExecution stops a running execution */
+  async stopExecution(id: string): Promise<Execution> {
+    const path = `/executions/${encodeURIComponent(id)}/stop`;
+    const data = await this.client.post(path);
+    return JSON.parse(data) as Execution;
+  }
 }

--- a/src/cli/commands/execution-delete.ts
+++ b/src/cli/commands/execution-delete.ts
@@ -1,0 +1,26 @@
+import type { Command } from "commander";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerExecutionDeleteCommand(parent: Command): void {
+  parent
+    .command("delete")
+    .description("Delete an execution by ID")
+    .argument("<id>", "Execution ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const execution = await ctx.executionService.deleteExecution(id);
+
+      if (ctx.config.output === "table") {
+        formatKeyValue({
+          ID: execution.id,
+          "Workflow ID": execution.workflowId,
+          Status: execution.status,
+        });
+        console.log("\nExecution deleted successfully.");
+      } else {
+        formatJSON(execution, true);
+      }
+    });
+}

--- a/src/cli/commands/execution-retry.ts
+++ b/src/cli/commands/execution-retry.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerExecutionRetryCommand(parent: Command): void {
+  parent
+    .command("retry")
+    .description("Retry a failed execution")
+    .argument("<id>", "Execution ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const execution = await ctx.executionService.retryExecution(id);
+
+      if (ctx.config.output === "table") {
+        formatKeyValue({
+          "Original ID": id,
+          "New Execution ID": execution.id,
+          "Workflow ID": execution.workflowId,
+          Status: execution.status,
+        });
+        console.log("\nExecution retry started.");
+      } else {
+        formatJSON(execution, true);
+      }
+    });
+}

--- a/src/cli/commands/execution-stop.ts
+++ b/src/cli/commands/execution-stop.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerExecutionStopCommand(parent: Command): void {
+  parent
+    .command("stop")
+    .description("Stop a running execution")
+    .argument("<id>", "Execution ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const execution = await ctx.executionService.stopExecution(id);
+
+      if (ctx.config.output === "table") {
+        formatKeyValue({
+          ID: execution.id,
+          "Workflow ID": execution.workflowId,
+          Status: execution.status,
+          Stopped: execution.stoppedAt ?? "-",
+        });
+        console.log("\nExecution stopped.");
+      } else {
+        formatJSON(execution, true);
+      }
+    });
+}

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -1,9 +1,15 @@
 import type { Command } from "commander";
+import { registerExecutionDeleteCommand } from "./execution-delete.ts";
 import { registerExecutionGetCommand } from "./execution-get.ts";
 import { registerExecutionListCommand } from "./execution-list.ts";
+import { registerExecutionRetryCommand } from "./execution-retry.ts";
+import { registerExecutionStopCommand } from "./execution-stop.ts";
 
 export function registerExecutionCommand(program: Command): void {
   const exec = program.command("execution").description("Manage n8n executions");
   registerExecutionListCommand(exec);
   registerExecutionGetCommand(exec);
+  registerExecutionDeleteCommand(exec);
+  registerExecutionRetryCommand(exec);
+  registerExecutionStopCommand(exec);
 }


### PR DESCRIPTION
## Summary

- Add `execution delete <id>` command to delete an execution
- Add `execution retry <id>` command to retry a failed execution
- Add `execution stop <id>` command to stop a running execution
- Include all changes from #3 (execution list/get commands)

## Changes

### New Commands
- `n8n-cli execution delete <id>` - Delete an execution by ID
- `n8n-cli execution retry <id>` - Retry a failed execution
- `n8n-cli execution stop <id>` - Stop a running execution

### API Service
- Add `deleteExecution()`, `retryExecution()`, `stopExecution()` methods to ExecutionService

## Test plan

- [ ] Test `execution delete` command
- [ ] Test `execution retry` command with a failed execution
- [ ] Test `execution stop` command with a running execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)