### PR TITLE
feat: add tags command

### DIFF
--- a/src/api/tag-service.ts
+++ b/src/api/tag-service.ts
@@ -87,6 +87,26 @@ export class TagService {
     }
   }
 
+  /** GetTag retrieves a tag by ID */
+  async getTag(id: string): Promise<Tag> {
+    const path = `/tags/${encodeURIComponent(id)}`;
+    const data = await this.client.get(path);
+    return JSON.parse(data) as Tag;
+  }
+
+  /** UpdateTag updates an existing tag */
+  async updateTag(id: string, input: TagInput): Promise<Tag> {
+    const path = `/tags/${encodeURIComponent(id)}`;
+    const data = await this.client.put(path, input);
+    return JSON.parse(data) as Tag;
+  }
+
+  /** DeleteTag deletes a tag by ID */
+  async deleteTag(id: string): Promise<void> {
+    const path = `/tags/${encodeURIComponent(id)}`;
+    await this.client.delete(path);
+  }
+
   /** UpdateWorkflowTags updates the tags for a workflow (replaces all tags) */
   async updateWorkflowTags(workflowId: string, tagIds: TagIDInput[]): Promise<void> {
     const path = `/workflows/${encodeURIComponent(workflowId)}/tags`;

--- a/src/cli/commands/tag-create.ts
+++ b/src/cli/commands/tag-create.ts
@@ -1,0 +1,32 @@
+import type { Command } from "commander";
+import type { Tag } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerTagCreateCommand(parent: Command): void {
+  parent
+    .command("create")
+    .description("Create a new tag")
+    .argument("<name>", "Tag name")
+    .action(async (name: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const tag = await ctx.tagService.createTag({ name });
+
+      console.log("Tag created successfully");
+      outputTag(tag, ctx.config.output);
+    });
+}
+
+function outputTag(tag: Tag, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: tag.id ?? "-",
+      Name: tag.name,
+      Created: tag.createdAt ? tag.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: tag.updatedAt ? tag.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(tag, true);
+  }
+}

--- a/src/cli/commands/tag-delete.ts
+++ b/src/cli/commands/tag-delete.ts
@@ -1,0 +1,77 @@
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import { isAuthError, isNotFoundError } from "@/api/errors.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerTagDeleteCommand(parent: Command): void {
+  parent
+    .command("delete")
+    .description("Delete one or more tags")
+    .argument("<ids...>", "One or more tag IDs to delete")
+    .option("--force", "Skip confirmation prompt")
+    .action(async (ids: string[], options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      if (!options.force) {
+        const lines: string[] = [];
+        for (const id of ids) {
+          try {
+            const tag = await ctx.tagService.getTag(id);
+            lines.push(`  - ${tag.name} (${id})`);
+          } catch (err) {
+            if (isNotFoundError(err)) {
+              console.error(`Error: tag not found: ${id}`);
+              process.exit(1);
+            }
+            if (isAuthError(err)) {
+              throw err;
+            }
+            lines.push(`  - ${id}`);
+          }
+        }
+
+        console.log(`The following ${ids.length} tag(s) will be deleted:\n${lines.join("\n")}`);
+
+        const confirmed = await confirmDelete("these tags");
+        if (!confirmed) {
+          console.log("Deletion cancelled");
+          return;
+        }
+      }
+
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const id of ids) {
+        try {
+          await ctx.tagService.deleteTag(id);
+          console.log(`Deleted: ${id}`);
+          succeeded++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`Error deleting ${id}: ${msg}`);
+          failed++;
+        }
+      }
+
+      console.log(`\nSummary: ${succeeded} succeeded, ${failed} failed (of ${ids.length} total)`);
+
+      if (failed > 0) {
+        process.exit(1);
+      }
+    });
+}
+
+function confirmDelete(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(`Are you sure you want to delete ${name}? [y/N]: `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      resolve(trimmed === "y" || trimmed === "yes");
+    });
+  });
+}

--- a/src/cli/commands/tag-get.ts
+++ b/src/cli/commands/tag-get.ts
@@ -1,0 +1,31 @@
+import type { Command } from "commander";
+import type { Tag } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerTagGetCommand(parent: Command): void {
+  parent
+    .command("get")
+    .description("Get a tag by ID")
+    .argument("<id>", "Tag ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const tag = await ctx.tagService.getTag(id);
+
+      outputTag(tag, ctx.config.output);
+    });
+}
+
+function outputTag(tag: Tag, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: tag.id ?? "-",
+      Name: tag.name,
+      Created: tag.createdAt ? tag.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: tag.updatedAt ? tag.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(tag, true);
+  }
+}

--- a/src/cli/commands/tag-list.ts
+++ b/src/cli/commands/tag-list.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+import type { Tag } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerTagListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List all tags")
+    .option("-l, --limit <n>", "Maximum number of tags to return per page")
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      const limit = options.limit ? Number.parseInt(options.limit as string, 10) : undefined;
+      const tags = await ctx.tagService.listAllTags();
+
+      const result = limit && limit > 0 ? tags.slice(0, limit) : tags;
+      outputTags(result, ctx.config.output);
+    });
+}
+
+function outputTags(tags: Tag[], format: string): void {
+  if (format === "table") {
+    console.log(`Found ${tags.length} tag(s)\n`);
+
+    if (tags.length === 0) return;
+
+    const headers = ["ID", "NAME", "CREATED", "UPDATED"];
+    const rows = tags.map((t) => [
+      t.id ?? "-",
+      t.name,
+      t.createdAt ? t.createdAt.slice(0, 19).replace("T", " ") : "-",
+      t.updatedAt ? t.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    ]);
+    formatTable(headers, rows);
+  } else {
+    formatJSON(tags, true);
+  }
+}

--- a/src/cli/commands/tag-update.ts
+++ b/src/cli/commands/tag-update.ts
@@ -1,0 +1,33 @@
+import type { Command } from "commander";
+import type { Tag } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerTagUpdateCommand(parent: Command): void {
+  parent
+    .command("update")
+    .description("Update an existing tag")
+    .argument("<id>", "Tag ID")
+    .requiredOption("-n, --name <name>", "New tag name")
+    .action(async (id: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const tag = await ctx.tagService.updateTag(id, { name: options.name as string });
+
+      console.log("Tag updated successfully");
+      outputTag(tag, ctx.config.output);
+    });
+}
+
+function outputTag(tag: Tag, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: tag.id ?? "-",
+      Name: tag.name,
+      Created: tag.createdAt ? tag.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: tag.updatedAt ? tag.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(tag, true);
+  }
+}

--- a/src/cli/commands/tag.ts
+++ b/src/cli/commands/tag.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { registerTagCreateCommand } from "./tag-create.ts";
+import { registerTagDeleteCommand } from "./tag-delete.ts";
+import { registerTagGetCommand } from "./tag-get.ts";
+import { registerTagListCommand } from "./tag-list.ts";
+import { registerTagUpdateCommand } from "./tag-update.ts";
+
+export function registerTagCommand(program: Command): void {
+  const tag = program.command("tag").description("Manage n8n tags");
+  registerTagListCommand(tag);
+  registerTagGetCommand(tag);
+  registerTagCreateCommand(tag);
+  registerTagUpdateCommand(tag);
+  registerTagDeleteCommand(tag);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { registerExecutionCommand } from "./cli/commands/execution.ts";
 import { registerFmtCommand } from "./cli/commands/fmt.ts";
 import { registerImportCommand } from "./cli/commands/import.ts";
 import { registerLintCommand } from "./cli/commands/lint.ts";
+import { registerTagCommand } from "./cli/commands/tag.ts";
 import { registerTestCommand } from "./cli/commands/test.ts";
 import { registerWorkflowCommand } from "./cli/commands/workflow.ts";
 import { createProgram } from "./cli/root.ts";
@@ -12,6 +13,7 @@ const program = createProgram();
 // Register commands
 registerWorkflowCommand(program);
 registerExecutionCommand(program);
+registerTagCommand(program);
 registerApplyCommand(program);
 registerImportCommand(program);
 registerLintCommand(program);


### PR DESCRIPTION
## Summary

Add CLI commands for managing n8n tags:

- `tag list` - List all tags
- `tag get <id>` - Get a specific tag
- `tag create` - Create a new tag  
- `tag update <id>` - Update a tag
- `tag delete <id>` - Delete a tag

## Changes

- Added `TagService` in `src/api/tag-service.ts`
- Added tag command files in `src/cli/commands/`
- Registered tag command in `src/index.ts`
- Added OpenAPI spec in `docs/openapi.yml`
