### PR TITLE
feat: add credential command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Format** - Auto-organize node positions for cleaner workflow layouts
 - **Test** - Execute CLI tests against workflows via webhook endpoints
 - **Workflow management** - List, get, create, update, delete, activate, and deactivate workflows via the n8n API
-- **Execution management** - List executions, get execution details, and view error information for debugging
+- **Execution management** - List executions, get execution details, delete, retry, and stop executions
+- **Tag management** - List, get, create, update, and delete tags
+- **Credential management** - List, get, create, update, delete credentials, get schema, and transfer between projects
 - **Git integration** - Apply only workflows changed in a Git diff
 - **YAML support** - Work with YAML workflow definitions and external code/SQL files
 - **CLAUDE.md integration** - Read project settings (default project ID, auto tags, YAML mode) from CLAUDE.md
@@ -246,6 +248,9 @@ n8n-cli execution <subcommand>
 |------------|-------------|
 | `list` | List workflow executions |
 | `get <id>` | Get execution details by ID |
+| `delete <id>` | Delete an execution by ID |
+| `retry <id>` | Retry a failed execution |
+| `stop <id>` | Stop a running execution |
 
 #### `execution list`
 
@@ -274,6 +279,192 @@ n8n-cli execution get <id> [options]
 - Start and stop timestamps
 - Error details (node, message, description) if the execution failed
 - Node execution summary (with `--show-data`)
+
+#### `execution delete`
+
+Delete an execution by ID.
+
+```bash
+n8n-cli execution delete <id>
+```
+
+#### `execution retry`
+
+Retry a failed execution.
+
+```bash
+n8n-cli execution retry <id>
+```
+
+#### `execution stop`
+
+Stop a running execution.
+
+```bash
+n8n-cli execution stop <id>
+```
+
+### `tag`
+
+Manage n8n tags.
+
+```bash
+n8n-cli tag <subcommand>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all tags |
+| `get <id>` | Get a tag by ID |
+| `create <name>` | Create a new tag |
+| `update <id>` | Update an existing tag |
+| `delete <ids...>` | Delete one or more tags |
+
+#### `tag list`
+
+```bash
+n8n-cli tag list [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit <n>` | Maximum number of tags to return |
+
+#### `tag get`
+
+Get a tag by ID.
+
+```bash
+n8n-cli tag get <id>
+```
+
+#### `tag create`
+
+Create a new tag.
+
+```bash
+n8n-cli tag create <name>
+```
+
+#### `tag update`
+
+Update an existing tag.
+
+```bash
+n8n-cli tag update <id> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | New tag name (required) |
+
+#### `tag delete`
+
+Delete one or more tags.
+
+```bash
+n8n-cli tag delete <ids...> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Skip confirmation prompt |
+
+### `credential`
+
+Manage n8n credentials.
+
+```bash
+n8n-cli credential <subcommand>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all credentials |
+| `get <id>` | Get a credential by ID |
+| `create` | Create a new credential |
+| `update <id>` | Update an existing credential |
+| `delete <ids...>` | Delete one or more credentials |
+| `schema <typeName>` | Get the schema for a credential type |
+| `transfer <id>` | Transfer a credential to a different project |
+
+#### `credential list`
+
+```bash
+n8n-cli credential list [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit <n>` | Maximum number of credentials to return |
+
+#### `credential get`
+
+Get a credential by ID.
+
+```bash
+n8n-cli credential get <id>
+```
+
+#### `credential create`
+
+Create a new credential.
+
+```bash
+n8n-cli credential create [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | Credential name (required) |
+| `-t, --type <type>` | Credential type, e.g., `slackApi` (required) |
+| `-d, --data <json>` | Credential data as JSON string (required) |
+
+#### `credential update`
+
+Update an existing credential.
+
+```bash
+n8n-cli credential update <id> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | New credential name |
+| `-t, --type <type>` | New credential type |
+| `-d, --data <json>` | New credential data as JSON string |
+
+#### `credential delete`
+
+Delete one or more credentials.
+
+```bash
+n8n-cli credential delete <ids...> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Skip confirmation prompt |
+
+#### `credential schema`
+
+Get the schema for a credential type.
+
+```bash
+n8n-cli credential schema <typeName>
+```
+
+#### `credential transfer`
+
+Transfer a credential to a different project.
+
+```bash
+n8n-cli credential transfer <id> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-p, --project <projectId>` | Destination project ID (required) |
 
 ### `version`
 

--- a/src/api/credential-service.ts
+++ b/src/api/credential-service.ts
@@ -1,0 +1,96 @@
+import type { Client } from "./client.ts";
+import type {
+  Credential,
+  CredentialInput,
+  CredentialSchema,
+  ListCredentialsResponse,
+  TransferInput,
+} from "./types.ts";
+
+/** ListCredentialsOptions represents options for listing credentials */
+export interface ListCredentialsOptions {
+  limit?: number;
+  cursor?: string;
+}
+
+/** CredentialService handles credential API operations */
+export class CredentialService {
+  constructor(private readonly client: Client) {}
+
+  /** ListCredentials lists all credentials with optional pagination */
+  async listCredentials(opts?: ListCredentialsOptions): Promise<ListCredentialsResponse> {
+    const params = new URLSearchParams();
+
+    if (opts) {
+      if (opts.limit && opts.limit > 0) {
+        params.set("limit", String(opts.limit));
+      }
+      if (opts.cursor) {
+        params.set("cursor", opts.cursor);
+      }
+    }
+
+    const query = params.toString();
+    const path = query ? `/credentials?${query}` : "/credentials";
+
+    const data = await this.client.get(path);
+    return JSON.parse(data) as ListCredentialsResponse;
+  }
+
+  /** ListAllCredentials lists all credentials with automatic pagination */
+  async listAllCredentials(): Promise<Credential[]> {
+    const allCredentials: Credential[] = [];
+    const opts: ListCredentialsOptions = { limit: 250 };
+
+    for (;;) {
+      const resp = await this.listCredentials(opts);
+      allCredentials.push(...resp.data);
+
+      if (!resp.nextCursor) {
+        break;
+      }
+      opts.cursor = resp.nextCursor;
+    }
+
+    return allCredentials;
+  }
+
+  /** GetCredential retrieves a credential by ID */
+  async getCredential(id: string): Promise<Credential> {
+    const path = `/credentials/${encodeURIComponent(id)}`;
+    const data = await this.client.get(path);
+    return JSON.parse(data) as Credential;
+  }
+
+  /** CreateCredential creates a new credential */
+  async createCredential(input: CredentialInput): Promise<Credential> {
+    const data = await this.client.post("/credentials", input);
+    return JSON.parse(data) as Credential;
+  }
+
+  /** UpdateCredential updates an existing credential */
+  async updateCredential(id: string, input: Partial<CredentialInput>): Promise<Credential> {
+    const path = `/credentials/${encodeURIComponent(id)}`;
+    const data = await this.client.patch(path, input);
+    return JSON.parse(data) as Credential;
+  }
+
+  /** DeleteCredential deletes a credential by ID */
+  async deleteCredential(id: string): Promise<void> {
+    const path = `/credentials/${encodeURIComponent(id)}`;
+    await this.client.delete(path);
+  }
+
+  /** GetCredentialSchema retrieves the schema for a credential type */
+  async getCredentialSchema(typeName: string): Promise<CredentialSchema> {
+    const path = `/credentials/schema/${encodeURIComponent(typeName)}`;
+    const data = await this.client.get(path);
+    return JSON.parse(data) as CredentialSchema;
+  }
+
+  /** TransferCredential transfers a credential to a different project */
+  async transferCredential(id: string, input: TransferInput): Promise<void> {
+    const path = `/credentials/${encodeURIComponent(id)}/transfer`;
+    await this.client.put(path, input);
+  }
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -138,3 +138,40 @@ export interface CLIConfig {
   autoTags?: string[];
   externalizeThreshold?: number;
 }
+
+/** Credential represents an n8n credential */
+export interface Credential {
+  id?: string;
+  name: string;
+  type: string;
+  data?: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** ListCredentialsResponse represents the response from listing credentials */
+export interface ListCredentialsResponse {
+  data: Credential[];
+  nextCursor?: string;
+}
+
+/** CredentialInput represents input for creating/updating a credential */
+export interface CredentialInput {
+  name: string;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+/** CredentialSchema represents the schema for a credential type */
+export interface CredentialSchema {
+  additionalProperties?: boolean;
+  type?: string;
+  properties?: Record<string, CredentialSchemaProperty>;
+  required?: string[];
+}
+
+/** CredentialSchemaProperty represents a property in a credential schema */
+export interface CredentialSchemaProperty {
+  type?: string;
+  default?: unknown;
+}

--- a/src/cli/commands/credential-create.ts
+++ b/src/cli/commands/credential-create.ts
@@ -1,0 +1,48 @@
+import type { Command } from "commander";
+import type { Credential } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialCreateCommand(parent: Command): void {
+  parent
+    .command("create")
+    .description("Create a new credential")
+    .requiredOption("-n, --name <name>", "Credential name")
+    .requiredOption("-t, --type <type>", "Credential type (e.g., slackApi, googleSheetsOAuth2Api)")
+    .requiredOption("-d, --data <json>", "Credential data as JSON string")
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(options.data as string);
+      } catch {
+        console.error("Error: Invalid JSON for --data option");
+        process.exit(1);
+      }
+
+      const credential = await ctx.credentialService.createCredential({
+        name: options.name as string,
+        type: options.type as string,
+        data,
+      });
+
+      console.log("Credential created successfully");
+      outputCredential(credential, ctx.config.output);
+    });
+}
+
+function outputCredential(credential: Credential, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: credential.id ?? "-",
+      Name: credential.name,
+      Type: credential.type,
+      Created: credential.createdAt ? credential.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: credential.updatedAt ? credential.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(credential, true);
+  }
+}

--- a/src/cli/commands/credential-delete.ts
+++ b/src/cli/commands/credential-delete.ts
@@ -1,0 +1,79 @@
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import { isAuthError, isNotFoundError } from "@/api/errors.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialDeleteCommand(parent: Command): void {
+  parent
+    .command("delete")
+    .description("Delete one or more credentials")
+    .argument("<ids...>", "One or more credential IDs to delete")
+    .option("--force", "Skip confirmation prompt")
+    .action(async (ids: string[], options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      if (!options.force) {
+        const lines: string[] = [];
+        for (const id of ids) {
+          try {
+            const credential = await ctx.credentialService.getCredential(id);
+            lines.push(`  - ${credential.name} (${id})`);
+          } catch (err) {
+            if (isNotFoundError(err)) {
+              console.error(`Error: credential not found: ${id}`);
+              process.exit(1);
+            }
+            if (isAuthError(err)) {
+              throw err;
+            }
+            lines.push(`  - ${id}`);
+          }
+        }
+
+        console.log(
+          `The following ${ids.length} credential(s) will be deleted:\n${lines.join("\n")}`,
+        );
+
+        const confirmed = await confirmDelete("these credentials");
+        if (!confirmed) {
+          console.log("Deletion cancelled");
+          return;
+        }
+      }
+
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const id of ids) {
+        try {
+          await ctx.credentialService.deleteCredential(id);
+          console.log(`Deleted: ${id}`);
+          succeeded++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`Error deleting ${id}: ${msg}`);
+          failed++;
+        }
+      }
+
+      console.log(`\nSummary: ${succeeded} succeeded, ${failed} failed (of ${ids.length} total)`);
+
+      if (failed > 0) {
+        process.exit(1);
+      }
+    });
+}
+
+function confirmDelete(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(`Are you sure you want to delete ${name}? [y/N]: `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      resolve(trimmed === "y" || trimmed === "yes");
+    });
+  });
+}

--- a/src/cli/commands/credential-get.ts
+++ b/src/cli/commands/credential-get.ts
@@ -1,0 +1,32 @@
+import type { Command } from "commander";
+import type { Credential } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialGetCommand(parent: Command): void {
+  parent
+    .command("get")
+    .description("Get a credential by ID")
+    .argument("<id>", "Credential ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const credential = await ctx.credentialService.getCredential(id);
+
+      outputCredential(credential, ctx.config.output);
+    });
+}
+
+function outputCredential(credential: Credential, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: credential.id ?? "-",
+      Name: credential.name,
+      Type: credential.type,
+      Created: credential.createdAt ? credential.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: credential.updatedAt ? credential.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(credential, true);
+  }
+}

--- a/src/cli/commands/credential-list.ts
+++ b/src/cli/commands/credential-list.ts
@@ -1,0 +1,41 @@
+import type { Command } from "commander";
+import type { Credential } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List all credentials")
+    .option("-l, --limit <n>", "Maximum number of credentials to return per page")
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      const limit = options.limit ? Number.parseInt(options.limit as string, 10) : undefined;
+      const credentials = await ctx.credentialService.listAllCredentials();
+
+      const result = limit && limit > 0 ? credentials.slice(0, limit) : credentials;
+      outputCredentials(result, ctx.config.output);
+    });
+}
+
+function outputCredentials(credentials: Credential[], format: string): void {
+  if (format === "table") {
+    console.log(`Found ${credentials.length} credential(s)\n`);
+
+    if (credentials.length === 0) return;
+
+    const headers = ["ID", "NAME", "TYPE", "CREATED", "UPDATED"];
+    const rows = credentials.map((c) => [
+      c.id ?? "-",
+      c.name,
+      c.type,
+      c.createdAt ? c.createdAt.slice(0, 19).replace("T", " ") : "-",
+      c.updatedAt ? c.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    ]);
+    formatTable(headers, rows);
+  } else {
+    formatJSON(credentials, true);
+  }
+}

--- a/src/cli/commands/credential-schema.ts
+++ b/src/cli/commands/credential-schema.ts
@@ -1,0 +1,41 @@
+import type { Command } from "commander";
+import type { CredentialSchema } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialSchemaCommand(parent: Command): void {
+  parent
+    .command("schema")
+    .description("Get the schema for a credential type")
+    .argument("<typeName>", "Credential type name (e.g., slackApi, googleSheetsOAuth2Api)")
+    .action(async (typeName: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const schema = await ctx.credentialService.getCredentialSchema(typeName);
+
+      outputSchema(schema, typeName, ctx.config.output);
+    });
+}
+
+function outputSchema(schema: CredentialSchema, typeName: string, format: string): void {
+  if (format === "table") {
+    console.log(`Schema for credential type: ${typeName}\n`);
+
+    if (!schema.properties || Object.keys(schema.properties).length === 0) {
+      console.log("No properties defined");
+      return;
+    }
+
+    const headers = ["PROPERTY", "TYPE", "REQUIRED", "DEFAULT"];
+    const required = new Set(schema.required ?? []);
+    const rows = Object.entries(schema.properties).map(([name, prop]) => [
+      name,
+      prop.type ?? "-",
+      required.has(name) ? "Yes" : "No",
+      prop.default !== undefined ? String(prop.default) : "-",
+    ]);
+    formatTable(headers, rows);
+  } else {
+    formatJSON(schema, true);
+  }
+}

--- a/src/cli/commands/credential-transfer.ts
+++ b/src/cli/commands/credential-transfer.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialTransferCommand(parent: Command): void {
+  parent
+    .command("transfer")
+    .description("Transfer a credential to a different project")
+    .argument("<id>", "Credential ID")
+    .requiredOption("-p, --project <projectId>", "Destination project ID")
+    .action(async (id: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      await ctx.credentialService.transferCredential(id, {
+        destinationProjectId: options.project as string,
+      });
+
+      console.log(`Credential ${id} transferred successfully to project ${options.project}`);
+    });
+}

--- a/src/cli/commands/credential-update.ts
+++ b/src/cli/commands/credential-update.ts
@@ -1,0 +1,59 @@
+import type { Command } from "commander";
+import type { Credential, CredentialInput } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerCredentialUpdateCommand(parent: Command): void {
+  parent
+    .command("update")
+    .description("Update an existing credential")
+    .argument("<id>", "Credential ID")
+    .option("-n, --name <name>", "New credential name")
+    .option("-t, --type <type>", "New credential type")
+    .option("-d, --data <json>", "New credential data as JSON string")
+    .action(async (id: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      const input: Partial<CredentialInput> = {};
+
+      if (options.name) {
+        input.name = options.name as string;
+      }
+      if (options.type) {
+        input.type = options.type as string;
+      }
+      if (options.data) {
+        try {
+          input.data = JSON.parse(options.data as string);
+        } catch {
+          console.error("Error: Invalid JSON for --data option");
+          process.exit(1);
+        }
+      }
+
+      if (Object.keys(input).length === 0) {
+        console.error("Error: At least one of --name, --type, or --data must be provided");
+        process.exit(1);
+      }
+
+      const credential = await ctx.credentialService.updateCredential(id, input);
+
+      console.log("Credential updated successfully");
+      outputCredential(credential, ctx.config.output);
+    });
+}
+
+function outputCredential(credential: Credential, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: credential.id ?? "-",
+      Name: credential.name,
+      Type: credential.type,
+      Created: credential.createdAt ? credential.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: credential.updatedAt ? credential.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(credential, true);
+  }
+}

--- a/src/cli/commands/credential.ts
+++ b/src/cli/commands/credential.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { registerCredentialCreateCommand } from "./credential-create.ts";
+import { registerCredentialDeleteCommand } from "./credential-delete.ts";
+import { registerCredentialGetCommand } from "./credential-get.ts";
+import { registerCredentialListCommand } from "./credential-list.ts";
+import { registerCredentialSchemaCommand } from "./credential-schema.ts";
+import { registerCredentialTransferCommand } from "./credential-transfer.ts";
+import { registerCredentialUpdateCommand } from "./credential-update.ts";
+
+export function registerCredentialCommand(program: Command): void {
+  const credential = program.command("credential").description("Manage n8n credentials");
+  registerCredentialListCommand(credential);
+  registerCredentialGetCommand(credential);
+  registerCredentialCreateCommand(credential);
+  registerCredentialUpdateCommand(credential);
+  registerCredentialDeleteCommand(credential);
+  registerCredentialSchemaCommand(credential);
+  registerCredentialTransferCommand(credential);
+}

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { Client } from "../api/client.ts";
+import { CredentialService } from "../api/credential-service.ts";
 import { ExecutionService } from "../api/execution-service.ts";
 import { TagService } from "../api/tag-service.ts";
 import { WorkflowService } from "../api/workflow-service.ts";
@@ -18,6 +19,7 @@ export interface GlobalContext {
   workflowService: WorkflowService;
   tagService: TagService;
   executionService: ExecutionService;
+  credentialService: CredentialService;
 }
 
 function createContext(config: Config): GlobalContext {
@@ -28,6 +30,7 @@ function createContext(config: Config): GlobalContext {
     workflowService: new WorkflowService(client),
     tagService: new TagService(client),
     executionService: new ExecutionService(client),
+    credentialService: new CredentialService(client),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { registerApplyCommand } from "./cli/commands/apply.ts";
+import { registerCredentialCommand } from "./cli/commands/credential.ts";
 import { registerExecutionCommand } from "./cli/commands/execution.ts";
 import { registerFmtCommand } from "./cli/commands/fmt.ts";
 import { registerImportCommand } from "./cli/commands/import.ts";
@@ -14,6 +15,7 @@ const program = createProgram();
 registerWorkflowCommand(program);
 registerExecutionCommand(program);
 registerTagCommand(program);
+registerCredentialCommand(program);
 registerApplyCommand(program);
 registerImportCommand(program);
 registerLintCommand(program);


### PR DESCRIPTION
## Summary
- Add credential CLI commands for managing n8n credentials
- Implements list, get, create, update, delete, schema, and transfer subcommands
- Fixes cuzic/n8n-cli#1

## CLI Commands
| Command | Description |
|---------|-------------|
| `credential list` | List all credentials |
| `credential get <id>` | Get a credential by ID |
| `credential create` | Create a new credential |
| `credential update <id>` | Update an existing credential |
| `credential delete <ids...>` | Delete one or more credentials |
| `credential schema <typeName>` | Get the schema for a credential type |
| `credential transfer <id>` | Transfer a credential to a different project |

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)