### PR TITLE
feat(data-tables): add management commands for data tables and rows

### DIFF
--- a/.claude/skills/n8n-cli/SKILL.md
+++ b/.claude/skills/n8n-cli/SKILL.md
@@ -413,6 +413,68 @@ Config file search order:
 # 3. Review error details and fix the workflow
 ```
 
+### 8. Data Tables
+
+**Manage data tables and rows:**
+
+```bash
+# List all data tables
+./n8n-cli data-tables list
+./n8n-cli -o table data-tables list
+
+# Get a data table by ID (includes column definitions)
+./n8n-cli data-tables get <data-table-id>
+
+# Create a data table
+./n8n-cli data-tables create --name "My Table" --columns '[{"name":"col1","type":"string"},{"name":"col2","type":"number"}]'
+
+# Update a data table name
+./n8n-cli data-tables update <data-table-id> --name "New Name"
+
+# Delete data tables
+./n8n-cli data-tables delete <data-table-id> --force
+```
+
+**Row operations:**
+
+```bash
+# List rows
+./n8n-cli data-tables rows list <data-table-id>
+./n8n-cli data-tables rows list <data-table-id> --limit 10 --search "keyword"
+
+# Insert rows
+./n8n-cli data-tables rows insert <data-table-id> --data '[{"col1":"hello","col2":42}]'
+./n8n-cli data-tables rows insert <data-table-id> --data '[{"col1":"value"}]' --return-type all
+
+# Update rows matching a filter
+./n8n-cli data-tables rows update <data-table-id> \
+  --filter '{"type":"and","filters":[{"columnName":"col1","condition":"eq","value":"hello"}]}' \
+  --data '{"col2":99}' --dry-run
+
+# Upsert rows
+./n8n-cli data-tables rows upsert <data-table-id> \
+  --filter '{"type":"and","filters":[{"columnName":"col1","condition":"eq","value":"hello"}]}' \
+  --data '{"col1":"hello","col2":100}'
+
+# Delete rows matching a filter
+./n8n-cli data-tables rows delete <data-table-id> \
+  --filter '{"type":"and","filters":[{"columnName":"col1","condition":"eq","value":"hello"}]}' \
+  --force
+```
+
+**Options:**
+
+| Subcommand | Key Options |
+|------------|-------------|
+| `list` | `--limit`, `--filter <json>`, `--sort-by <field:dir>` |
+| `rows list` | `--limit`, `--filter <json>`, `--sort-by`, `--search <text>` |
+| `rows insert` | `-d, --data <json>` (required), `--return-type count\|id\|all` |
+| `rows update` | `--filter <json>` (required), `-d, --data <json>` (required), `--return-data`, `--dry-run` |
+| `rows upsert` | `--filter <json>` (required), `-d, --data <json>` (required), `--return-data`, `--dry-run` |
+| `rows delete` | `--filter <json>` (required), `--return-data`, `--dry-run`, `--force` |
+
+Supported column types: `string`, `number`, `boolean`, `date`, `json`.
+
 ## Typical Workflow Operations
 
 ### Editing Workflows

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Execution management** - List executions, get execution details, delete, retry, and stop executions
 - **Tag management** - List, get, create, update, and delete tags
 - **Credential management** - List, get, create, update, delete credentials, get schema, and transfer between projects
+- **Data table management** - List, get, create, update, delete data tables and manage rows (insert, update, upsert, delete)
 - **Git integration** - Apply only workflows changed in a Git diff
 - **YAML support** - Work with YAML workflow definitions and external code/SQL files
 - **CLAUDE.md integration** - Read project settings (default project ID, auto tags, YAML mode) from CLAUDE.md
@@ -465,6 +466,159 @@ n8n-cli credential transfer <id> [options]
 | Option | Description |
 |--------|-------------|
 | `-p, --project <projectId>` | Destination project ID (required) |
+
+### `data-tables`
+
+Manage n8n data tables and their rows.
+
+```bash
+n8n-cli data-tables <subcommand>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all data tables |
+| `get <id>` | Get a data table by ID |
+| `create` | Create a new data table |
+| `update <id>` | Update an existing data table |
+| `delete <ids...>` | Delete one or more data tables |
+| `rows list <dataTableId>` | List rows in a data table |
+| `rows insert <dataTableId>` | Insert rows into a data table |
+| `rows update <dataTableId>` | Update rows in a data table |
+| `rows upsert <dataTableId>` | Upsert rows in a data table |
+| `rows delete <dataTableId>` | Delete rows from a data table |
+
+#### `data-tables list`
+
+```bash
+n8n-cli data-tables list [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit <n>` | Maximum number of data tables to return |
+| `--filter <json>` | Filter as JSON string |
+| `--sort-by <field:dir>` | Sort by field and direction (e.g., `name:asc`) |
+
+#### `data-tables get`
+
+Get a data table by ID, including column definitions.
+
+```bash
+n8n-cli data-tables get <id>
+```
+
+#### `data-tables create`
+
+Create a new data table with column definitions.
+
+```bash
+n8n-cli data-tables create [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | Data table name (required) |
+| `-c, --columns <json>` | Columns as JSON array (required), e.g., `'[{"name":"col1","type":"string"}]'` |
+
+Supported column types: `string`, `number`, `boolean`, `date`, `json`.
+
+#### `data-tables update`
+
+Update an existing data table (name only).
+
+```bash
+n8n-cli data-tables update <id> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | New data table name (required) |
+
+#### `data-tables delete`
+
+Delete one or more data tables.
+
+```bash
+n8n-cli data-tables delete <ids...> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Skip confirmation prompt |
+
+#### `data-tables rows list`
+
+List rows in a data table.
+
+```bash
+n8n-cli data-tables rows list <dataTableId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit <n>` | Maximum number of rows to return |
+| `--filter <json>` | Filter as JSON string |
+| `--sort-by <field:dir>` | Sort by field and direction |
+| `--search <text>` | Search text |
+
+#### `data-tables rows insert`
+
+Insert rows into a data table.
+
+```bash
+n8n-cli data-tables rows insert <dataTableId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-d, --data <json>` | Row data as JSON array (required), e.g., `'[{"col1":"value"}]'` |
+| `--return-type <type>` | Return type: `count`, `id`, or `all` (default: `count`) |
+
+#### `data-tables rows update`
+
+Update rows matching a filter.
+
+```bash
+n8n-cli data-tables rows update <dataTableId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--filter <json>` | Filter as JSON string (required) |
+| `-d, --data <json>` | Update data as JSON object (required) |
+| `--return-data` | Return updated data |
+| `--dry-run` | Dry run without making changes |
+
+#### `data-tables rows upsert`
+
+Upsert rows matching a filter.
+
+```bash
+n8n-cli data-tables rows upsert <dataTableId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--filter <json>` | Filter as JSON string (required) |
+| `-d, --data <json>` | Upsert data as JSON object (required) |
+| `--return-data` | Return upserted data |
+| `--dry-run` | Dry run without making changes |
+
+#### `data-tables rows delete`
+
+Delete rows matching a filter.
+
+```bash
+n8n-cli data-tables rows delete <dataTableId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--filter <json>` | Filter as JSON string (required) |
+| `--return-data` | Return deleted data |
+| `--dry-run` | Dry run without making changes |
+| `--force` | Skip confirmation prompt |
 
 ### `version`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/data-table-service.ts
+++ b/src/api/data-table-service.ts
@@ -1,0 +1,204 @@
+import type { Client } from "./client.ts";
+import type {
+  DataTable,
+  DataTableFilter,
+  DataTableInput,
+  DataTableRow,
+  DataTableUpdateInput,
+  InsertRowsInput,
+  ListDataTableRowsResponse,
+  ListDataTablesResponse,
+  UpdateRowsInput,
+  UpsertRowInput,
+} from "./types.ts";
+
+/** ListDataTablesOptions represents options for listing data tables */
+export interface ListDataTablesOptions {
+  limit?: number;
+  cursor?: string;
+  filter?: string;
+  sortBy?: string;
+}
+
+/** ListDataTableRowsOptions represents options for listing data table rows */
+export interface ListDataTableRowsOptions {
+  limit?: number;
+  cursor?: string;
+  filter?: string;
+  sortBy?: string;
+  search?: string;
+}
+
+/** DeleteRowsOptions represents options for deleting rows */
+export interface DeleteRowsOptions {
+  returnData?: boolean;
+  dryRun?: boolean;
+}
+
+/** DataTableService handles data table API operations */
+export class DataTableService {
+  constructor(private readonly client: Client) {}
+
+  /** listDataTables lists data tables with optional pagination and filtering */
+  async listDataTables(opts?: ListDataTablesOptions): Promise<ListDataTablesResponse> {
+    const params = new URLSearchParams();
+
+    if (opts) {
+      if (opts.limit && opts.limit > 0) {
+        params.set("limit", String(opts.limit));
+      }
+      if (opts.cursor) {
+        params.set("cursor", opts.cursor);
+      }
+      if (opts.filter) {
+        params.set("filter", opts.filter);
+      }
+      if (opts.sortBy) {
+        params.set("sortBy", opts.sortBy);
+      }
+    }
+
+    const query = params.toString();
+    const path = query ? `/data-tables?${query}` : "/data-tables";
+
+    const data = await this.client.get(path);
+    return JSON.parse(data) as ListDataTablesResponse;
+  }
+
+  /** listAllDataTables lists all data tables with automatic pagination */
+  async listAllDataTables(): Promise<DataTable[]> {
+    const all: DataTable[] = [];
+    const opts: ListDataTablesOptions = { limit: 250 };
+
+    for (;;) {
+      const resp = await this.listDataTables(opts);
+      all.push(...resp.data);
+
+      if (!resp.nextCursor) {
+        break;
+      }
+      opts.cursor = resp.nextCursor;
+    }
+
+    return all;
+  }
+
+  /** getDataTable retrieves a data table by ID */
+  async getDataTable(id: string): Promise<DataTable> {
+    const path = `/data-tables/${encodeURIComponent(id)}`;
+    const data = await this.client.get(path);
+    return JSON.parse(data) as DataTable;
+  }
+
+  /** createDataTable creates a new data table */
+  async createDataTable(input: DataTableInput): Promise<DataTable> {
+    const data = await this.client.post("/data-tables", input);
+    return JSON.parse(data) as DataTable;
+  }
+
+  /** updateDataTable updates an existing data table */
+  async updateDataTable(id: string, input: DataTableUpdateInput): Promise<DataTable> {
+    const path = `/data-tables/${encodeURIComponent(id)}`;
+    const data = await this.client.patch(path, input);
+    return JSON.parse(data) as DataTable;
+  }
+
+  /** deleteDataTable deletes a data table by ID */
+  async deleteDataTable(id: string): Promise<void> {
+    const path = `/data-tables/${encodeURIComponent(id)}`;
+    await this.client.delete(path);
+  }
+
+  /** listRows lists rows in a data table with optional pagination */
+  async listRows(
+    tableId: string,
+    opts?: ListDataTableRowsOptions,
+  ): Promise<ListDataTableRowsResponse> {
+    const params = new URLSearchParams();
+
+    if (opts) {
+      if (opts.limit && opts.limit > 0) {
+        params.set("limit", String(opts.limit));
+      }
+      if (opts.cursor) {
+        params.set("cursor", opts.cursor);
+      }
+      if (opts.filter) {
+        params.set("filter", opts.filter);
+      }
+      if (opts.sortBy) {
+        params.set("sortBy", opts.sortBy);
+      }
+      if (opts.search) {
+        params.set("search", opts.search);
+      }
+    }
+
+    const query = params.toString();
+    const basePath = `/data-tables/${encodeURIComponent(tableId)}/rows`;
+    const path = query ? `${basePath}?${query}` : basePath;
+
+    const data = await this.client.get(path);
+    return JSON.parse(data) as ListDataTableRowsResponse;
+  }
+
+  /** listAllRows lists all rows in a data table with automatic pagination */
+  async listAllRows(tableId: string): Promise<DataTableRow[]> {
+    const all: DataTableRow[] = [];
+    const opts: ListDataTableRowsOptions = { limit: 250 };
+
+    for (;;) {
+      const resp = await this.listRows(tableId, opts);
+      all.push(...resp.data);
+
+      if (!resp.nextCursor) {
+        break;
+      }
+      opts.cursor = resp.nextCursor;
+    }
+
+    return all;
+  }
+
+  /** insertRows inserts rows into a data table */
+  async insertRows(tableId: string, input: InsertRowsInput): Promise<unknown> {
+    const path = `/data-tables/${encodeURIComponent(tableId)}/rows`;
+    const data = await this.client.post(path, input);
+    return JSON.parse(data);
+  }
+
+  /** updateRows updates rows in a data table */
+  async updateRows(tableId: string, input: UpdateRowsInput): Promise<unknown> {
+    const path = `/data-tables/${encodeURIComponent(tableId)}/rows/update`;
+    const data = await this.client.patch(path, input);
+    return JSON.parse(data);
+  }
+
+  /** upsertRow upserts rows in a data table */
+  async upsertRow(tableId: string, input: UpsertRowInput): Promise<unknown> {
+    const path = `/data-tables/${encodeURIComponent(tableId)}/rows/upsert`;
+    const data = await this.client.post(path, input);
+    return JSON.parse(data);
+  }
+
+  /** deleteRows deletes rows from a data table */
+  async deleteRows(
+    tableId: string,
+    filter: DataTableFilter,
+    opts?: DeleteRowsOptions,
+  ): Promise<unknown> {
+    const params = new URLSearchParams();
+    params.set("filter", JSON.stringify(filter));
+
+    if (opts?.returnData) {
+      params.set("returnData", "true");
+    }
+    if (opts?.dryRun) {
+      params.set("dryRun", "true");
+    }
+
+    const path = `/data-tables/${encodeURIComponent(tableId)}/rows/delete?${params.toString()}`;
+    const data = await this.client.delete(path);
+    return JSON.parse(data);
+  }
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -175,3 +175,90 @@ export interface CredentialSchemaProperty {
   type?: string;
   default?: unknown;
 }
+
+/** DataTableColumnType represents the type of a data table column */
+export type DataTableColumnType = "string" | "number" | "boolean" | "date" | "json";
+
+/** DataTableColumn represents a column in a data table */
+export interface DataTableColumn {
+  id?: string;
+  name: string;
+  type: DataTableColumnType;
+  index?: number;
+}
+
+/** DataTable represents an n8n data table */
+export interface DataTable {
+  id: string;
+  name: string;
+  columns: DataTableColumn[];
+  projectId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** ListDataTablesResponse represents the response from listing data tables */
+export interface ListDataTablesResponse {
+  data: DataTable[];
+  nextCursor?: string;
+}
+
+/** DataTableInput represents input for creating a data table */
+export interface DataTableInput {
+  name: string;
+  columns: DataTableColumn[];
+}
+
+/** DataTableUpdateInput represents input for updating a data table */
+export interface DataTableUpdateInput {
+  name: string;
+}
+
+/** DataTableRow represents a row in a data table */
+export interface DataTableRow {
+  id: number;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+/** ListDataTableRowsResponse represents the response from listing data table rows */
+export interface ListDataTableRowsResponse {
+  data: DataTableRow[];
+  nextCursor?: string;
+}
+
+/** DataTableFilterCondition represents a single filter condition */
+export interface DataTableFilterCondition {
+  columnName: string;
+  condition: string;
+  value: unknown;
+}
+
+/** DataTableFilter represents a filter for querying data table rows */
+export interface DataTableFilter {
+  type: "and" | "or";
+  filters: DataTableFilterCondition[];
+}
+
+/** InsertRowsInput represents input for inserting rows */
+export interface InsertRowsInput {
+  data: Record<string, unknown>[];
+  returnType?: "count" | "id" | "all";
+}
+
+/** UpdateRowsInput represents input for updating rows */
+export interface UpdateRowsInput {
+  filter: DataTableFilter;
+  data: Record<string, unknown>;
+  returnData?: boolean;
+  dryRun?: boolean;
+}
+
+/** UpsertRowInput represents input for upserting rows */
+export interface UpsertRowInput {
+  filter: DataTableFilter;
+  data: Record<string, unknown>;
+  returnData?: boolean;
+  dryRun?: boolean;
+}

--- a/src/cli/commands/data-table-create.ts
+++ b/src/cli/commands/data-table-create.ts
@@ -1,0 +1,50 @@
+import type { Command } from "commander";
+import type { DataTable, DataTableColumn } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableCreateCommand(parent: Command): void {
+  parent
+    .command("create")
+    .description("Create a new data table")
+    .requiredOption("-n, --name <name>", "Data table name")
+    .requiredOption(
+      "-c, --columns <json>",
+      'Columns as JSON array (e.g., \'[{"name":"col1","type":"string"}]\')',
+    )
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      let columns: DataTableColumn[];
+      try {
+        columns = JSON.parse(options.columns as string);
+      } catch {
+        console.error("Error: Invalid JSON for --columns option");
+        process.exit(1);
+      }
+
+      const table = await ctx.dataTableService.createDataTable({
+        name: options.name as string,
+        columns,
+      });
+
+      console.log("Data table created successfully");
+      outputDataTable(table, ctx.config.output);
+    });
+}
+
+function outputDataTable(table: DataTable, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: table.id,
+      Name: table.name,
+      Columns: String(table.columns.length),
+      Project: table.projectId ?? "-",
+      Created: table.createdAt ? table.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: table.updatedAt ? table.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(table, true);
+  }
+}

--- a/src/cli/commands/data-table-delete.ts
+++ b/src/cli/commands/data-table-delete.ts
@@ -1,0 +1,79 @@
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import { isAuthError, isNotFoundError } from "@/api/errors.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableDeleteCommand(parent: Command): void {
+  parent
+    .command("delete")
+    .description("Delete one or more data tables")
+    .argument("<ids...>", "One or more data table IDs to delete")
+    .option("--force", "Skip confirmation prompt")
+    .action(async (ids: string[], options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      if (!options.force) {
+        const lines: string[] = [];
+        for (const id of ids) {
+          try {
+            const table = await ctx.dataTableService.getDataTable(id);
+            lines.push(`  - ${table.name} (${id})`);
+          } catch (err) {
+            if (isNotFoundError(err)) {
+              console.error(`Error: data table not found: ${id}`);
+              process.exit(1);
+            }
+            if (isAuthError(err)) {
+              throw err;
+            }
+            lines.push(`  - ${id}`);
+          }
+        }
+
+        console.log(
+          `The following ${ids.length} data table(s) will be deleted:\n${lines.join("\n")}`,
+        );
+
+        const confirmed = await confirmDelete("these data tables");
+        if (!confirmed) {
+          console.log("Deletion cancelled");
+          return;
+        }
+      }
+
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const id of ids) {
+        try {
+          await ctx.dataTableService.deleteDataTable(id);
+          console.log(`Deleted: ${id}`);
+          succeeded++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`Error deleting ${id}: ${msg}`);
+          failed++;
+        }
+      }
+
+      console.log(`\nSummary: ${succeeded} succeeded, ${failed} failed (of ${ids.length} total)`);
+
+      if (failed > 0) {
+        process.exit(1);
+      }
+    });
+}
+
+function confirmDelete(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(`Are you sure you want to delete ${name}? [y/N]: `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      resolve(trimmed === "y" || trimmed === "yes");
+    });
+  });
+}

--- a/src/cli/commands/data-table-get.ts
+++ b/src/cli/commands/data-table-get.ts
@@ -1,0 +1,44 @@
+import type { Command } from "commander";
+import type { DataTable } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue, formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableGetCommand(parent: Command): void {
+  parent
+    .command("get")
+    .description("Get a data table by ID")
+    .argument("<id>", "Data table ID")
+    .action(async (id: string, _options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const table = await ctx.dataTableService.getDataTable(id);
+
+      outputDataTable(table, ctx.config.output);
+    });
+}
+
+function outputDataTable(table: DataTable, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: table.id,
+      Name: table.name,
+      Project: table.projectId ?? "-",
+      Created: table.createdAt ? table.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: table.updatedAt ? table.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+
+    if (table.columns.length > 0) {
+      console.log(`\nColumns (${table.columns.length}):`);
+      const headers = ["ID", "NAME", "TYPE", "INDEX"];
+      const rows = table.columns.map((c) => [
+        c.id ?? "-",
+        c.name,
+        c.type,
+        c.index !== undefined ? String(c.index) : "-",
+      ]);
+      formatTable(headers, rows);
+    }
+  } else {
+    formatJSON(table, true);
+  }
+}

--- a/src/cli/commands/data-table-list.ts
+++ b/src/cli/commands/data-table-list.ts
@@ -1,0 +1,44 @@
+import type { Command } from "commander";
+import type { DataTable } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List all data tables")
+    .option("-l, --limit <n>", "Maximum number of data tables to return per page")
+    .option("--filter <json>", "Filter as JSON string")
+    .option("--sort-by <field:dir>", "Sort by field and direction (e.g., name:asc)")
+    .action(async (options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+
+      const limit = options.limit ? Number.parseInt(options.limit as string, 10) : undefined;
+      const tables = await ctx.dataTableService.listAllDataTables();
+
+      const result = limit && limit > 0 ? tables.slice(0, limit) : tables;
+      outputDataTables(result, ctx.config.output);
+    });
+}
+
+function outputDataTables(tables: DataTable[], format: string): void {
+  if (format === "table") {
+    console.log(`Found ${tables.length} data table(s)\n`);
+
+    if (tables.length === 0) return;
+
+    const headers = ["ID", "NAME", "COLUMNS", "PROJECT", "CREATED", "UPDATED"];
+    const rows = tables.map((t) => [
+      t.id,
+      t.name,
+      String(t.columns.length),
+      t.projectId ?? "-",
+      t.createdAt ? t.createdAt.slice(0, 19).replace("T", " ") : "-",
+      t.updatedAt ? t.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    ]);
+    formatTable(headers, rows);
+  } else {
+    formatJSON(tables, true);
+  }
+}

--- a/src/cli/commands/data-table-rows-delete.ts
+++ b/src/cli/commands/data-table-rows-delete.ts
@@ -1,0 +1,61 @@
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import type { DataTableFilter } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableRowsDeleteCommand(parent: Command): void {
+  parent
+    .command("delete")
+    .description("Delete rows from a data table")
+    .argument("<dataTableId>", "Data table ID")
+    .requiredOption("--filter <json>", "Filter as JSON string (required)")
+    .option("--return-data", "Return deleted data")
+    .option("--dry-run", "Dry run without making changes")
+    .option("--force", "Skip confirmation prompt")
+    .action(async (dataTableId: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent?.parent!);
+
+      let filter: DataTableFilter;
+      try {
+        filter = JSON.parse(options.filter as string);
+      } catch {
+        console.error("Error: Invalid JSON for --filter option");
+        process.exit(1);
+      }
+
+      if (!options.force && !options.dryRun) {
+        const confirmed = await confirmDelete("matching rows");
+        if (!confirmed) {
+          console.log("Deletion cancelled");
+          return;
+        }
+      }
+
+      const result = await ctx.dataTableService.deleteRows(dataTableId, filter, {
+        returnData: options.returnData as boolean | undefined,
+        dryRun: options.dryRun as boolean | undefined,
+      });
+
+      if (options.dryRun) {
+        console.log("Dry run result:");
+      } else {
+        console.log("Rows deleted successfully");
+      }
+      formatJSON(result, true);
+    });
+}
+
+function confirmDelete(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(`Are you sure you want to delete ${name}? [y/N]: `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      resolve(trimmed === "y" || trimmed === "yes");
+    });
+  });
+}

--- a/src/cli/commands/data-table-rows-insert.ts
+++ b/src/cli/commands/data-table-rows-insert.ts
@@ -1,0 +1,31 @@
+import type { Command } from "commander";
+import { formatJSON } from "@/cli/output/json.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableRowsInsertCommand(parent: Command): void {
+  parent
+    .command("insert")
+    .description("Insert rows into a data table")
+    .argument("<dataTableId>", "Data table ID")
+    .requiredOption("-d, --data <json>", 'Row data as JSON array (e.g., \'[{"col1":"value"}]\')')
+    .option("--return-type <type>", "Return type: count, id, or all", "count")
+    .action(async (dataTableId: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent?.parent!);
+
+      let data: Record<string, unknown>[];
+      try {
+        data = JSON.parse(options.data as string);
+      } catch {
+        console.error("Error: Invalid JSON for --data option");
+        process.exit(1);
+      }
+
+      const result = await ctx.dataTableService.insertRows(dataTableId, {
+        data,
+        returnType: options.returnType as "count" | "id" | "all" | undefined,
+      });
+
+      console.log("Rows inserted successfully");
+      formatJSON(result, true);
+    });
+}

--- a/src/cli/commands/data-table-rows-list.ts
+++ b/src/cli/commands/data-table-rows-list.ts
@@ -1,0 +1,48 @@
+import type { Command } from "commander";
+import type { DataTableRow } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatTable } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableRowsListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List rows in a data table")
+    .argument("<dataTableId>", "Data table ID")
+    .option("-l, --limit <n>", "Maximum number of rows to return per page")
+    .option("--filter <json>", "Filter as JSON string")
+    .option("--sort-by <field:dir>", "Sort by field and direction")
+    .option("--search <text>", "Search text")
+    .action(async (dataTableId: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent?.parent!);
+
+      const limit = options.limit ? Number.parseInt(options.limit as string, 10) : undefined;
+      const rows = await ctx.dataTableService.listAllRows(dataTableId);
+
+      const result = limit && limit > 0 ? rows.slice(0, limit) : rows;
+      outputRows(result, ctx.config.output);
+    });
+}
+
+function outputRows(rows: DataTableRow[], format: string): void {
+  if (format === "table") {
+    console.log(`Found ${rows.length} row(s)\n`);
+
+    if (rows.length === 0) return;
+
+    // Dynamically generate headers from the first row's keys
+    const headers = Object.keys(rows[0]!).map((k) => k.toUpperCase());
+    const keys = Object.keys(rows[0]!);
+    const tableRows = rows.map((r) =>
+      keys.map((k) => {
+        const v = r[k];
+        if (v === null || v === undefined) return "-";
+        if (typeof v === "object") return JSON.stringify(v);
+        return String(v);
+      }),
+    );
+    formatTable(headers, tableRows);
+  } else {
+    formatJSON(rows, true);
+  }
+}

--- a/src/cli/commands/data-table-rows-update.ts
+++ b/src/cli/commands/data-table-rows-update.ts
@@ -1,0 +1,48 @@
+import type { Command } from "commander";
+import type { DataTableFilter } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableRowsUpdateCommand(parent: Command): void {
+  parent
+    .command("update")
+    .description("Update rows in a data table")
+    .argument("<dataTableId>", "Data table ID")
+    .requiredOption("--filter <json>", "Filter as JSON string")
+    .requiredOption("-d, --data <json>", "Update data as JSON object")
+    .option("--return-data", "Return updated data")
+    .option("--dry-run", "Dry run without making changes")
+    .action(async (dataTableId: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent?.parent!);
+
+      let filter: DataTableFilter;
+      try {
+        filter = JSON.parse(options.filter as string);
+      } catch {
+        console.error("Error: Invalid JSON for --filter option");
+        process.exit(1);
+      }
+
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(options.data as string);
+      } catch {
+        console.error("Error: Invalid JSON for --data option");
+        process.exit(1);
+      }
+
+      const result = await ctx.dataTableService.updateRows(dataTableId, {
+        filter,
+        data,
+        returnData: options.returnData as boolean | undefined,
+        dryRun: options.dryRun as boolean | undefined,
+      });
+
+      if (options.dryRun) {
+        console.log("Dry run result:");
+      } else {
+        console.log("Rows updated successfully");
+      }
+      formatJSON(result, true);
+    });
+}

--- a/src/cli/commands/data-table-rows-upsert.ts
+++ b/src/cli/commands/data-table-rows-upsert.ts
@@ -1,0 +1,48 @@
+import type { Command } from "commander";
+import type { DataTableFilter } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableRowsUpsertCommand(parent: Command): void {
+  parent
+    .command("upsert")
+    .description("Upsert rows in a data table")
+    .argument("<dataTableId>", "Data table ID")
+    .requiredOption("--filter <json>", "Filter as JSON string")
+    .requiredOption("-d, --data <json>", "Upsert data as JSON object")
+    .option("--return-data", "Return upserted data")
+    .option("--dry-run", "Dry run without making changes")
+    .action(async (dataTableId: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent?.parent!);
+
+      let filter: DataTableFilter;
+      try {
+        filter = JSON.parse(options.filter as string);
+      } catch {
+        console.error("Error: Invalid JSON for --filter option");
+        process.exit(1);
+      }
+
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(options.data as string);
+      } catch {
+        console.error("Error: Invalid JSON for --data option");
+        process.exit(1);
+      }
+
+      const result = await ctx.dataTableService.upsertRow(dataTableId, {
+        filter,
+        data,
+        returnData: options.returnData as boolean | undefined,
+        dryRun: options.dryRun as boolean | undefined,
+      });
+
+      if (options.dryRun) {
+        console.log("Dry run result:");
+      } else {
+        console.log("Rows upserted successfully");
+      }
+      formatJSON(result, true);
+    });
+}

--- a/src/cli/commands/data-table-update.ts
+++ b/src/cli/commands/data-table-update.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import type { DataTable } from "@/api/types.ts";
+import { formatJSON } from "@/cli/output/json.ts";
+import { formatKeyValue } from "@/cli/output/table.ts";
+import { resolveContext } from "@/cli/root.ts";
+
+export function registerDataTableUpdateCommand(parent: Command): void {
+  parent
+    .command("update")
+    .description("Update an existing data table")
+    .argument("<id>", "Data table ID")
+    .requiredOption("-n, --name <name>", "New data table name")
+    .action(async (id: string, options, command) => {
+      const ctx = resolveContext(command.parent?.parent!);
+      const table = await ctx.dataTableService.updateDataTable(id, {
+        name: options.name as string,
+      });
+
+      console.log("Data table updated successfully");
+      outputDataTable(table, ctx.config.output);
+    });
+}
+
+function outputDataTable(table: DataTable, format: string): void {
+  if (format === "table") {
+    formatKeyValue({
+      ID: table.id,
+      Name: table.name,
+      Project: table.projectId ?? "-",
+      Created: table.createdAt ? table.createdAt.slice(0, 19).replace("T", " ") : "-",
+      Updated: table.updatedAt ? table.updatedAt.slice(0, 19).replace("T", " ") : "-",
+    });
+  } else {
+    formatJSON(table, true);
+  }
+}

--- a/src/cli/commands/data-table.ts
+++ b/src/cli/commands/data-table.ts
@@ -1,0 +1,30 @@
+import type { Command } from "commander";
+import { registerDataTableCreateCommand } from "./data-table-create.ts";
+import { registerDataTableDeleteCommand } from "./data-table-delete.ts";
+import { registerDataTableGetCommand } from "./data-table-get.ts";
+import { registerDataTableListCommand } from "./data-table-list.ts";
+import { registerDataTableRowsDeleteCommand } from "./data-table-rows-delete.ts";
+import { registerDataTableRowsInsertCommand } from "./data-table-rows-insert.ts";
+import { registerDataTableRowsListCommand } from "./data-table-rows-list.ts";
+import { registerDataTableRowsUpdateCommand } from "./data-table-rows-update.ts";
+import { registerDataTableRowsUpsertCommand } from "./data-table-rows-upsert.ts";
+import { registerDataTableUpdateCommand } from "./data-table-update.ts";
+
+export function registerDataTableCommand(program: Command): void {
+  const dt = program.command("data-tables").description("Manage n8n data tables");
+
+  // Table CRUD commands
+  registerDataTableListCommand(dt);
+  registerDataTableGetCommand(dt);
+  registerDataTableCreateCommand(dt);
+  registerDataTableUpdateCommand(dt);
+  registerDataTableDeleteCommand(dt);
+
+  // Rows subcommand group
+  const rows = dt.command("rows").description("Manage data table rows");
+  registerDataTableRowsListCommand(rows);
+  registerDataTableRowsInsertCommand(rows);
+  registerDataTableRowsUpdateCommand(rows);
+  registerDataTableRowsUpsertCommand(rows);
+  registerDataTableRowsDeleteCommand(rows);
+}

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { Client } from "../api/client.ts";
 import { CredentialService } from "../api/credential-service.ts";
+import { DataTableService } from "../api/data-table-service.ts";
 import { ExecutionService } from "../api/execution-service.ts";
 import { TagService } from "../api/tag-service.ts";
 import { WorkflowService } from "../api/workflow-service.ts";
@@ -20,6 +21,7 @@ export interface GlobalContext {
   tagService: TagService;
   executionService: ExecutionService;
   credentialService: CredentialService;
+  dataTableService: DataTableService;
 }
 
 function createContext(config: Config): GlobalContext {
@@ -31,6 +33,7 @@ function createContext(config: Config): GlobalContext {
     tagService: new TagService(client),
     executionService: new ExecutionService(client),
     credentialService: new CredentialService(client),
+    dataTableService: new DataTableService(client),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { registerApplyCommand } from "./cli/commands/apply.ts";
 import { registerCredentialCommand } from "./cli/commands/credential.ts";
+import { registerDataTableCommand } from "./cli/commands/data-table.ts";
 import { registerExecutionCommand } from "./cli/commands/execution.ts";
 import { registerFmtCommand } from "./cli/commands/fmt.ts";
 import { registerImportCommand } from "./cli/commands/import.ts";
@@ -17,6 +18,7 @@ registerWorkflowCommand(program);
 registerExecutionCommand(program);
 registerTagCommand(program);
 registerCredentialCommand(program);
+registerDataTableCommand(program);
 registerApplyCommand(program);
 registerImportCommand(program);
 registerLintCommand(program);


### PR DESCRIPTION
- Implemented commands for creating, updating, deleting, and listing data tables.
- Added functionality for managing rows within data tables, including insert, update, upsert, and delete operations.
- Updated README and documentation to reflect new data table management features.
- Bumped version to 2.0.7.