### PR TITLE
fix: strip API-only settings before workflow create/update

### DIFF
--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -325,6 +325,15 @@ export class Executor {
     return op;
   }
 
+  /** Strip settings the n8n API exports but rejects on write. */
+  private sanitizeSettings(settings?: Record<string, unknown>): Record<string, unknown> | undefined {
+    if (!settings) return undefined;
+    const STRIP_SETTINGS = ['availableInMCP', 'binaryMode', 'callerPolicy'];
+    return Object.fromEntries(
+      Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k))
+    );
+  }
+
   /** Performs the actual create operation. */
   private async executeCreate(wf: WorkflowFile, op: ApplyOperation): Promise<void> {
     const workflow = wf.workflow!;
@@ -332,7 +341,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: workflow.settings,
+      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 
@@ -353,7 +362,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: workflow.settings,
+      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 


### PR DESCRIPTION
## Summary
- Strip `availableInMCP`, `binaryMode`, and `callerPolicy` from workflow settings before sending create/update API requests
- These properties are exported by the n8n API on GET but rejected on PUT/PATCH with `request/body/settings must NOT have additional properties`
- Follows the existing pattern where `pinData` is already excluded from the request body

## Problem
When using `n8n-cli import` followed by `n8n-cli apply`, the imported YAML contains server-side settings that the API rejects on write. This forces users to manually strip these fields before pushing.

## Fix
Added a `sanitizeSettings()` method in `executor.ts` that blacklists known API-only settings, applied in both `executeCreate()` and `executeUpdate()`.

## Test plan
- [x] Imported workflows with `availableInMCP`, `binaryMode`, `callerPolicy` in settings
- [x] Verified `apply` succeeds without manual field stripping
- [x] Verified `apply --dry-run` shows no errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly filters out three known `settings` keys before write requests to avoid n8n API validation errors; primary risk is unintentionally dropping a setting if the blacklist is incomplete/incorrect.
> 
> **Overview**
> Prevents `apply` create/update requests from failing due to n8n returning API-only workflow `settings` fields on read.
> 
> Adds `sanitizeSettings()` in `Executor` to remove `availableInMCP`, `binaryMode`, and `callerPolicy`, and uses it when building the `WorkflowInput` for both `executeCreate()` and `executeUpdate()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3937e3c742308f9b0ab72ab3698254e0e2a20a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->