### PR TITLE
feat: add convert command for JSON/YAML format conversion

### DIFF
--- a/.claude/skills/n8n-cli/SKILL.md
+++ b/.claude/skills/n8n-cli/SKILL.md
@@ -459,11 +459,46 @@ Config file search order:
 # 3. Review error details and fix the workflow
 ```
 
-<<<<<<< HEAD
-### 9. Data Tables
-=======
-### 8. Data Tables
->>>>>>> 2127c8ac10de74433e5bdbf0da7fc5a9437c9369
+### 9. Convert (Format Conversion)
+
+**Convert workflow files between JSON and YAML formats (local-only, no API needed):**
+
+```bash
+# Convert all JSON workflows to YAML
+./n8n-cli convert -d ./definitions --format yaml
+
+# Convert specific workflows by ID
+./n8n-cli convert -d ./definitions --format json --ids <workflow-id>
+
+# Preview without writing
+./n8n-cli convert -d ./definitions --format yaml --dry-run
+
+# Keep original files
+./n8n-cli convert -d ./definitions --format yaml --keep
+
+# Convert a single file
+./n8n-cli convert --format yaml definitions/<filename>.json
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--format <format>` | Target format: `json`, `yaml` (required) |
+| `-d, --directory <dir>` | Directory to scan for workflow files |
+| `--ids <ids>` | Comma-separated workflow IDs to convert |
+| `--tags <tags>` | Filter by tags (comma-separated, AND condition) |
+| `-t, --threshold <n>` | Minimum lines for code externalization (JSON→YAML) |
+| `--dry-run` | Preview only |
+| `--keep` | Keep original files |
+
+**Behavior:**
+- JSON→YAML: generates YAML + `_subfiles/` with externalized code
+- YAML→JSON: resolves `!include` refs and removes `_subfiles/`
+- Files already in target format are skipped
+- Original files removed after conversion unless `--keep`
+
+### 10. Data Tables
 
 **Manage data tables and rows:**
 
@@ -525,8 +560,7 @@ Config file search order:
 
 Supported column types: `string`, `number`, `boolean`, `date`, `json`.
 
-<<<<<<< HEAD
-### 10. Trace (Data Flow Analysis)
+### 11. Trace (Data Flow Analysis)
 
 **Analyze data flow and cardinality through a workflow:**
 
@@ -570,7 +604,7 @@ When a node shows `?` for estimated items, it means cardinality could not be sta
 4. For `HTTP Request`, check if the response is an array or single object
 5. **Do not assume `?` means "many"** — it simply means "unknown at static analysis time"
 
-### 11. Credential (Credential Management)
+### 12. Credential (Credential Management)
 
 **Check available credentials:**
 
@@ -589,7 +623,7 @@ When a node shows `?` for estimated items, it means cardinality could not be sta
 - If a node uses an external service, verify the corresponding credential exists
 - If a credential is missing, ask the user to create it in the n8n UI
 
-### 12. Node Schema (Node Schema Reference)
+### 13. Node Schema (Node Schema Reference)
 
 **Check node parameter definitions:**
 
@@ -622,9 +656,6 @@ When a node shows `?` for estimated items, it means cardinality could not be sta
 |--------|-------------|
 | `--type <nodeType>` | Specific node type schema (e.g., `n8n-nodes-base.slack`) |
 | `-o, --output-dir <dir>` | Dump all nodes as individual files to directory |
-
-=======
->>>>>>> 2127c8ac10de74433e5bdbf0da7fc5a9437c9369
 ## Typical Workflow Operations
 
 ### Editing Workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ n8n-cli/
 │   ├── cli/              # CLI commands and output formatters
 │   ├── common/           # Shared utilities
 │   ├── config/           # Configuration loading
+│   ├── convert/          # Format conversion (JSON ↔ YAML)
 │   ├── formatter/        # Workflow formatting
 │   ├── git/              # Git integration
 │   ├── importer/         # Import command logic

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 ## Features
 
 - **Apply** - Deploy local workflow definitions (JSON/YAML) to an n8n server with dry-run support and conflict detection
+- **Convert** - Convert workflow files between JSON and YAML formats locally
 - **Import** - Pull workflows from an n8n server to local files, with optional YAML conversion and code externalization
 - **Lint** - Validate workflow definitions against configurable rules
 - **Format** - Auto-organize node positions for cleaner workflow layouts
@@ -108,6 +109,50 @@ n8n-cli apply [options]
 | `0` | Success |
 | `1` | Error detected |
 | `2` | Conflict detected (dry-run) or warning detected (non-force mode) |
+
+### `convert`
+
+Convert workflow files between formats (JSON ↔ YAML). This is a local-only operation that does not require an n8n server connection.
+
+```bash
+n8n-cli convert [options] [files...]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--format <format>` | Target format: `json`, `yaml` (required) |
+| `-d, --directory <dir>` | Directory to scan for workflow files |
+| `--ids <ids>` | Comma-separated workflow IDs to convert |
+| `--tags <tags>` | Filter by tags (comma-separated, AND condition) |
+| `-t, --threshold <n>` | Minimum lines for code externalization (JSON→YAML) |
+| `--dry-run` | Preview conversions without writing files |
+| `--keep` | Keep original files after conversion |
+
+**Examples:**
+
+```bash
+# Convert all JSON workflows in a directory to YAML
+n8n-cli convert -d ./definitions --format yaml
+
+# Convert specific workflows by ID
+n8n-cli convert -d ./definitions --format json --ids wf-100,wf-200
+
+# Preview conversions without making changes
+n8n-cli convert -d ./definitions --format yaml --dry-run
+
+# Convert but keep the original files
+n8n-cli convert -d ./definitions --format yaml --keep
+
+# Convert a specific file
+n8n-cli convert --format yaml workflow__wf-100.json
+```
+
+**Behavior:**
+
+- **JSON → YAML**: Generates YAML with code externalization (`_subfiles/`) and `description.md`
+- **YAML → JSON**: Resolves `!include` directives (inlines external files) and removes `_subfiles/` directories
+- Files already in the target format are skipped
+- Original files are removed after conversion unless `--keep` is specified
 
 ### `import`
 

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -1,0 +1,177 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import type { Command } from "commander";
+import { WORKFLOW_EXTENSIONS } from "@/common/extensions.ts";
+import { hasAllTags, parseTagFilter } from "@/common/tags.ts";
+import { getEffectiveExternalizeThreshold, loadCLIConfig } from "@/config/claude-md.ts";
+import { convertWorkflowFile, type TargetFormat } from "@/convert/converter.ts";
+import { parseWorkflowFile } from "@/importer/scanner.ts";
+
+/** registerConvertCommand registers the convert subcommand. */
+export function registerConvertCommand(program: Command): void {
+  program
+    .command("convert")
+    .description("Convert workflow files between formats (JSON ↔ YAML)")
+    .requiredOption("--format <format>", "Target format: json, yaml")
+    .option("-d, --directory <dir>", "Directory to scan for workflow files")
+    .option("--ids <ids>", "Comma-separated workflow IDs to convert")
+    .option("--tags <tags>", "Filter by tags (comma-separated, AND condition)")
+    .option("-t, --threshold <n>", "Minimum lines for code externalization (JSON→YAML)", "0")
+    .option("--dry-run", "Preview conversions without writing files", false)
+    .option("--keep", "Keep original files after conversion", false)
+    .argument("[files...]", "Specific workflow files to convert")
+    .action(
+      async (
+        files: string[],
+        opts: {
+          format: string;
+          directory?: string;
+          ids?: string;
+          tags?: string;
+          threshold: string;
+          dryRun: boolean;
+          keep: boolean;
+        },
+      ) => {
+        // Validate target format
+        const targetFormat = opts.format as TargetFormat;
+        if (targetFormat !== "json" && targetFormat !== "yaml") {
+          console.error(`Error: unsupported format "${opts.format}". Use "json" or "yaml".`);
+          process.exit(1);
+        }
+
+        // Load config for threshold
+        const cliConfig = loadCLIConfig();
+        const threshold = getEffectiveExternalizeThreshold(
+          Number.parseInt(opts.threshold, 10) || 0,
+          cliConfig,
+        );
+
+        // Collect target files
+        const targetFiles = [...files];
+        if (opts.directory) {
+          targetFiles.push(...scanWorkflowFiles(opts.directory));
+        }
+
+        if (targetFiles.length === 0) {
+          console.error("Error: no files specified. Use -d <directory> or provide file paths.");
+          process.exit(1);
+        }
+
+        // Parse --ids filter
+        const idsFilter = opts.ids
+          ? new Set(
+              opts.ids
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            )
+          : null;
+
+        // Parse --tags filter
+        const filterByTags = parseTagFilter(opts.tags);
+
+        if (filterByTags.length > 0) {
+          console.error(`Filtering by tags: ${filterByTags.join(", ")} (AND)`);
+        }
+
+        let converted = 0;
+        let skipped = 0;
+        let errors = 0;
+
+        for (const filePath of targetFiles) {
+          // ID filtering
+          if (idsFilter) {
+            try {
+              const wf = parseWorkflowFile(filePath);
+              if (!wf.id || !idsFilter.has(wf.id)) {
+                continue;
+              }
+            } catch {
+              // Cannot parse — skip
+              continue;
+            }
+          }
+
+          // Tag filtering
+          if (filterByTags.length > 0) {
+            try {
+              const wf = parseWorkflowFile(filePath);
+              if (!hasAllTags(wf.tags, filterByTags)) {
+                continue;
+              }
+            } catch {
+              // Cannot parse — skip
+              continue;
+            }
+          }
+
+          const directory = opts.directory ?? path.dirname(filePath);
+
+          const result = convertWorkflowFile(filePath, {
+            targetFormat,
+            directory,
+            externalizeThreshold: threshold,
+            dryRun: opts.dryRun,
+            keepOriginal: opts.keep,
+          });
+
+          if (result.error) {
+            console.error(`Error: ${filePath}: ${result.error.message}`);
+            errors++;
+            continue;
+          }
+
+          if (result.skipped) {
+            console.error(`Skip: ${filePath}: ${result.skipReason}`);
+            skipped++;
+            continue;
+          }
+
+          const dryRunLabel = opts.dryRun ? " (dry-run)" : "";
+          console.log(`Converted${dryRunLabel}: ${filePath} → ${result.outputPath}`);
+
+          if (result.removedFiles.length > 0) {
+            for (const removed of result.removedFiles) {
+              console.log(`  Removed: ${removed}`);
+            }
+          }
+
+          converted++;
+        }
+
+        console.log(`\nConverted: ${converted}, Skipped: ${skipped}, Errors: ${errors}`);
+
+        if (errors > 0) {
+          process.exit(1);
+        }
+      },
+    );
+}
+
+/** Recursively scans a directory for workflow files (.json, .yaml, .yml). */
+function scanWorkflowFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  try {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        if (entry.startsWith("_")) continue;
+        results.push(...scanWorkflowFiles(fullPath));
+      } else {
+        const ext = path.extname(entry).toLowerCase();
+        if (WORKFLOW_EXTENSIONS.has(ext)) {
+          results.push(fullPath);
+        }
+      }
+    }
+  } catch {
+    // Skip unreadable directories
+  }
+
+  return results;
+}

--- a/src/convert/converter.ts
+++ b/src/convert/converter.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import { parseWorkflowFile } from "@/importer/scanner.ts";
+import {
+  findExistingSubfilesDirs,
+  generateFilePath,
+  generateYamlFilePath,
+  writeWorkflowJSON,
+  writeWorkflowYAML,
+} from "@/importer/writer.ts";
+
+/** Supported target formats for conversion. */
+export type TargetFormat = "json" | "yaml";
+
+/** Options for converting a workflow file. */
+export interface ConvertOptions {
+  targetFormat: TargetFormat;
+  directory: string;
+  externalizeThreshold: number;
+  dryRun: boolean;
+  keepOriginal: boolean;
+}
+
+/** Result of converting a single workflow file. */
+export interface ConvertResult {
+  sourcePath: string;
+  outputPath: string;
+  sourceFormat: TargetFormat;
+  targetFormat: TargetFormat;
+  writtenFiles: string[];
+  removedFiles: string[];
+  skipped: boolean;
+  skipReason?: string;
+  error?: Error;
+}
+
+/** Detects the format of a file based on its extension. */
+export function detectFormat(filePath: string): TargetFormat | null {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".json") return "json";
+  if (ext === ".yaml" || ext === ".yml") return "yaml";
+  return null;
+}
+
+/** Converts a single workflow file to the target format. */
+export function convertWorkflowFile(filePath: string, options: ConvertOptions): ConvertResult {
+  const sourceFormat = detectFormat(filePath);
+  const result: ConvertResult = {
+    sourcePath: filePath,
+    outputPath: "",
+    sourceFormat: sourceFormat ?? "json",
+    targetFormat: options.targetFormat,
+    writtenFiles: [],
+    removedFiles: [],
+    skipped: false,
+  };
+
+  if (!sourceFormat) {
+    result.skipped = true;
+    result.skipReason = "unsupported file extension";
+    return result;
+  }
+
+  if (sourceFormat === options.targetFormat) {
+    result.skipped = true;
+    result.skipReason = `already in ${options.targetFormat} format`;
+    return result;
+  }
+
+  let workflow: Workflow;
+  try {
+    workflow = parseWorkflowFile(filePath);
+  } catch (e) {
+    result.error = e instanceof Error ? e : new Error(String(e));
+    return result;
+  }
+
+  const workflowID = workflow.id ?? "";
+  if (!workflowID) {
+    result.error = new Error("workflow has no ID");
+    return result;
+  }
+
+  try {
+    if (options.targetFormat === "yaml") {
+      result.outputPath = generateYamlFilePath(options.directory, workflowID, workflow.name);
+
+      if (!options.dryRun) {
+        const written = writeWorkflowYAML(
+          options.directory,
+          null,
+          workflow,
+          options.externalizeThreshold,
+        );
+        result.writtenFiles = written;
+        if (written.length > 0) {
+          result.outputPath = written[0]!;
+        }
+      }
+    } else {
+      result.outputPath = generateFilePath(options.directory, workflowID, workflow.name);
+
+      if (!options.dryRun) {
+        writeWorkflowJSON(result.outputPath, workflow);
+        result.writtenFiles = [result.outputPath];
+      }
+    }
+
+    // Remove original file and associated _subfiles (for YAML→JSON)
+    if (!options.dryRun && !options.keepOriginal) {
+      // Delete source file (unless output overwrote it — same path)
+      if (path.resolve(filePath) !== path.resolve(result.outputPath)) {
+        fs.unlinkSync(filePath);
+        result.removedFiles.push(filePath);
+      }
+
+      // When converting YAML→JSON, clean up _subfiles directories
+      if (sourceFormat === "yaml") {
+        const subfilesDirs = findExistingSubfilesDirs(options.directory, workflowID);
+        for (const dir of subfilesDirs) {
+          fs.rmSync(dir, { recursive: true, force: true });
+          result.removedFiles.push(dir);
+        }
+      }
+    }
+  } catch (e) {
+    result.error = e instanceof Error ? e : new Error(String(e));
+  }
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { registerApplyCommand } from "./cli/commands/apply.ts";
+import { registerConvertCommand } from "./cli/commands/convert.ts";
 import { registerCredentialCommand } from "./cli/commands/credential.ts";
 import { registerDataTableCommand } from "./cli/commands/data-table.ts";
 import { registerExecutionCommand } from "./cli/commands/execution.ts";
@@ -21,6 +22,7 @@ registerTagCommand(program);
 registerCredentialCommand(program);
 registerDataTableCommand(program);
 registerApplyCommand(program);
+registerConvertCommand(program);
 registerImportCommand(program);
 registerLintCommand(program);
 registerNodeSchemaCommand(program);

--- a/tests/convert/converter.test.ts
+++ b/tests/convert/converter.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import { type ConvertOptions, convertWorkflowFile, detectFormat } from "@/convert/converter.ts";
+
+const tmpBase = path.join(import.meta.dirname, "__tmp_convert_test__");
+
+function makeWorkflow(overrides?: Partial<Workflow>): Workflow {
+  return {
+    id: "wf-100",
+    name: "Test Workflow",
+    active: true,
+    nodes: [
+      {
+        id: "node-1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0] as [number, number],
+      },
+    ],
+    connections: {},
+    ...overrides,
+  };
+}
+
+function writeJSON(dir: string, filename: string, workflow: Workflow): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, filename);
+  fs.writeFileSync(filePath, JSON.stringify(workflow, null, 2));
+  return filePath;
+}
+
+function writeYAML(dir: string, filename: string, workflow: Workflow): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, filename);
+  // Simple YAML serialization sufficient for tests
+  const yaml = require("js-yaml") as typeof import("js-yaml");
+  fs.writeFileSync(filePath, yaml.dump(workflow));
+  return filePath;
+}
+
+function defaultOptions(overrides?: Partial<ConvertOptions>): ConvertOptions {
+  return {
+    targetFormat: "yaml",
+    directory: tmpBase,
+    externalizeThreshold: 3,
+    dryRun: false,
+    keepOriginal: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(tmpBase, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+});
+
+describe("detectFormat", () => {
+  test("returns json for .json files", () => {
+    expect(detectFormat("workflow.json")).toBe("json");
+  });
+
+  test("returns yaml for .yaml files", () => {
+    expect(detectFormat("workflow.yaml")).toBe("yaml");
+  });
+
+  test("returns yaml for .yml files", () => {
+    expect(detectFormat("workflow.yml")).toBe("yaml");
+  });
+
+  test("returns null for unsupported extensions", () => {
+    expect(detectFormat("workflow.txt")).toBeNull();
+  });
+});
+
+describe("convertWorkflowFile", () => {
+  test("converts JSON to YAML", () => {
+    const wf = makeWorkflow();
+    const jsonPath = writeJSON(tmpBase, "test__wf-100.json", wf);
+
+    const result = convertWorkflowFile(jsonPath, defaultOptions());
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBe(false);
+    expect(result.outputPath).toContain(".yaml");
+    expect(result.writtenFiles.length).toBeGreaterThan(0);
+    // Original JSON should be removed
+    expect(fs.existsSync(jsonPath)).toBe(false);
+    // YAML output should exist
+    expect(fs.existsSync(result.outputPath)).toBe(true);
+  });
+
+  test("converts YAML to JSON", () => {
+    const wf = makeWorkflow();
+    const yamlPath = writeYAML(tmpBase, "test__wf-100.yaml", wf);
+
+    const result = convertWorkflowFile(yamlPath, defaultOptions({ targetFormat: "json" }));
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBe(false);
+    expect(result.outputPath).toContain(".json");
+    // Original YAML should be removed
+    expect(fs.existsSync(yamlPath)).toBe(false);
+    // JSON output should exist
+    expect(fs.existsSync(result.outputPath)).toBe(true);
+    // Verify it's valid JSON
+    const content = fs.readFileSync(result.outputPath, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.id).toBe("wf-100");
+    expect(parsed.name).toBe("Test Workflow");
+  });
+
+  test("skips when source format matches target format", () => {
+    const wf = makeWorkflow();
+    const jsonPath = writeJSON(tmpBase, "test__wf-100.json", wf);
+
+    const result = convertWorkflowFile(jsonPath, defaultOptions({ targetFormat: "json" }));
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe("already in json format");
+    // File should still exist
+    expect(fs.existsSync(jsonPath)).toBe(true);
+  });
+
+  test("skips unsupported file extensions", () => {
+    const filePath = path.join(tmpBase, "workflow.txt");
+    fs.writeFileSync(filePath, "not a workflow");
+
+    const result = convertWorkflowFile(filePath, defaultOptions());
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe("unsupported file extension");
+  });
+
+  test("errors on workflow without ID", () => {
+    const wf = makeWorkflow({ id: undefined });
+    const jsonPath = writeJSON(tmpBase, "test.json", wf);
+
+    const result = convertWorkflowFile(jsonPath, defaultOptions());
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toBe("workflow has no ID");
+  });
+
+  test("dry-run does not write or remove files", () => {
+    const wf = makeWorkflow();
+    const jsonPath = writeJSON(tmpBase, "test__wf-100.json", wf);
+
+    const result = convertWorkflowFile(jsonPath, defaultOptions({ dryRun: true }));
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBe(false);
+    expect(result.outputPath).toContain(".yaml");
+    expect(result.writtenFiles).toEqual([]);
+    expect(result.removedFiles).toEqual([]);
+    // Original should still exist
+    expect(fs.existsSync(jsonPath)).toBe(true);
+  });
+
+  test("--keep preserves original file", () => {
+    const wf = makeWorkflow();
+    const jsonPath = writeJSON(tmpBase, "test__wf-100.json", wf);
+
+    const result = convertWorkflowFile(jsonPath, defaultOptions({ keepOriginal: true }));
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBe(false);
+    expect(result.removedFiles).toEqual([]);
+    // Both files should exist
+    expect(fs.existsSync(jsonPath)).toBe(true);
+    expect(fs.existsSync(result.outputPath)).toBe(true);
+  });
+
+  test("YAML to JSON cleans up _subfiles directory", () => {
+    const wf = makeWorkflow();
+    const yamlPath = writeYAML(tmpBase, "test__wf-100.yaml", wf);
+
+    // Create a fake _subfiles directory
+    const subfilesDir = path.join(tmpBase, "_subfiles", "test-workflow__wf-100");
+    fs.mkdirSync(subfilesDir, { recursive: true });
+    fs.writeFileSync(path.join(subfilesDir, "code.js"), "// code");
+
+    const result = convertWorkflowFile(yamlPath, defaultOptions({ targetFormat: "json" }));
+
+    expect(result.error).toBeUndefined();
+    expect(result.removedFiles).toContain(subfilesDir);
+    expect(fs.existsSync(subfilesDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `convert` command for converting workflow files between JSON and YAML formats
- Local-only operation (no n8n server connection required)
- Supports `--ids` and `--tags` filtering, `--dry-run`, and `--keep` options
- JSON to YAML: code externalization (`_subfiles/`) + `description.md` generation
- YAML to JSON: resolves `!include` directives and cleans up `_subfiles/` directories

## Changes
- `src/convert/converter.ts` — core conversion logic
- `src/cli/commands/convert.ts` — CLI command registration
- `src/index.ts` — register the new command
- `tests/convert/converter.test.ts` — tests (12 cases)
- `README.md` — add command documentation
- `CONTRIBUTING.md` — add `convert/` to project structure
- `.claude/skills/n8n-cli/SKILL.md` — add convert section to operations guide + resolve merge conflicts

## Test plan
- [x] `bun test tests/convert/converter.test.ts` — all 12 tests pass
- [x] `bun test` — all 662 existing tests pass
- [x] `bun run build` — build succeeds
- [x] `./n8n-cli convert --help` — help output verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)