### PR TITLE
feat(apply): require explicit scope to prevent accidental wide apply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.0.12",
+  "version": "2.1.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/apply/types.ts
+++ b/src/apply/types.ts
@@ -9,6 +9,7 @@ export type SourceType = "json" | "yaml";
 /** ApplyOptions holds configuration for the apply command. */
 export interface ApplyOptions {
   directory: string;
+  all: boolean;
   dryRun: boolean;
   force: boolean;
   projectID: string;
@@ -27,6 +28,7 @@ export interface ApplyOptions {
 export function defaultApplyOptions(): ApplyOptions {
   return {
     directory: "./definitions",
+    all: false,
     dryRun: false,
     force: false,
     projectID: "",

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -28,6 +28,10 @@ export function registerApplyCommand(program: Command): void {
     .option("--yaml", "Enable YAML file processing")
     .option("--no-yaml", "Disable YAML processing")
     .option(
+      "--dangerously-apply-all",
+      "Apply ALL workflows in the directory, overwriting remote state (required when no scope filter is specified)",
+    )
+    .option(
       "--warn-duplicates",
       "Warn when creating workflows with names that already exist remotely",
     )
@@ -36,6 +40,7 @@ export function registerApplyCommand(program: Command): void {
 
       const opts = defaultApplyOptions();
       opts.directory = options.dir as string;
+      opts.all = !!options.dangerouslyApplyAll;
       opts.dryRun = !!options.dryRun;
       opts.force = !!options.force;
       opts.noAutoTag = !!options.noAutoTag;
@@ -73,6 +78,24 @@ export function registerApplyCommand(program: Command): void {
         if (opts.filterByTags.length > 0) {
           console.log(`Filtering by tags: ${opts.filterByTags.join(", ")} (AND)`);
         }
+      }
+
+      // Require explicit scope: --ids, --from-git-changes, or --dangerously-apply-all
+      const hasScope = opts.ids.length > 0 || opts.fromGitChanges || opts.filterByTags.length > 0;
+      if (!hasScope && !opts.all) {
+        console.error(
+          [
+            "Error: No scope specified — refusing to apply all workflows.",
+            "",
+            "You must specify which workflows to apply:",
+            "  --ids <id1>,<id2>              Apply specific workflows by ID",
+            "  --from-git-changes <spec>      Apply only files changed in Git diff",
+            "",
+            "Applying without a scope filter is not allowed by default.",
+            "See --help for more options.",
+          ].join("\n"),
+        );
+        process.exit(1);
       }
 
       // Load CLI config from CLAUDE.md

--- a/tests/cli/apply-scope-validation.test.ts
+++ b/tests/cli/apply-scope-validation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+/**
+ * CLI integration tests for the apply command's scope validation.
+ *
+ * When no scope-limiting flag (--ids, --from-git-changes, APPLY_FILTER_BY_TAGS)
+ * is provided, the --dangerously-apply-all flag must be explicitly passed.
+ * This prevents accidental wide applies that affect all workflows.
+ *
+ * The error message intentionally does NOT mention --dangerously-apply-all
+ * to avoid AI agents mechanically adding the flag to bypass the safety check.
+ */
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+async function runApply(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(
+    ["bun", "run", CLI_ENTRY, "--api-url", "http://localhost:0", "--api-key", "dummy", "apply", ...args],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, ...env },
+    },
+  );
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("apply --dangerously-apply-all scope validation", () => {
+  test("rejects apply with no scope flags", async () => {
+    const { stderr, exitCode } = await runApply(["--dry-run"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No scope specified");
+  });
+
+  test("error message does NOT reveal the bypass flag", async () => {
+    const { stderr } = await runApply(["--dry-run"]);
+    expect(stderr).not.toContain("dangerously");
+  });
+
+  test("error message guides toward scoped alternatives", async () => {
+    const { stderr } = await runApply(["--dry-run"]);
+    expect(stderr).toContain("--ids");
+    expect(stderr).toContain("--from-git-changes");
+  });
+
+  test("rejects apply with only --dir", async () => {
+    const { stderr, exitCode } = await runApply(["--dir", "./definitions", "--dry-run"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No scope specified");
+  });
+
+  test("accepts apply with --ids", async () => {
+    const { stderr } = await runApply(["--ids", "123", "--dry-run"]);
+    expect(stderr).not.toContain("No scope specified");
+  });
+
+  test("accepts apply with --dangerously-apply-all", async () => {
+    const { stderr } = await runApply(["--dangerously-apply-all", "--dry-run"]);
+    expect(stderr).not.toContain("No scope specified");
+  });
+
+  test("accepts apply with APPLY_FILTER_BY_TAGS env", async () => {
+    const { stderr } = await runApply(["--dry-run"], { APPLY_FILTER_BY_TAGS: "production" });
+    expect(stderr).not.toContain("No scope specified");
+  });
+});

--- a/tests/cli/apply-scope-validation.test.ts
+++ b/tests/cli/apply-scope-validation.test.ts
@@ -19,7 +19,17 @@ async function runApply(
   env?: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn(
-    ["bun", "run", CLI_ENTRY, "--api-url", "http://localhost:0", "--api-key", "dummy", "apply", ...args],
+    [
+      "bun",
+      "run",
+      CLI_ENTRY,
+      "--api-url",
+      "http://localhost:0",
+      "--api-key",
+      "dummy",
+      "apply",
+      ...args,
+    ],
     {
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
## Summary
- Require `--dangerously-apply-all` flag when no scope filter (`--ids`, `--from-git-changes`, `APPLY_FILTER_BY_TAGS`) is specified for the `apply` command
- Error message intentionally omits the bypass flag, guiding users toward `--ids` or `--from-git-changes` to narrow scope
- Prevents AI agents from accidentally overwriting all remote workflows with stale local state

## Test plan
- [x] `apply` without scope flags → rejected with error
- [x] Error message does not contain `dangerously`
- [x] `apply --ids <id>` → passes validation
- [x] `apply --dangerously-apply-all` → passes validation
- [x] `apply` with `APPLY_FILTER_BY_TAGS` env → passes validation
- [x] All 669 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)