### PR TITLE
lint: -c なしでも .n8nlintrc.json を自動検出する

### DIFF
--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { hasAllTags, parseTagFilter } from "@/common/tags.ts";
-import { getRuleOptions, loadLintConfig } from "@/lint/config.ts";
+import { findConfigFile, getRuleOptions, loadLintConfig } from "@/lint/config.ts";
 import { formatJSON } from "@/lint/output/json.ts";
 import type { LintResult } from "@/lint/output/result.ts";
 import { hasErrors } from "@/lint/output/result.ts";
@@ -32,8 +32,15 @@ export function registerLintCommand(program: Command): void {
         return;
       }
 
-      // Load config
-      const config = opts.config ? loadLintConfig(opts.config) : loadLintConfig();
+      // Load config (auto-discover from CWD when -c is not specified)
+      let resolvedConfigPath: string | undefined = opts.config;
+      if (!resolvedConfigPath) {
+        resolvedConfigPath = findConfigFile(process.cwd());
+        if (resolvedConfigPath && opts.output !== "json") {
+          console.error(`Using config: ${resolvedConfigPath}`);
+        }
+      }
+      const config = loadLintConfig(resolvedConfigPath);
 
       // Get enabled rules
       const enabledRules = registry.enabledRulesWithConfig(config, opts.disableRule);

--- a/src/lint/config.ts
+++ b/src/lint/config.ts
@@ -1,4 +1,24 @@
 import fs from "node:fs";
+import path from "node:path";
+
+const CONFIG_FILENAME = ".n8nlintrc.json";
+
+/**
+ * Searches for a config file by walking up from startDir to the filesystem root.
+ * Returns the first `.n8nlintrc.json` found, or undefined if none exists.
+ */
+export function findConfigFile(startDir: string): string | undefined {
+  let dir = path.resolve(startDir);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const candidate = path.join(dir, CONFIG_FILENAME);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
 
 /** RuleConfig represents the configuration for a single rule */
 export interface RuleConfig {
@@ -15,12 +35,13 @@ export interface LintConfig {
   rulesConfig: Map<string, RuleConfig>;
 }
 
-/** Load reads and parses a lint config file. Returns default if not found. */
+/** Load reads and parses a lint config file. Auto-discovers from CWD if no path given. */
 export function loadLintConfig(configPath?: string): LintConfig {
   const defaultConfig: LintConfig = { rulesConfig: new Map() };
 
   if (!configPath) {
-    return defaultConfig;
+    configPath = findConfigFile(process.cwd());
+    if (!configPath) return defaultConfig;
   }
 
   let data: string;

--- a/tests/lint/config.test.ts
+++ b/tests/lint/config.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { findConfigFile, loadLintConfig } from "@/lint/config.ts";
+
+describe("findConfigFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-config-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("finds config in the given directory", () => {
+    const configPath = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(configPath, '{"rules":{}}');
+
+    const found = findConfigFile(tmpDir);
+    expect(found).toBe(configPath);
+  });
+
+  test("finds config in a parent directory", () => {
+    const configPath = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(configPath, '{"rules":{}}');
+
+    const subDir = path.join(tmpDir, "sub", "deep");
+    fs.mkdirSync(subDir, { recursive: true });
+
+    const found = findConfigFile(subDir);
+    expect(found).toBe(configPath);
+  });
+
+  test("returns undefined when no config exists", () => {
+    const found = findConfigFile(tmpDir);
+    expect(found).toBeUndefined();
+  });
+
+  test("returns the nearest config when multiple exist", () => {
+    const parentConfig = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(parentConfig, '{"rules":{"json-syntax":true}}');
+
+    const subDir = path.join(tmpDir, "sub");
+    fs.mkdirSync(subDir);
+    const childConfig = path.join(subDir, ".n8nlintrc.json");
+    fs.writeFileSync(childConfig, '{"rules":{"json-syntax":false}}');
+
+    const found = findConfigFile(subDir);
+    expect(found).toBe(childConfig);
+  });
+});
+
+describe("loadLintConfig auto-discovery", () => {
+  const originalCwd = process.cwd();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-config-auto-"));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("auto-discovers config from CWD when no path given", () => {
+    const configPath = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: {
+          "schedule-trigger-frequency": ["error", { minInterval: "hourly" }],
+        },
+      }),
+    );
+
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    const rc = config.rulesConfig.get("schedule-trigger-frequency");
+    expect(rc).toBeDefined();
+    expect(rc!.severity).toBe("error");
+    expect(rc!.options).toEqual({ minInterval: "hourly" });
+  });
+
+  test("returns empty config when no config file exists in CWD", () => {
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    expect(config.rulesConfig.size).toBe(0);
+  });
+
+  test("explicit path takes precedence over auto-discovery", () => {
+    const autoConfig = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(autoConfig, JSON.stringify({ rules: { "json-syntax": "off" } }));
+
+    const explicitDir = path.join(tmpDir, "explicit");
+    fs.mkdirSync(explicitDir);
+    const explicitConfig = path.join(explicitDir, "custom-lint.json");
+    fs.writeFileSync(explicitConfig, JSON.stringify({ rules: { "json-syntax": "error" } }));
+
+    process.chdir(tmpDir);
+    const config = loadLintConfig(explicitConfig);
+    const rc = config.rulesConfig.get("json-syntax");
+    expect(rc).toBeDefined();
+    expect(rc!.severity).toBe("error");
+  });
+});


### PR DESCRIPTION
## 概要

\`n8n-cli lint\` で \`-c .n8nlintrc.json\` を付け忘れると、severity やルールオプションが全て無視されてデフォルト動作になる。ESLint/Prettier と同じように、CWD から上方向に \`.n8nlintrc.json\` を自動で探して読み込むようにする。

## 変更内容

- \`loadLintConfig()\` に path が渡されなかった場合、CWD から親ディレクトリを辿って \`.n8nlintrc.json\` を探す
- 見つかったら stderr に \`Using config: <path>\` を表示（JSON 出力時は抑制）
- \`-c\` を明示指定した場合はそちらが優先（従来通り）

## テスト (7 件追加、全 pass)

- CWD の config を検出
- 親ディレクトリの config を検出
- config がなければ空（従来通り）
- 複数 config があれば最も近いものを使用
- \`-c\` 明示指定が自動検出より優先

Signed-off-by: nakamura-tsubasa-283 <tsubasa.nakamura@ubie-partners.com>