### PR TITLE
lint: 6-field cron とカンマ区切りのスケジュール検出に対応

### DIFF
--- a/src/lint/rules/schedule-trigger-frequency.ts
+++ b/src/lint/rules/schedule-trigger-frequency.ts
@@ -53,16 +53,37 @@ export function intervalToSeconds(entry: IntervalEntry): number | undefined {
  * Estimates minimum interval in seconds from a cron expression.
  * Only handles simple patterns; returns undefined (safe-side skip) for complex expressions.
  *
- * Standard cron: minute hour day-of-month month day-of-week
+ * Supports both:
+ * - 5-field standard cron: minute hour day-of-month month day-of-week
+ * - 6-field n8n cron:      second minute hour day-of-month month day-of-week
  */
 export function estimateCronIntervalSeconds(cron: string): number | undefined {
   const parts = cron.trim().split(/\s+/);
-  if (parts.length !== 5) return undefined;
 
-  const [minute, hour, dayOfMonth, _month, _dayOfWeek] = parts;
+  let minute: string;
+  let hour: string;
+  let dayOfMonth: string;
 
+  if (parts.length === 6) {
+    // 6-field cron (n8n format): second minute hour dom month dow
+    [, minute, hour, dayOfMonth] = parts as [string, string, string, string, string, string];
+  } else if (parts.length === 5) {
+    // 5-field standard cron: minute hour dom month dow
+    [minute, hour, dayOfMonth] = parts as [string, string, string, string, string];
+  } else {
+    return undefined;
+  }
+
+  return estimateFromMinuteHourDay(minute, hour, dayOfMonth);
+}
+
+function estimateFromMinuteHourDay(
+  minute: string,
+  hour: string,
+  dayOfMonth: string,
+): number | undefined {
   // Check minute field first (finest granularity)
-  const minuteInterval = parseCronField(minute!);
+  const minuteInterval = parseCronField(minute);
   if (minuteInterval !== undefined) {
     // If minute is *, interval is every minute = 60s
     // If minute is */N, interval is N minutes
@@ -74,9 +95,15 @@ export function estimateCronIntervalSeconds(cron: string): number | undefined {
     }
   }
 
+  // Minute is a list (e.g., "0,30") — estimate from the count of values per hour
+  const minuteListCount = countListValues(minute);
+  if (minuteListCount !== undefined && minuteListCount > 1 && hour === "*") {
+    return Math.floor(3600 / minuteListCount);
+  }
+
   // Minute is a specific number (e.g., "0") — check hour field
-  if (isSpecificNumber(minute!)) {
-    const hourInterval = parseCronField(hour!);
+  if (isSpecificNumber(minute)) {
+    const hourInterval = parseCronField(hour);
     if (hourInterval !== undefined) {
       if (hourInterval === 1) {
         return 3600; // every hour at specific minute
@@ -86,9 +113,15 @@ export function estimateCronIntervalSeconds(cron: string): number | undefined {
       }
     }
 
+    // Hour is a list (e.g., "0,6,12,18") — estimate from count per day
+    const hourListCount = countListValues(hour);
+    if (hourListCount !== undefined && hourListCount > 1) {
+      return Math.floor(86400 / hourListCount);
+    }
+
     // Hour is specific — check day field
-    if (isSpecificNumber(hour!)) {
-      const dayInterval = parseCronField(dayOfMonth!);
+    if (isSpecificNumber(hour)) {
+      const dayInterval = parseCronField(dayOfMonth);
       if (dayInterval !== undefined) {
         if (dayInterval === 1) {
           return 86400; // daily
@@ -96,7 +129,7 @@ export function estimateCronIntervalSeconds(cron: string): number | undefined {
         return dayInterval * 86400;
       }
       // Day is specific number → at most once per month
-      if (isSpecificNumber(dayOfMonth!)) {
+      if (isSpecificNumber(dayOfMonth)) {
         return 2592000;
       }
     }
@@ -116,6 +149,12 @@ function parseCronField(field: string): number | undefined {
 
 function isSpecificNumber(field: string): boolean {
   return /^\d+$/.test(field);
+}
+
+// Parses a comma-separated list of numbers (e.g., "0,15,30,45"). Returns the count, or undefined.
+function countListValues(field: string): number | undefined {
+  if (!/^\d+(,\d+)+$/.test(field)) return undefined;
+  return field.split(",").length;
 }
 
 /**

--- a/tests/lint/rules/schedule-trigger-frequency.test.ts
+++ b/tests/lint/rules/schedule-trigger-frequency.test.ts
@@ -170,6 +170,55 @@ describe("estimateCronIntervalSeconds", () => {
   test("every 2 hours: 0 */2 * * *", () => {
     expect(estimateCronIntervalSeconds("0 */2 * * *")).toBe(7200);
   });
+
+  // 6-field cron (n8n format: second minute hour dom month dow)
+  test("6-field: every 5 minutes: 0 */5 * * * *", () => {
+    expect(estimateCronIntervalSeconds("0 */5 * * * *")).toBe(300);
+  });
+
+  test("6-field: every minute: 0 * * * * *", () => {
+    expect(estimateCronIntervalSeconds("0 * * * * *")).toBe(60);
+  });
+
+  test("6-field: every hour: 0 0 * * * *", () => {
+    expect(estimateCronIntervalSeconds("0 0 * * * *")).toBe(3600);
+  });
+
+  test("6-field: every 3 hours: 0 0 */3 * * *", () => {
+    expect(estimateCronIntervalSeconds("0 0 */3 * * *")).toBe(10800);
+  });
+
+  test("6-field: daily at midnight: 0 0 0 * * *", () => {
+    expect(estimateCronIntervalSeconds("0 0 0 * * *")).toBe(86400);
+  });
+
+  test("6-field: monthly: 0 0 0 1 * *", () => {
+    expect(estimateCronIntervalSeconds("0 0 0 1 * *")).toBe(2592000);
+  });
+
+  test("6-field: weekday restriction still works: 0 0 10 * * 1-5", () => {
+    // Minute=0, hour=10 (specific), day=* → daily
+    expect(estimateCronIntervalSeconds("0 0 10 * * 1-5")).toBe(86400);
+  });
+
+  // Comma-separated values
+  test("minute list: 0,30 * * * * (every 30 min)", () => {
+    expect(estimateCronIntervalSeconds("0,30 * * * *")).toBe(1800);
+  });
+
+  test("hour list: 0 0,6,12,18 * * * (every 6 hours)", () => {
+    expect(estimateCronIntervalSeconds("0 0,6,12,18 * * *")).toBe(21600);
+  });
+
+  test("6-field hour list: 0 0 0,6,12,18 * * * (every 6 hours)", () => {
+    expect(estimateCronIntervalSeconds("0 0 0,6,12,18 * * *")).toBe(21600);
+  });
+
+  test("6-field minute list: 0 0,30 8-20 * * 1-5", () => {
+    // minute=0,30 (2 per hour), hour=8-20 (not * but complex) → can't determine fully
+    // hour is not *, so minute list estimation doesn't apply; falls through to undefined
+    expect(estimateCronIntervalSeconds("0 0,30 8-20 * * 1-5")).toBeUndefined();
+  });
 });
 
 describe("cron-based schedule trigger", () => {
@@ -189,6 +238,25 @@ describe("cron-based schedule trigger", () => {
     const wf = makeWorkflow([{ field: "cronExpression", cronExpression: "*/5 * * * *" }]);
     const violations = scheduleTriggerFrequencyRule.check(wf, "", { minInterval: "hourly" });
     expect(violations.length).toBe(1);
+  });
+
+  test("6-field cron every 5 minutes with minInterval=hourly → violation", () => {
+    const wf = makeWorkflow([{ field: "cronExpression", cronExpression: "0 */5 * * * *" }]);
+    const violations = scheduleTriggerFrequencyRule.check(wf, "", { minInterval: "hourly" });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain("300s");
+  });
+
+  test("6-field cron every hour with minInterval=hourly → OK", () => {
+    const wf = makeWorkflow([{ field: "cronExpression", cronExpression: "0 0 * * * *" }]);
+    const violations = scheduleTriggerFrequencyRule.check(wf, "", { minInterval: "hourly" });
+    expect(violations.length).toBe(0);
+  });
+
+  test("6-field cron daily with minInterval=hourly → OK", () => {
+    const wf = makeWorkflow([{ field: "cronExpression", cronExpression: "0 0 0 * * *" }]);
+    const violations = scheduleTriggerFrequencyRule.check(wf, "", { minInterval: "hourly" });
+    expect(violations.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## 概要

\`schedule-trigger-frequency\` ルールが 5-field cron しか対応しておらず、n8n が内部で使う 6-field cron（秒フィールド付き）のサブ時間スケジュールを検出できなかった。

例: \`0 */5 * * * *\`（5分ごと）は 6-field cron のため検出をすり抜けていた。

## 変更内容

- \`estimateCronIntervalSeconds\` を 5-field / 6-field 両対応に
- カンマ区切り値の検出を追加（\`0,30 * * * *\` → 30分ごと、\`0 0,6,12,18 * * *\` → 6時間ごと）

## テスト (15 件追加、全 46 件 pass)

| 入力 | 期待値 |
|------|--------|
| \`0 */5 * * * *\` (6-field, 5分) | 300s |
| \`0 0 * * * *\` (6-field, 毎時) | 3600s |
| \`0 0 0 * * *\` (6-field, 毎日) | 86400s |
| \`0,30 * * * *\` (カンマ, 30分) | 1800s |
| \`0 0,6,12,18 * * *\` (カンマ, 6時間) | 21600s |
| 既存 5-field テスト全件 | 変更なし |

Signed-off-by: nakamura-tsubasa-283 <tsubasa.nakamura@ubie-partners.com>