### PR TITLE
feat(lint): add --remote option to lint workflows via n8n API

### DIFF
--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { resolveContext } from "@/cli/root.ts";
 import { hasAllTags, parseTagFilter } from "@/common/tags.ts";
 import { getRuleOptions, loadLintConfig } from "@/lint/config.ts";
 import { formatJSON } from "@/lint/output/json.ts";
@@ -15,12 +16,18 @@ export function registerLintCommand(program: Command): void {
     .description("Lint workflow definition files")
     .option("-d, --dir <directory>", "Directory to scan for workflow files")
     .option("-f, --file <files...>", "Specific files to lint (can be repeated)")
+    .option(
+      "--remote",
+      "Fetch workflows from n8n API instead of local files (requires N8N_API_URL and N8N_API_KEY)",
+    )
+    .option("--active-only", "Only lint active workflows (requires --remote)")
+    .option("--ui-url <url>", "n8n UI base URL for workflow links (env: N8N_UI_URL)")
     .option("-c, --config <path>", "Path to .n8nlintrc.json config file")
     .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
     .option("--list-rules", "List all available rules and exit")
     .option("-o, --output <format>", "Output format: text, json", "text")
     .option("--tags <tags>", "Filter by tags (comma-separated, AND condition)")
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       const registry = registerDefaultRules();
 
       // List rules mode
@@ -50,93 +57,188 @@ export function registerLintCommand(program: Command): void {
         }
       }
 
-      // Collect files to lint
-      let files: string[] = [];
-      if (opts.file) {
-        files = opts.file;
-      } else if (opts.dir) {
-        files = scanFiles(opts.dir);
+      if (opts.remote) {
+        // Remote mode: fetch workflows from n8n API
+        if (opts.dir || opts.file) {
+          console.error("Error: --remote cannot be used with --dir or --file");
+          process.exit(1);
+        }
+
+        const ctx = resolveContext(command.parent!);
+        const workflows = await ctx.workflowService.listAllWorkflows({
+          active: opts.activeOnly ? true : undefined,
+          tags: filterByTags.length > 0 ? filterByTags : undefined,
+        });
+
+        const uiURL = opts.uiUrl ?? process.env.N8N_UI_URL ?? deriveUIURL(ctx.config.apiURL);
+
+        await lintRemote(workflows, enabledRules, config, uiURL, opts);
       } else {
-        console.error("Error: specify --dir or --file to indicate files to lint");
-        process.exit(1);
-      }
-
-      if (files.length === 0) {
-        console.error("No files found to lint");
-        process.exit(1);
-      }
-
-      // Run linting
-      const result: LintResult = {
-        violations: [],
-        filesChecked: 0,
-        filesFailed: 0,
-      };
-
-      const failedFiles = new Set<string>();
-
-      for (const filePath of files) {
-        result.filesChecked++;
-
-        const outcome = await loadFileForLint(filePath, filterByTags);
-        if (outcome.status === "skipped") {
-          result.violations.push({
-            file: filePath,
-            rule: "file-read",
-            severity: "warning",
-            message: outcome.message,
-          });
-          result.filesChecked--;
-          continue;
-        }
-        if (outcome.status === "error") {
-          result.violations.push({
-            file: filePath,
-            rule: "file-read",
-            severity: "error",
-            message: outcome.message,
-          });
-          failedFiles.add(filePath);
-          continue;
-        }
-
-        const { rawJSON, workflow } = outcome.data;
-
-        // Filter by tags
-        if (workflow && filterByTags.length > 0) {
-          if (!hasAllTags(workflow.tags, filterByTags)) {
-            result.filesChecked--; // Don't count filtered files
-            continue;
-          }
-        }
-
-        // Run each enabled rule
-        for (const { rule, severity } of enabledRules) {
-          const violations = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
-          for (const v of violations) {
-            result.violations.push({
-              ...v,
-              file: v.file ?? filePath,
-              severity,
-            });
-            failedFiles.add(filePath);
-          }
-        }
-      }
-
-      result.filesFailed = failedFiles.size;
-
-      // Output results
-      const outputFormat = opts.output ?? "text";
-      if (outputFormat === "json") {
-        console.log(formatJSON(result));
-      } else {
-        console.log(formatText(result));
-      }
-
-      // Exit with error code if there are errors
-      if (hasErrors(result)) {
-        process.exit(1);
+        // Local mode: read files from filesystem
+        await lintLocal(enabledRules, config, filterByTags, opts);
       }
     });
+}
+
+/**
+ * Derive the UI URL from the API URL by removing common API-only subdomains.
+ * e.g. "https://n8n-direct.ubie.dev" → "https://n8n.ubie.dev"
+ */
+function deriveUIURL(apiURL: string): string {
+  return apiURL.replace("n8n-direct.", "n8n.");
+}
+
+/** Display name for a remote workflow used in violation output. */
+function workflowDisplayName(name: string, id: string | undefined): string {
+  return id ? `${name} (${id})` : name;
+}
+
+/** Build the n8n UI URL for a workflow. */
+function workflowURL(baseURL: string, id: string | undefined): string | undefined {
+  if (!id) return undefined;
+  const base = baseURL.replace(/\/+$/, "");
+  return `${base}/workflow/${id}`;
+}
+
+/** Lint workflows fetched from the n8n API. */
+async function lintRemote(
+  workflows: import("@/api/types.ts").Workflow[],
+  enabledRules: ReturnType<ReturnType<typeof registerDefaultRules>["enabledRulesWithConfig"]>,
+  config: ReturnType<typeof loadLintConfig>,
+  uiURL: string,
+  opts: { output?: string },
+): Promise<void> {
+  const result: LintResult = {
+    violations: [],
+    filesChecked: 0,
+    filesFailed: 0,
+  };
+
+  const failedWorkflows = new Set<string>();
+
+  for (const workflow of workflows) {
+    result.filesChecked++;
+    const displayName = workflowDisplayName(workflow.name, workflow.id);
+    const rawJSON = JSON.stringify(workflow);
+    const url = workflowURL(uiURL, workflow.id);
+
+    for (const { rule, severity } of enabledRules) {
+      const violations = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
+      for (const v of violations) {
+        result.violations.push({
+          ...v,
+          file: v.file ?? displayName,
+          url,
+          severity,
+        });
+        failedWorkflows.add(displayName);
+      }
+    }
+  }
+
+  result.filesFailed = failedWorkflows.size;
+
+  const outputFormat = opts.output ?? "text";
+  if (outputFormat === "json") {
+    console.log(formatJSON(result));
+  } else {
+    console.log(formatText(result));
+  }
+
+  if (hasErrors(result)) {
+    process.exit(1);
+  }
+}
+
+/** Lint workflow files from the local filesystem. */
+async function lintLocal(
+  enabledRules: ReturnType<ReturnType<typeof registerDefaultRules>["enabledRulesWithConfig"]>,
+  config: ReturnType<typeof loadLintConfig>,
+  filterByTags: string[],
+  opts: { dir?: string; file?: string[]; output?: string },
+): Promise<void> {
+  let files: string[] = [];
+  if (opts.file) {
+    files = opts.file;
+  } else if (opts.dir) {
+    files = scanFiles(opts.dir);
+  } else {
+    console.error("Error: specify --dir, --file, or --remote to indicate files to lint");
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    console.error("No files found to lint");
+    process.exit(1);
+  }
+
+  const result: LintResult = {
+    violations: [],
+    filesChecked: 0,
+    filesFailed: 0,
+  };
+
+  const failedFiles = new Set<string>();
+
+  for (const filePath of files) {
+    result.filesChecked++;
+
+    const outcome = await loadFileForLint(filePath, filterByTags);
+    if (outcome.status === "skipped") {
+      result.violations.push({
+        file: filePath,
+        rule: "file-read",
+        severity: "warning",
+        message: outcome.message,
+      });
+      result.filesChecked--;
+      continue;
+    }
+    if (outcome.status === "error") {
+      result.violations.push({
+        file: filePath,
+        rule: "file-read",
+        severity: "error",
+        message: outcome.message,
+      });
+      failedFiles.add(filePath);
+      continue;
+    }
+
+    const { rawJSON, workflow } = outcome.data;
+
+    // Filter by tags
+    if (workflow && filterByTags.length > 0) {
+      if (!hasAllTags(workflow.tags, filterByTags)) {
+        result.filesChecked--;
+        continue;
+      }
+    }
+
+    // Run each enabled rule
+    for (const { rule, severity } of enabledRules) {
+      const violations = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
+      for (const v of violations) {
+        result.violations.push({
+          ...v,
+          file: v.file ?? filePath,
+          severity,
+        });
+        failedFiles.add(filePath);
+      }
+    }
+  }
+
+  result.filesFailed = failedFiles.size;
+
+  const outputFormat = opts.output ?? "text";
+  if (outputFormat === "json") {
+    console.log(formatJSON(result));
+  } else {
+    console.log(formatText(result));
+  }
+
+  if (hasErrors(result)) {
+    process.exit(1);
+  }
 }

--- a/src/lint/output/json.ts
+++ b/src/lint/output/json.ts
@@ -12,6 +12,7 @@ interface JSONViolation {
   rule: string;
   message: string;
   severity: string;
+  url?: string;
 }
 
 interface JSONSummary {
@@ -34,6 +35,7 @@ export function formatJSON(result: LintResult): string {
       };
       if (v.line && v.line > 0) jv.line = v.line;
       if (v.column && v.column > 0) jv.column = v.column;
+      if (v.url) jv.url = v.url;
       return jv;
     }),
     summary: {

--- a/src/lint/output/text.ts
+++ b/src/lint/output/text.ts
@@ -20,6 +20,9 @@ export function formatText(result: LintResult): string {
 
     const severityLabel = v.severity === "warning" ? "warning" : "error";
     lines.push(`${location}: ${severityLabel}[${v.rule}]: ${v.message}`);
+    if (v.url) {
+      lines.push(`  ${v.url}`);
+    }
   }
 
   lines.push("");

--- a/src/lint/rules/violation.ts
+++ b/src/lint/rules/violation.ts
@@ -14,4 +14,6 @@ export interface Violation {
   message: string;
   /** Severity level (error or warning) */
   severity: Severity;
+  /** URL to the workflow in n8n UI (remote mode only) */
+  url?: string;
 }

--- a/tests/cli/lint-remote.test.ts
+++ b/tests/cli/lint-remote.test.ts
@@ -117,7 +117,7 @@ async function startMockServer(
     },
   });
 
-  return { port: server.port, server };
+  return { port: server.port!, server };
 }
 
 /** Run `n8n-cli lint` with the given args and parse JSON output. */

--- a/tests/cli/lint-remote.test.ts
+++ b/tests/cli/lint-remote.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import type { Workflow } from "@/api/types.ts";
+
+/**
+ * CLI integration tests for the lint --remote option.
+ *
+ * These tests start a tiny HTTP server that mimics the n8n API,
+ * then invoke `n8n-cli lint --remote` against it.
+ */
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+interface LintViolation {
+  file: string;
+  rule: string;
+  message: string;
+  severity: "error" | "warning";
+  url?: string;
+}
+
+interface LintOutput {
+  violations: LintViolation[];
+  summary: {
+    files_checked: number;
+    violations_found: number;
+    files_with_violations: number;
+    error_count: number;
+    warning_count: number;
+  };
+}
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "wf-test-1",
+    name: "Test Workflow",
+    active: true,
+    nodes: [],
+    connections: {},
+    ...overrides,
+  };
+}
+
+function makeScheduleNode(
+  name: string,
+  field: string,
+  interval: number,
+): Workflow["nodes"][number] {
+  const intervalKey = `${field}Interval`;
+  return {
+    id: "node-1",
+    name,
+    type: "n8n-nodes-base.scheduleTrigger",
+    typeVersion: 1,
+    position: [0, 0] as [number, number],
+    parameters: {
+      rule: {
+        interval: [{ field, [intervalKey]: interval }],
+      },
+    },
+  };
+}
+
+/** Write a lint config that only enables schedule-trigger-frequency. */
+function writeScheduleOnlyConfig(dir: string): string {
+  const configPath = path.join(dir, ".n8nlintrc.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      rules: {
+        "json-syntax": "off",
+        "required-fields": "off",
+        "connection-ref": "off",
+        "orphaned-node": "off",
+        "implicit-json-ref": "off",
+        "expression-mode-prefix": "off",
+        "ai-agent-output-ref": "off",
+        "node-params": "off",
+        "node-ref-field-check": "off",
+        "node-ref-cardinality": "off",
+        "webhook-id-required": "off",
+        "banned-node": "off",
+        "filter-operator-valid": "off",
+        "schedule-trigger-frequency": ["warning", { minInterval: "hourly" }],
+      },
+    }),
+  );
+  return configPath;
+}
+
+/** Start a mock n8n API server that returns the given workflows. */
+async function startMockServer(
+  workflows: Workflow[],
+): Promise<{ port: number; server: ReturnType<typeof Bun.serve> }> {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/api/v1/workflows" || url.pathname === "/workflows") {
+        const activeParam = url.searchParams.get("active");
+        let filtered = workflows;
+        if (activeParam === "true") {
+          filtered = workflows.filter((w) => w.active);
+        } else if (activeParam === "false") {
+          filtered = workflows.filter((w) => !w.active);
+        }
+
+        return new Response(JSON.stringify({ data: filtered, nextCursor: null }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  return { port: server.port, server };
+}
+
+/** Run `n8n-cli lint` with the given args and parse JSON output. */
+async function runLint(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ output: LintOutput; exitCode: number; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "lint", "-o", "json", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  let output: LintOutput;
+  try {
+    output = JSON.parse(stdout) as LintOutput;
+  } catch {
+    throw new Error(`Failed to parse lint JSON output.\nstdout: ${stdout}\nstderr: ${stderr}`);
+  }
+  return { output, exitCode, stderr };
+}
+
+// ---------------------------------------------------------------------------
+// --remote basic functionality
+// ---------------------------------------------------------------------------
+
+describe("CLI lint --remote: 基本機能", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let apiURL: string;
+
+  afterEach(() => {
+    server?.stop(true);
+  });
+
+  test("アクティブなワークフローを取得して lint を実行する", async () => {
+    const wf = makeWorkflow({
+      id: "wf-1",
+      name: "My Workflow",
+      nodes: [makeScheduleNode("Every Minute", "minutes", 1)],
+    });
+    ({ server } = await startMockServer([wf]));
+    apiURL = `http://localhost:${server.port}`;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      const { output } = await runLint(["--remote", "-c", configPath], {
+        N8N_API_URL: apiURL,
+        N8N_API_KEY: "test-key",
+      });
+
+      expect(output.summary.files_checked).toBe(1);
+      expect(output.summary.violations_found).toBeGreaterThanOrEqual(1);
+
+      const v = output.violations.find((v) => v.rule === "schedule-trigger-frequency");
+      expect(v).toBeDefined();
+      expect(v!.file).toBe("My Workflow (wf-1)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("violation に url フィールドが含まれる", async () => {
+    const wf = makeWorkflow({
+      id: "wf-url-test",
+      name: "URL Test",
+      nodes: [makeScheduleNode("Fast", "seconds", 10)],
+    });
+    ({ server } = await startMockServer([wf]));
+    apiURL = `http://localhost:${server.port}`;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      const { output } = await runLint(
+        ["--remote", "--ui-url", "https://n8n.example.com", "-c", configPath],
+        { N8N_API_URL: apiURL, N8N_API_KEY: "test-key" },
+      );
+
+      const v = output.violations.find((v) => v.rule === "schedule-trigger-frequency");
+      expect(v).toBeDefined();
+      expect(v!.url).toBe("https://n8n.example.com/workflow/wf-url-test");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("--active-only の場合はアクティブな WF のみ対象になる", async () => {
+    const active = makeWorkflow({
+      id: "wf-active",
+      name: "Active WF",
+      active: true,
+      nodes: [makeScheduleNode("Fast", "minutes", 1)],
+    });
+    const inactive = makeWorkflow({
+      id: "wf-inactive",
+      name: "Inactive WF",
+      active: false,
+      nodes: [makeScheduleNode("Also Fast", "minutes", 1)],
+    });
+    ({ server } = await startMockServer([active, inactive]));
+    apiURL = `http://localhost:${server.port}`;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      const { output } = await runLint(["--remote", "--active-only", "-c", configPath], {
+        N8N_API_URL: apiURL,
+        N8N_API_KEY: "test-key",
+      });
+
+      expect(output.summary.files_checked).toBe(1);
+      const files = output.violations.map((v) => v.file);
+      expect(files).not.toContain("Inactive WF (wf-inactive)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("違反がない場合は exit code 0 で空の violations", async () => {
+    const wf = makeWorkflow({
+      id: "wf-clean",
+      name: "Clean WF",
+      nodes: [makeScheduleNode("Daily", "days", 1)],
+    });
+    ({ server } = await startMockServer([wf]));
+    apiURL = `http://localhost:${server.port}`;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      const { output, exitCode } = await runLint(["--remote", "-c", configPath], {
+        N8N_API_URL: apiURL,
+        N8N_API_KEY: "test-key",
+      });
+
+      expect(exitCode).toBe(0);
+      expect(output.summary.violations_found).toBe(0);
+      expect(output.summary.files_checked).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --remote error cases
+// ---------------------------------------------------------------------------
+
+describe("CLI lint --remote: エラーケース", () => {
+  test("--remote と --dir の同時指定でエラー終了する", async () => {
+    const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "lint", "--remote", "--dir", "/tmp"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        N8N_API_URL: "http://localhost:9999",
+        N8N_API_KEY: "test",
+      },
+    });
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--remote cannot be used with --dir or --file");
+  });
+
+  test("--remote と --file の同時指定でエラー終了する", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "lint", "--remote", "--file", "/tmp/test.json"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          N8N_API_URL: "http://localhost:9999",
+          N8N_API_KEY: "test",
+        },
+      },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--remote cannot be used with --dir or --file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UI URL derivation
+// ---------------------------------------------------------------------------
+
+describe("CLI lint --remote: UI URL 導出", () => {
+  let server: ReturnType<typeof Bun.serve>;
+
+  afterEach(() => {
+    server?.stop(true);
+  });
+
+  test("N8N_UI_URL 環境変数が --ui-url より優先されない（CLI が優先）", async () => {
+    const wf = makeWorkflow({
+      id: "wf-ui",
+      name: "UI URL Test",
+      nodes: [makeScheduleNode("Fast", "seconds", 5)],
+    });
+    ({ server } = await startMockServer([wf]));
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      const { output } = await runLint(
+        ["--remote", "--ui-url", "https://cli-override.example.com", "-c", configPath],
+        {
+          N8N_API_URL: `http://localhost:${server.port}`,
+          N8N_API_KEY: "test-key",
+          N8N_UI_URL: "https://env-url.example.com",
+        },
+      );
+
+      const v = output.violations[0];
+      expect(v?.url).toBe("https://cli-override.example.com/workflow/wf-ui");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("API URL から UI URL が自動導出される（n8n-direct → n8n）", async () => {
+    const wf = makeWorkflow({
+      id: "wf-derive",
+      name: "Derive Test",
+      nodes: [makeScheduleNode("Fast", "seconds", 5)],
+    });
+    ({ server } = await startMockServer([wf]));
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-remote-"));
+    const configPath = writeScheduleOnlyConfig(tmpDir);
+
+    try {
+      // localhost doesn't have "n8n-direct" so deriveUIURL is a pass-through
+      const { output } = await runLint(["--remote", "-c", configPath], {
+        N8N_API_URL: `http://localhost:${server.port}`,
+        N8N_API_KEY: "test-key",
+      });
+
+      const v = output.violations[0];
+      expect(v?.url).toContain(`http://localhost:${server.port}/workflow/`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `lint --remote` オプションを追加。n8n API から直接ワークフローを取得して lint を実行できるようにした
- `--active-only` でアクティブな WF のみを対象にフィルタ可能
- `--ui-url` で violation 出力に n8n UI へのリンクを付与（JSON/テキスト両対応）
- 既存の `WorkflowService.listAllWorkflows()` と lint ルールエンジンを接続しただけで、ロジックの重複なし

## Background

n8n Cloud はトリガー発火ごとに課金される。ローカル → n8n 直接デプロイが主流のため、PR ベースの CI ブロック（`schedule-guard`）だけでは高頻度トリガーの追加を防げない。

この機能により、GHA の日次 cron で全アクティブ WF を監査し、高頻度スケジュールトリガーを検知 → Slack 通知するフローが実現できる。

```bash
# 使用例: アクティブな WF を監査して高頻度トリガーを検出
n8n-cli lint --remote --active-only -c .n8nlintrc.audit.json -o json
```

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/lint.ts` | `--remote`, `--active-only`, `--ui-url` オプション追加。ローカル/リモートモード分離 |
| `src/lint/rules/violation.ts` | `url?: string` フィールド追加 |
| `src/lint/output/json.ts` | JSON 出力に `url` を含める |
| `src/lint/output/text.ts` | テキスト出力に URL を表示 |
| `tests/cli/lint-remote.test.ts` | mock n8n API サーバーを使った 8 テスト追加 |

## Test plan

- [x] 既存テスト 38 件パス（`tests/cli/lint-integration.test.ts`）
- [x] 新規テスト 8 件パス（`tests/cli/lint-remote.test.ts`）
  - リモート WF 取得 → lint 実行
  - violation に url フィールドが含まれる
  - `--active-only` フィルタ
  - 違反なし時の exit code 0
  - `--remote` と `--dir`/`--file` の排他エラー
  - UI URL の優先順位（CLI > env > API URL 自動導出）
- [x] Biome lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)