### PR TITLE
fix: strip write-unsupported settings before workflow create/update

### DIFF
--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -326,13 +326,13 @@ export class Executor {
   }
 
   /** Strip settings the n8n API exports but rejects on write. */
-  private sanitizeSettings(
+  private stripWriteUnsupportedSettings(
     settings?: Record<string, unknown>,
   ): Record<string, unknown> | undefined {
     if (!settings) return undefined;
-    const STRIP_SETTINGS = ["binaryMode"];
+    const WRITE_UNSUPPORTED_SETTINGS = ["binaryMode"];
     return Object.fromEntries(
-      Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k)),
+      Object.entries(settings).filter(([k]) => !WRITE_UNSUPPORTED_SETTINGS.includes(k)),
     );
   }
 
@@ -343,7 +343,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
+      settings: this.stripWriteUnsupportedSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 
@@ -364,7 +364,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
+      settings: this.stripWriteUnsupportedSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -330,7 +330,7 @@ export class Executor {
     settings?: Record<string, unknown>,
   ): Record<string, unknown> | undefined {
     if (!settings) return undefined;
-    const STRIP_SETTINGS = ["availableInMCP", "binaryMode", "callerPolicy"];
+    const STRIP_SETTINGS = ["binaryMode"];
     return Object.fromEntries(
       Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k)),
     );

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -326,11 +326,13 @@ export class Executor {
   }
 
   /** Strip settings the n8n API exports but rejects on write. */
-  private sanitizeSettings(settings?: Record<string, unknown>): Record<string, unknown> | undefined {
+  private sanitizeSettings(
+    settings?: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
     if (!settings) return undefined;
-    const STRIP_SETTINGS = ['availableInMCP', 'binaryMode', 'callerPolicy'];
+    const STRIP_SETTINGS = ["availableInMCP", "binaryMode", "callerPolicy"];
     return Object.fromEntries(
-      Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k))
+      Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k)),
     );
   }
 

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -325,6 +325,15 @@ export class Executor {
     return op;
   }
 
+  /** Strip settings the n8n API exports but rejects on write. */
+  private sanitizeSettings(settings?: Record<string, unknown>): Record<string, unknown> | undefined {
+    if (!settings) return undefined;
+    const STRIP_SETTINGS = ['availableInMCP', 'binaryMode', 'callerPolicy'];
+    return Object.fromEntries(
+      Object.entries(settings).filter(([k]) => !STRIP_SETTINGS.includes(k))
+    );
+  }
+
   /** Performs the actual create operation. */
   private async executeCreate(wf: WorkflowFile, op: ApplyOperation): Promise<void> {
     const workflow = wf.workflow!;
@@ -332,7 +341,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: workflow.settings,
+      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 
@@ -353,7 +362,7 @@ export class Executor {
       name: workflow.name,
       nodes: workflow.nodes,
       connections: workflow.connections,
-      settings: workflow.settings,
+      settings: this.sanitizeSettings(workflow.settings as Record<string, unknown>),
       staticData: workflow.staticData,
     };
 


### PR DESCRIPTION
## Summary
- Based on #30 (original author credited with Co-authored-by). Before create/update, remove workflow settings that the n8n API returns on read but does not accept on write. This stops `apply` from failing on imported workflows.

## Problem
When you run `n8n-cli import` and then `apply`, the local definition contains server-side settings. The API does not accept them on write and returns `request/body/settings must NOT have additional properties`. So `apply` fails.

## Changes on top of #30
- Remove only binaryMode now. The public API accepts callerPolicy and availableInMCP on write since n8n 2025-10 (n8n-io/n8n#21297). Removing them would silently delete valid settings that the user set.
- Rename sanitizeSettings to stripWriteUnsupportedSettings. In this repo, sanitize* means cleaning an input value (sanitizeFilename, sanitizeNodeName), not removing keys.
- Apply biome formatting.

## Test plan
- [x] Ran apply on a workflow whose settings include binaryMode. It succeeds (the API rejected it before).
- [x] biome check, typecheck, and apply tests pass.
