### PR TITLE
fix: strip timeSavedMode and credentialResolverId before workflow write

### DIFF
--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -330,7 +330,7 @@ export class Executor {
     settings?: Record<string, unknown>,
   ): Record<string, unknown> | undefined {
     if (!settings) return undefined;
-    const WRITE_UNSUPPORTED_SETTINGS = ["binaryMode"];
+    const WRITE_UNSUPPORTED_SETTINGS = ["binaryMode", "timeSavedMode", "credentialResolverId"];
     return Object.fromEntries(
       Object.entries(settings).filter(([k]) => !WRITE_UNSUPPORTED_SETTINGS.includes(k)),
     );


### PR DESCRIPTION
## Summary
- Add timeSavedMode and credentialResolverId to the list of write-unsupported settings that we strip (the list added in #38).

## Problem
After `import` and then `apply`, a workflow fails when its settings include timeSavedMode (or credentialResolverId on instances that use dynamic credentials). The API returns `request/body/settings must NOT have additional properties`. These fields are read-only, the same as binaryMode that #38 already strips. The list was simply incomplete.

## How these fields were chosen
The n8n public API validates settings on write against workflowSettings.yml, so that schema defines the keys allowed on write. I compared it with the internal IWorkflowSettings type, which is the full set of fields the API can return on read. The only fields that are returned on read but rejected on write are binaryMode (already handled), timeSavedMode, and credentialResolverId.

- write schema (allowed keys): https://github.com/n8n-io/n8n/blob/03eecb1f50f144d72bcd074f4bb5710634b53860/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
- internal settings type: https://github.com/n8n-io/n8n/blob/03eecb1f50f144d72bcd074f4bb5710634b53860/packages/workflow/src/interfaces.ts#L3358-L3376 (IWorkflowSettings)

## Test plan
- [x] biome check and typecheck pass
- [x] Ran apply on a workflow whose settings include timeSavedMode and confirmed it succeeds
