### PR TITLE
feat(proxy): add HTTP proxy subcommand with server-side lint enforcement

### DIFF
--- a/.claude/skills/n8n-cli/SKILL.md
+++ b/.claude/skills/n8n-cli/SKILL.md
@@ -240,7 +240,7 @@ Summary (dry-run): 1 to create, 2 to update, 1 unchanged
 |--------|-------------|
 | `--from-git-changes <spec>` | Apply only files changed in Git diff |
 | `--yaml` / `--no-yaml` | Enable/disable YAML processing |
-| `--warn-duplicates` | Warn if a workflow with the same name already exists |
+| `--allow-duplicates` | Skip the upstream duplicate-name check (default: on; use `--force` to push through warnings instead of disabling the check) |
 | `--no-auto-tag` | Disable automatic tagging (managed-as-code) |
 | `-p, --project <id>` | Specify target project ID |
 

--- a/README.md
+++ b/README.md
@@ -828,6 +828,9 @@ n8n-cli proxy [options]
 | `--enforce <level>` | `off`, `warn`, or `error` (default: `error`) |
 | `--disable-rule <rules...>` | Disable specific rules (can be repeated) |
 | `--log-format <fmt>` | Log format: `text` or `json` (default: `text`) |
+| `--warn-duplicates` | Reject workflow creation when a workflow with the same name already exists upstream (409 under `error`, header under `warn`) |
+| `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
+| `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
 
 **Enforcement levels:**
 
@@ -867,7 +870,9 @@ Clients then point at `http://proxy-host:8080` instead of n8n directly. From the
 }
 ```
 
-**Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations. The proxy exposes `GET /healthz` for liveness probes.
+**Apply-style safety checks:** beyond lint, the proxy can also surface the same duplicate-name risk that `apply --warn-duplicates` catches locally. Pass `--warn-duplicates` to make the proxy fetch the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and reject `POST /api/v1/workflows` when a same-named workflow already exists upstream. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
+
+**Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations. The proxy exposes `GET /healthz` (and `HEAD /healthz`) for liveness probes.
 
 ### `version`
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Convert** - Convert workflow files between JSON and YAML formats locally
 - **Import** - Pull workflows from an n8n server to local files, with optional YAML conversion and code externalization
 - **Lint** - Validate workflow definitions against configurable rules
+- **Proxy** - Transparent HTTP proxy that intercepts workflow saves to the n8n public API and runs lint server-side, blocking violations before they reach n8n
 - **Format** - Auto-organize node positions for cleaner workflow layouts
 - **Test** - Execute CLI tests against workflows via webhook endpoints
 - **Workflow management** - List, get, create, update, delete, activate, and deactivate workflows via the n8n API
@@ -808,6 +809,65 @@ n8n-cli trace [options]
 | Items | Estimated output item count |
 | Inputs | Upstream nodes |
 | Outputs | Downstream nodes |
+
+### `proxy`
+
+Run a transparent HTTP proxy in front of an n8n server that intercepts workflow saves on the public REST API and runs the linter server-side. Workflows that violate `error`-severity rules are rejected with HTTP 422 before they reach n8n.
+
+This solves a common problem: when humans or AI agents push workflows directly to the n8n API (bypassing client-side lint), poor quality definitions silently end up in production. The proxy makes lint enforcement structural rather than convention-based.
+
+```bash
+n8n-cli proxy [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--listen <addr>` | Address to bind, e.g. `:8080` or `127.0.0.1:8080` (default: `:8080`) |
+| `--upstream <url>` | Upstream n8n base URL (env: `N8N_API_URL`) |
+| `-c, --lint-config <path>` | Path to `.n8nlintrc.json` (auto-discovered if omitted) |
+| `--enforce <level>` | `off`, `warn`, or `error` (default: `error`) |
+| `--disable-rule <rules...>` | Disable specific rules (can be repeated) |
+| `--log-format <fmt>` | Log format: `text` or `json` (default: `text`) |
+
+**Enforcement levels:**
+
+| Level | Behavior |
+|-------|----------|
+| `off` | Forwards every request; lint runs only for audit logging |
+| `warn` | Forwards every request; attaches `X-N8n-Lint-Violations` and `X-N8n-Lint-Errors` headers to the response |
+| `error` | Blocks requests with any error-level violation; returns HTTP 422 with a violations JSON body. Warnings still pass through |
+
+**Intercepted endpoints (n8n public API only):**
+
+- `POST /api/v1/workflows` (create)
+- `PUT /api/v1/workflows/:id` (update)
+
+All other paths (including the n8n editor's internal `/rest/*` routes) are forwarded transparently. The `X-N8N-API-KEY` header is passed through as-is.
+
+**Example: run the proxy in front of a production n8n**
+
+```bash
+n8n-cli proxy \
+  --listen :8080 \
+  --upstream https://n8n.example.com \
+  --enforce error \
+  --log-format json
+```
+
+Clients then point at `http://proxy-host:8080` instead of n8n directly. From the client's perspective the API is identical, except that lint-violating saves now return:
+
+```json
+{
+  "error": "workflow_lint_failed",
+  "message": "Workflow violates 2 linter rules and was not forwarded to n8n",
+  "violations": [
+    { "rule": "required-fields", "severity": "error", "message": "Missing required field: \"name\"" }
+  ],
+  "docs": "https://github.com/ubie-oss/n8n-cli#lint"
+}
+```
+
+**Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations. The proxy exposes `GET /healthz` for liveness probes.
 
 ### `version`
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ n8n-cli apply [options]
 | `--force` | Override conflict detection and duplicate warnings |
 | `--no-auto-tag` | Disable automatic tagging |
 | `--yaml` / `--no-yaml` | Enable/disable YAML file processing |
-| `--warn-duplicates` | Warn when creating workflows with names that already exist remotely |
+| `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default; use `--force` to push through warnings instead of disabling the check) |
 
 #### Exit Codes
 
@@ -828,7 +828,7 @@ n8n-cli proxy [options]
 | `--enforce <level>` | `off`, `warn`, or `error` (default: `error`) |
 | `--disable-rule <rules...>` | Disable specific rules (can be repeated) |
 | `--log-format <fmt>` | Log format: `text` or `json` (default: `text`) |
-| `--warn-duplicates` | Reject workflow creation when a workflow with the same name already exists upstream (409 under `error`, header under `warn`) |
+| `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default) |
 | `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
 
@@ -870,7 +870,7 @@ Clients then point at `http://proxy-host:8080` instead of n8n directly. From the
 }
 ```
 
-**Apply-style safety checks:** beyond lint, the proxy can also surface the same duplicate-name risk that `apply --warn-duplicates` catches locally. Pass `--warn-duplicates` to make the proxy fetch the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and reject `POST /api/v1/workflows` when a same-named workflow already exists upstream. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
+**Apply-style safety checks:** beyond lint, the proxy mirrors the same default-on duplicate-name safety that `apply` enforces. On every `POST /api/v1/workflows` the proxy fetches the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and rejects creates that collide with an existing remote name. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Pass `--allow-duplicates` to disable the check entirely (e.g. during a one-off bulk import). Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
 
 **Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations. The proxy exposes `GET /healthz` (and `HEAD /healthz`) for liveness probes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.3.1",
+  "version": "2.2.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/workflow-service.ts
+++ b/src/api/workflow-service.ts
@@ -7,6 +7,12 @@ export interface ListOptions {
   tags?: string[];
   limit?: number;
   cursor?: string;
+  /**
+   * Maximum number of pages to fetch in listAllWorkflows. Defaults to
+   * unlimited; pass a value to cap the walk on huge instances so a runaway
+   * paginator can't pin the process. Ignored by listWorkflows.
+   */
+  maxPages?: number;
 }
 
 /** WorkflowService handles workflow API operations */
@@ -48,12 +54,18 @@ export class WorkflowService {
     if (!paginationOpts.limit) {
       paginationOpts.limit = 100;
     }
+    const maxPages = paginationOpts.maxPages ?? Number.POSITIVE_INFINITY;
 
+    let page = 0;
     for (;;) {
       const resp = await this.listWorkflows(paginationOpts);
       allWorkflows.push(...resp.data);
+      page++;
 
       if (!resp.nextCursor) {
+        break;
+      }
+      if (page >= maxPages) {
         break;
       }
       paginationOpts.cursor = resp.nextCursor;

--- a/src/apply/duplicate.ts
+++ b/src/apply/duplicate.ts
@@ -9,13 +9,20 @@ export class DuplicateChecker {
 
   constructor(private readonly workflowService: WorkflowService) {}
 
-  /** Fetches all remote workflows and indexes them by name. */
+  /**
+   * Fetches all remote workflows and indexes them by name.
+   *
+   * Capped at 50 pages (5000 workflows at the default limit) so a misbehaving
+   * upstream can't keep the apply step paginating forever. Real n8n
+   * deployments well above this size should pass `--allow-duplicates`.
+   */
   async loadRemoteWorkflows(): Promise<void> {
     if (this.loaded) return;
 
     this.remoteWorkflows = new Map();
     const workflows = await this.workflowService.listAllWorkflows({
       limit: 100,
+      maxPages: 50,
     });
 
     for (const workflow of workflows) {

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -109,9 +109,21 @@ export class Executor {
     const result = emptyResult(this.opts.dryRun);
 
     // Duplicate-name check is on by default; opt out with allowDuplicates.
-    if (!this.opts.allowDuplicates) {
-      this.duplicateChecker = new DuplicateChecker(this.workflowService);
-      await this.duplicateChecker.loadRemoteWorkflows();
+    // Skip on dry-run so a local preview stays cheap and works offline. If
+    // the upstream list call fails (auth, transient 5xx), degrade to a
+    // warning rather than aborting the whole apply — the proxy does the
+    // same in src/proxy/duplicate.ts.
+    if (!this.opts.allowDuplicates && !this.opts.dryRun) {
+      const checker = new DuplicateChecker(this.workflowService);
+      try {
+        await checker.loadRemoteWorkflows();
+        this.duplicateChecker = checker;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `Warning: duplicate-name check skipped — could not list upstream workflows: ${message}`,
+        );
+      }
     }
 
     // Scan workflow files

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -108,8 +108,8 @@ export class Executor {
   async execute(): Promise<ApplyResult> {
     const result = emptyResult(this.opts.dryRun);
 
-    // Initialize duplicate checker if warnings are enabled
-    if (this.opts.warnDuplicates) {
+    // Duplicate-name check is on by default; opt out with allowDuplicates.
+    if (!this.opts.allowDuplicates) {
       this.duplicateChecker = new DuplicateChecker(this.workflowService);
       await this.duplicateChecker.loadRemoteWorkflows();
     }

--- a/src/apply/types.ts
+++ b/src/apply/types.ts
@@ -20,7 +20,15 @@ export interface ApplyOptions {
   gitDiffSpec: string;
   yamlEnabled: boolean;
   noYaml: boolean;
-  warnDuplicates: boolean;
+  /**
+   * When true, skip the upstream duplicate-name check.
+   *
+   * Default false (check ON): on every apply we list the upstream workflows
+   * and surface a warning if a local workflow would create a remotely-existing
+   * name. The warning causes a non-zero exit unless `--force` is also passed.
+   * Set true to disable the check entirely.
+   */
+  allowDuplicates: boolean;
   filterByTags: string[];
 }
 
@@ -39,7 +47,7 @@ export function defaultApplyOptions(): ApplyOptions {
     gitDiffSpec: "",
     yamlEnabled: false,
     noYaml: false,
-    warnDuplicates: false,
+    allowDuplicates: false,
     filterByTags: [],
   };
 }

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -32,8 +32,8 @@ export function registerApplyCommand(program: Command): void {
       "Apply ALL workflows in the directory, overwriting remote state (required when no scope filter is specified)",
     )
     .option(
-      "--warn-duplicates",
-      "Warn when creating workflows with names that already exist remotely",
+      "--allow-duplicates",
+      "Skip the upstream duplicate-name check (the check is on by default; use --force to push through warnings without disabling the check)",
     )
     .action(async (options, command) => {
       const ctx = resolveContext(command.parent!);
@@ -44,7 +44,7 @@ export function registerApplyCommand(program: Command): void {
       opts.dryRun = !!options.dryRun;
       opts.force = !!options.force;
       opts.noAutoTag = !!options.noAutoTag;
-      opts.warnDuplicates = !!options.warnDuplicates;
+      opts.allowDuplicates = !!options.allowDuplicates;
 
       if (options.yaml === true) opts.yamlEnabled = true;
       if (options.yaml === false) opts.noYaml = true;

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
 import { resolveContext } from "@/cli/root.ts";
 import { hasAllTags, parseTagFilter } from "@/common/tags.ts";
-import { findConfigFile, getRuleOptions, loadLintConfig } from "@/lint/config.ts";
+import { findConfigFile, loadLintConfig } from "@/lint/config.ts";
+import { lintWorkflow } from "@/lint/engine.ts";
 import { formatJSON } from "@/lint/output/json.ts";
 import type { LintResult } from "@/lint/output/result.ts";
 import { hasErrors } from "@/lint/output/result.ts";
@@ -129,17 +130,10 @@ async function lintRemote(
     const rawJSON = JSON.stringify(workflow);
     const url = workflowURL(uiURL, workflow.id);
 
-    for (const { rule, severity } of enabledRules) {
-      const violations = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
-      for (const v of violations) {
-        result.violations.push({
-          ...v,
-          file: v.file ?? displayName,
-          url,
-          severity,
-        });
-        failedWorkflows.add(displayName);
-      }
+    const violations = lintWorkflow(workflow, rawJSON, enabledRules, config);
+    for (const v of violations) {
+      result.violations.push({ ...v, file: v.file ?? displayName, url });
+      failedWorkflows.add(displayName);
     }
   }
 
@@ -222,17 +216,10 @@ async function lintLocal(
       }
     }
 
-    // Run each enabled rule
-    for (const { rule, severity } of enabledRules) {
-      const violations = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
-      for (const v of violations) {
-        result.violations.push({
-          ...v,
-          file: v.file ?? filePath,
-          severity,
-        });
-        failedFiles.add(filePath);
-      }
+    const violations = lintWorkflow(workflow, rawJSON, enabledRules, config);
+    for (const v of violations) {
+      result.violations.push({ ...v, file: v.file ?? filePath });
+      failedFiles.add(filePath);
     }
   }
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -9,7 +9,7 @@ interface ProxyOptions {
   enforce: string;
   disableRule?: string[];
   logFormat: string;
-  warnDuplicates?: boolean;
+  allowDuplicates?: boolean;
   duplicateTtl?: string;
   upstreamTimeout?: string;
 }
@@ -27,14 +27,10 @@ export function registerProxyCommand(program: Command): void {
     .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
     .option("--log-format <fmt>", "Log format: text, json", "text")
     .option(
-      "--warn-duplicates",
-      "Check upstream for an existing workflow of the same name on POST /api/v1/workflows. Under enforce=error a match returns 409; under enforce=warn a warning header is attached.",
+      "--allow-duplicates",
+      "Skip the upstream duplicate-name check on POST /api/v1/workflows (the check is on by default; under enforce=error a match returns 409, under enforce=warn a header is attached)",
     )
-    .option(
-      "--duplicate-ttl <ms>",
-      "TTL (ms) for the cached upstream workflow-name index used by --warn-duplicates",
-      "60000",
-    )
+    .option("--duplicate-ttl <ms>", "TTL (ms) for the cached upstream workflow-name index", "60000")
     .option(
       "--upstream-timeout <ms>",
       "Per-request upstream timeout in milliseconds (0 disables)",
@@ -61,7 +57,7 @@ export function registerProxyCommand(program: Command): void {
         enforce,
         disableRules: opts.disableRule ?? [],
         logFormat,
-        warnDuplicates: !!opts.warnDuplicates,
+        allowDuplicates: !!opts.allowDuplicates,
         duplicateTtlMs,
         upstreamTimeoutMs,
       });

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -9,6 +9,9 @@ interface ProxyOptions {
   enforce: string;
   disableRule?: string[];
   logFormat: string;
+  warnDuplicates?: boolean;
+  duplicateTtl?: string;
+  upstreamTimeout?: string;
 }
 
 export function registerProxyCommand(program: Command): void {
@@ -23,6 +26,20 @@ export function registerProxyCommand(program: Command): void {
     .option("--enforce <level>", "Enforcement level for workflow saves: off, warn, error", "error")
     .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
     .option("--log-format <fmt>", "Log format: text, json", "text")
+    .option(
+      "--warn-duplicates",
+      "Check upstream for an existing workflow of the same name on POST /api/v1/workflows. Under enforce=error a match returns 409; under enforce=warn a warning header is attached.",
+    )
+    .option(
+      "--duplicate-ttl <ms>",
+      "TTL (ms) for the cached upstream workflow-name index used by --warn-duplicates",
+      "60000",
+    )
+    .option(
+      "--upstream-timeout <ms>",
+      "Per-request upstream timeout in milliseconds (0 disables)",
+      "30000",
+    )
     .action((opts: ProxyOptions) => {
       const upstream = opts.upstream ?? process.env.N8N_API_URL;
       if (!upstream) {
@@ -34,6 +51,8 @@ export function registerProxyCommand(program: Command): void {
 
       const logFormat = opts.logFormat === "json" ? "json" : "text";
       const enforce = parseEnforceLevel(opts.enforce);
+      const duplicateTtlMs = parsePositiveInt(opts.duplicateTtl, "--duplicate-ttl");
+      const upstreamTimeoutMs = parsePositiveInt(opts.upstreamTimeout, "--upstream-timeout");
 
       const handle = startProxy({
         listen: opts.listen,
@@ -42,6 +61,9 @@ export function registerProxyCommand(program: Command): void {
         enforce,
         disableRules: opts.disableRule ?? [],
         logFormat,
+        warnDuplicates: !!opts.warnDuplicates,
+        duplicateTtlMs,
+        upstreamTimeoutMs,
       });
 
       // Friendly startup line on stderr so it never pollutes JSON log streams.
@@ -59,4 +81,13 @@ export function registerProxyCommand(program: Command): void {
       process.on("SIGINT", () => shutdown("SIGINT"));
       process.on("SIGTERM", () => shutdown("SIGTERM"));
     });
+}
+
+function parsePositiveInt(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(value)) {
+    console.error(`Error: ${flag} expects a non-negative integer (got "${value}")`);
+    process.exit(1);
+  }
+  return Number.parseInt(value, 10);
 }

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1,0 +1,62 @@
+import type { Command } from "commander";
+import { parseEnforceLevel } from "@/proxy/config.ts";
+import { startProxy } from "@/proxy/server.ts";
+
+interface ProxyOptions {
+  listen: string;
+  upstream?: string;
+  lintConfig?: string;
+  enforce: string;
+  disableRule?: string[];
+  logFormat: string;
+}
+
+export function registerProxyCommand(program: Command): void {
+  program
+    .command("proxy")
+    .description(
+      "Run a transparent HTTP proxy that intercepts n8n public-API workflow saves and runs lint",
+    )
+    .option("--listen <addr>", "Address to bind (host:port or :port)", ":8080")
+    .option("--upstream <url>", "Upstream n8n base URL (env: N8N_API_URL)")
+    .option("-c, --lint-config <path>", "Path to .n8nlintrc.json (auto-discovered if omitted)")
+    .option("--enforce <level>", "Enforcement level for workflow saves: off, warn, error", "error")
+    .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
+    .option("--log-format <fmt>", "Log format: text, json", "text")
+    .action((opts: ProxyOptions) => {
+      const upstream = opts.upstream ?? process.env.N8N_API_URL;
+      if (!upstream) {
+        console.error(
+          "Error: --upstream is required (or set N8N_API_URL). Example: --upstream https://n8n.example.com",
+        );
+        process.exit(1);
+      }
+
+      const logFormat = opts.logFormat === "json" ? "json" : "text";
+      const enforce = parseEnforceLevel(opts.enforce);
+
+      const handle = startProxy({
+        listen: opts.listen,
+        upstream,
+        lintConfigPath: opts.lintConfig,
+        enforce,
+        disableRules: opts.disableRule ?? [],
+        logFormat,
+      });
+
+      // Friendly startup line on stderr so it never pollutes JSON log streams.
+      console.error(
+        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, lint=${
+          opts.lintConfig ?? "auto"
+        })`,
+      );
+
+      const shutdown = async (signal: string) => {
+        console.error(`\nReceived ${signal}, shutting down proxy...`);
+        await handle.stop();
+        process.exit(0);
+      };
+      process.on("SIGINT", () => shutdown("SIGINT"));
+      process.on("SIGTERM", () => shutdown("SIGTERM"));
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { registerFmtCommand } from "./cli/commands/fmt.ts";
 import { registerImportCommand } from "./cli/commands/import.ts";
 import { registerLintCommand } from "./cli/commands/lint.ts";
 import { registerNodeSchemaCommand } from "./cli/commands/node-schema.ts";
+import { registerProxyCommand } from "./cli/commands/proxy.ts";
 import { registerTagCommand } from "./cli/commands/tag.ts";
 import { registerTestCommand } from "./cli/commands/test.ts";
 import { registerTraceCommand } from "./cli/commands/trace.ts";
@@ -34,6 +35,7 @@ registerNodeSchemaCommand(program);
 registerFmtCommand(program);
 registerTestCommand(program);
 registerTraceCommand(program);
+registerProxyCommand(program);
 
 try {
   await program.parseAsync(process.argv);

--- a/src/lint/engine.ts
+++ b/src/lint/engine.ts
@@ -34,12 +34,18 @@ export function lintWorkflow(
   return violations;
 }
 
-/** Returns the number of error-level violations in a list. */
-export function countErrors(violations: Violation[]): number {
+/**
+ * Returns the number of error-level violations in a list.
+ *
+ * The `!v.severity` fallback treats unset severities as errors. `lintWorkflow`
+ * always sets `severity`, but external callers may pass violations from other
+ * sources, so the conservative default is "block unless explicitly downgraded".
+ */
+export function countErrorViolations(violations: Violation[]): number {
   return violations.filter((v) => v.severity === "error" || !v.severity).length;
 }
 
 /** Returns true if any violation is error-level. */
-export function hasErrors(violations: Violation[]): boolean {
-  return countErrors(violations) > 0;
+export function hasErrorViolations(violations: Violation[]): boolean {
+  return countErrorViolations(violations) > 0;
 }

--- a/src/lint/engine.ts
+++ b/src/lint/engine.ts
@@ -1,0 +1,45 @@
+import type { Workflow } from "@/api/types.ts";
+import { getRuleOptions, type LintConfig } from "./config.ts";
+import type { RuleWithConfig } from "./registry.ts";
+import type { Violation } from "./rules/violation.ts";
+
+/**
+ * Runs all enabled rules against a single workflow already in memory.
+ *
+ * This is the library entry point used by callers that already hold a parsed
+ * workflow (e.g. the proxy server intercepting an API request). For file-based
+ * linting use the CLI command which adds I/O and reporting on top of this.
+ *
+ * @param workflow Parsed workflow, or null if the source could not be parsed.
+ *   Rules that operate on rawJSON only (json-syntax) still run when null.
+ * @param rawJSON Raw JSON string used by rules that need precise line numbers.
+ * @param enabledRules Rules + severities resolved from a config.
+ * @param config Lint config used to resolve per-rule options. Pass null for
+ *   defaults.
+ * @returns Violations with the configured severity applied. Empty when clean.
+ */
+export function lintWorkflow(
+  workflow: Workflow | null,
+  rawJSON: string,
+  enabledRules: RuleWithConfig[],
+  config: LintConfig | null,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const { rule, severity } of enabledRules) {
+    const found = rule.check(workflow, rawJSON, getRuleOptions(config, rule.name));
+    for (const v of found) {
+      violations.push({ ...v, severity });
+    }
+  }
+  return violations;
+}
+
+/** Returns the number of error-level violations in a list. */
+export function countErrors(violations: Violation[]): number {
+  return violations.filter((v) => v.severity === "error" || !v.severity).length;
+}
+
+/** Returns true if any violation is error-level. */
+export function hasErrors(violations: Violation[]): boolean {
+  return countErrors(violations) > 0;
+}

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -15,11 +15,15 @@ export interface ProxyConfig {
   /** Log format */
   logFormat: "text" | "json";
   /**
-   * When true, intercept workflow creation and check the upstream for an
-   * existing workflow of the same name. Under enforce=error a match returns
-   * 409; under enforce=warn an x-n8n-duplicate-warning header is attached.
+   * When true, skip the upstream duplicate-name check on workflow creation.
+   *
+   * Default false (check ON): on every `POST /api/v1/workflows` the proxy
+   * looks up the upstream for an existing workflow of the same name. Under
+   * `enforce=error` a match returns 409; under `enforce=warn` an
+   * `x-n8n-duplicate-warning` header is attached. Set true to disable the
+   * check entirely.
    */
-  warnDuplicates?: boolean;
+  allowDuplicates?: boolean;
   /** TTL for the duplicate-name index cache in ms. Default 60_000. */
   duplicateTtlMs?: number;
   /** Total upstream request timeout in ms. Default 30_000. 0 disables. */

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -1,0 +1,44 @@
+/** Enforce levels: off = log only, warn = forward + log violations, error = block on errors */
+export type EnforceLevel = "off" | "warn" | "error";
+
+export interface ProxyConfig {
+  /** Address to bind, e.g. ":8080" or "127.0.0.1:8080" */
+  listen: string;
+  /** Upstream n8n base URL, e.g. "https://n8n.example.com" */
+  upstream: string;
+  /** Optional path to .n8nlintrc.json (auto-discovered if omitted) */
+  lintConfigPath?: string;
+  /** Enforcement level */
+  enforce: EnforceLevel;
+  /** Rule names to disable */
+  disableRules: string[];
+  /** Log format */
+  logFormat: "text" | "json";
+}
+
+/** Parses a `--listen` value like ":8080" or "127.0.0.1:8080" into host/port. */
+export function parseListenAddr(addr: string): { host: string; port: number } {
+  if (!addr.includes(":")) {
+    throw new Error(`Invalid --listen address: "${addr}" (expected host:port or :port)`);
+  }
+  const idx = addr.lastIndexOf(":");
+  const host = idx === 0 ? "0.0.0.0" : addr.slice(0, idx);
+  const portStr = addr.slice(idx + 1);
+  const port = Number.parseInt(portStr, 10);
+  // Port 0 is allowed and means "ask the OS for an ephemeral port" — used by tests.
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid port in --listen: "${portStr}"`);
+  }
+  return { host, port };
+}
+
+/** Normalizes upstream URL by stripping a trailing slash. */
+export function normalizeUpstream(upstream: string): string {
+  return upstream.replace(/\/+$/, "");
+}
+
+/** Validates an enforce level string. */
+export function parseEnforceLevel(value: string): EnforceLevel {
+  if (value === "off" || value === "warn" || value === "error") return value;
+  throw new Error(`Invalid --enforce value: "${value}" (expected off, warn, or error)`);
+}

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -14,18 +14,54 @@ export interface ProxyConfig {
   disableRules: string[];
   /** Log format */
   logFormat: "text" | "json";
+  /**
+   * When true, intercept workflow creation and check the upstream for an
+   * existing workflow of the same name. Under enforce=error a match returns
+   * 409; under enforce=warn an x-n8n-duplicate-warning header is attached.
+   */
+  warnDuplicates?: boolean;
+  /** TTL for the duplicate-name index cache in ms. Default 60_000. */
+  duplicateTtlMs?: number;
+  /** Total upstream request timeout in ms. Default 30_000. 0 disables. */
+  upstreamTimeoutMs?: number;
 }
 
-/** Parses a `--listen` value like ":8080" or "127.0.0.1:8080" into host/port. */
+/**
+ * Parses a `--listen` value into host/port. Accepts:
+ *
+ * - `:8080` → host "0.0.0.0", port 8080
+ * - `127.0.0.1:8080` → host "127.0.0.1", port 8080
+ * - `[::1]:8080` → host "::1", port 8080 (IPv6 in brackets per RFC 3986)
+ *
+ * Port 0 is allowed and means "ask the OS for an ephemeral port" — used by
+ * tests. Trailing garbage in the port (e.g. `:8080abc`) is rejected.
+ */
 export function parseListenAddr(addr: string): { host: string; port: number } {
   if (!addr.includes(":")) {
     throw new Error(`Invalid --listen address: "${addr}" (expected host:port or :port)`);
   }
-  const idx = addr.lastIndexOf(":");
-  const host = idx === 0 ? "0.0.0.0" : addr.slice(0, idx);
-  const portStr = addr.slice(idx + 1);
+
+  let host: string;
+  let portStr: string;
+
+  if (addr.startsWith("[")) {
+    // Bracketed IPv6: [::1]:8080
+    const closing = addr.indexOf("]");
+    if (closing === -1 || addr[closing + 1] !== ":") {
+      throw new Error(`Invalid --listen address: "${addr}" (expected [ipv6]:port)`);
+    }
+    host = addr.slice(1, closing);
+    portStr = addr.slice(closing + 2);
+  } else {
+    const idx = addr.lastIndexOf(":");
+    host = idx === 0 ? "0.0.0.0" : addr.slice(0, idx);
+    portStr = addr.slice(idx + 1);
+  }
+
+  if (!/^\d+$/.test(portStr)) {
+    throw new Error(`Invalid port in --listen: "${portStr}" (expected digits only)`);
+  }
   const port = Number.parseInt(portStr, 10);
-  // Port 0 is allowed and means "ask the OS for an ephemeral port" — used by tests.
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid port in --listen: "${portStr}"`);
   }

--- a/src/proxy/duplicate.ts
+++ b/src/proxy/duplicate.ts
@@ -31,6 +31,14 @@ interface CacheEntry {
   expiresAt: number;
 }
 
+/**
+ * TTL for cached upstream failures. Much shorter than the success TTL so a
+ * single transient 401/5xx doesn't poison duplicate detection for a full
+ * minute, but long enough that bursty requests under a permission outage
+ * don't hammer the upstream.
+ */
+const FAILURE_TTL_MS = 5_000;
+
 export class DuplicateChecker {
   private cache: CacheEntry | null = null;
 
@@ -47,27 +55,41 @@ export class DuplicateChecker {
   /**
    * Returns duplicate matches for the given name, or an empty array.
    *
+   * Callers without an API key are skipped (`apiKey == null` returns `[]`)
+   * rather than triggering an unauthenticated upstream call whose 401 would
+   * poison the cache for every subsequent caller.
+   *
    * @param apiKey The caller's `X-N8N-API-KEY` header value. Used as-is so
    *   the upstream query runs under the caller's permissions.
    */
   async findByName(name: string, apiKey: string | null): Promise<DuplicateMatch[]> {
     if (!name) return [];
+    if (!apiKey) return [];
     const index = await this.getIndex(apiKey);
     return index.get(name) ?? [];
   }
 
-  private async getIndex(apiKey: string | null): Promise<Map<string, DuplicateMatch[]>> {
+  private async getIndex(apiKey: string): Promise<Map<string, DuplicateMatch[]>> {
     const now = performance.now();
     if (this.cache && this.cache.expiresAt > now) {
       return this.cache.byName;
     }
 
-    const byName = await this.fetchWorkflowIndex(apiKey);
-    this.cache = { byName, expiresAt: now + this.ttlMs };
-    return byName;
+    const result = await this.fetchWorkflowIndex(apiKey);
+    const ttl = result.complete ? this.ttlMs : FAILURE_TTL_MS;
+    this.cache = { byName: result.byName, expiresAt: now + ttl };
+    return result.byName;
   }
 
-  private async fetchWorkflowIndex(apiKey: string | null): Promise<Map<string, DuplicateMatch[]>> {
+  /**
+   * Walks upstream pagination, returning the indexed names plus a `complete`
+   * flag indicating whether every page succeeded. Partial / empty results
+   * caused by an upstream error are returned as `complete: false` so the
+   * caller can pick a short cache TTL and recover quickly.
+   */
+  private async fetchWorkflowIndex(
+    apiKey: string,
+  ): Promise<{ byName: Map<string, DuplicateMatch[]>; complete: boolean }> {
     const byName = new Map<string, DuplicateMatch[]>();
     let cursor: string | undefined;
     let pages = 0;
@@ -79,15 +101,19 @@ export class DuplicateChecker {
       url.searchParams.set("limit", "100");
       if (cursor) url.searchParams.set("cursor", cursor);
 
-      const headers: Record<string, string> = { Accept: "application/json" };
-      if (apiKey) headers["X-N8N-API-KEY"] = apiKey;
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+        "X-N8N-API-KEY": apiKey,
+      };
 
-      const res = await fetch(url.toString(), { headers });
+      let res: Response;
+      try {
+        res = await fetch(url.toString(), { headers });
+      } catch {
+        return { byName, complete: false };
+      }
       if (!res.ok) {
-        // On any upstream error, return whatever we collected so far and stop.
-        // The proxy will treat this as "no duplicate" — safer than blocking on
-        // a transient upstream hiccup.
-        break;
+        return { byName, complete: false };
       }
       const body = (await res.json()) as UpstreamListResponse;
       const items = body.data ?? [];
@@ -101,6 +127,6 @@ export class DuplicateChecker {
       if (!cursor) break;
     }
 
-    return byName;
+    return { byName, complete: true };
   }
 }

--- a/src/proxy/duplicate.ts
+++ b/src/proxy/duplicate.ts
@@ -1,0 +1,106 @@
+/**
+ * Detects duplicate workflow names on the upstream n8n instance.
+ *
+ * Modeled after `src/apply/duplicate.ts` but adapted for the proxy's
+ * request-scoped lifecycle: the upstream workflow list is cached with a TTL
+ * so a chatty client doesn't trigger a `GET /workflows` for every POST.
+ *
+ * Each lookup uses the auth header from the inbound request — never a
+ * proxy-wide credential — so duplicate detection respects the caller's own
+ * permissions and never escalates privileges.
+ */
+
+interface UpstreamWorkflow {
+  id?: string;
+  name?: string;
+  active?: boolean;
+}
+
+interface UpstreamListResponse {
+  data?: UpstreamWorkflow[];
+  nextCursor?: string | null;
+}
+
+export interface DuplicateMatch {
+  id: string;
+  active: boolean;
+}
+
+interface CacheEntry {
+  byName: Map<string, DuplicateMatch[]>;
+  expiresAt: number;
+}
+
+export class DuplicateChecker {
+  private cache: CacheEntry | null = null;
+
+  constructor(
+    private readonly upstreamBase: string,
+    private readonly ttlMs: number = 60_000,
+  ) {}
+
+  /** Clears the cache. Mostly useful for tests. */
+  invalidate(): void {
+    this.cache = null;
+  }
+
+  /**
+   * Returns duplicate matches for the given name, or an empty array.
+   *
+   * @param apiKey The caller's `X-N8N-API-KEY` header value. Used as-is so
+   *   the upstream query runs under the caller's permissions.
+   */
+  async findByName(name: string, apiKey: string | null): Promise<DuplicateMatch[]> {
+    if (!name) return [];
+    const index = await this.getIndex(apiKey);
+    return index.get(name) ?? [];
+  }
+
+  private async getIndex(apiKey: string | null): Promise<Map<string, DuplicateMatch[]>> {
+    const now = performance.now();
+    if (this.cache && this.cache.expiresAt > now) {
+      return this.cache.byName;
+    }
+
+    const byName = await this.fetchWorkflowIndex(apiKey);
+    this.cache = { byName, expiresAt: now + this.ttlMs };
+    return byName;
+  }
+
+  private async fetchWorkflowIndex(apiKey: string | null): Promise<Map<string, DuplicateMatch[]>> {
+    const byName = new Map<string, DuplicateMatch[]>();
+    let cursor: string | undefined;
+    let pages = 0;
+
+    // Hard cap pages to keep a misbehaving upstream from spinning the proxy.
+    while (pages < 50) {
+      pages++;
+      const url = new URL(`${this.upstreamBase}/api/v1/workflows`);
+      url.searchParams.set("limit", "100");
+      if (cursor) url.searchParams.set("cursor", cursor);
+
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (apiKey) headers["X-N8N-API-KEY"] = apiKey;
+
+      const res = await fetch(url.toString(), { headers });
+      if (!res.ok) {
+        // On any upstream error, return whatever we collected so far and stop.
+        // The proxy will treat this as "no duplicate" — safer than blocking on
+        // a transient upstream hiccup.
+        break;
+      }
+      const body = (await res.json()) as UpstreamListResponse;
+      const items = body.data ?? [];
+      for (const wf of items) {
+        if (!wf.name) continue;
+        const list = byName.get(wf.name) ?? [];
+        list.push({ id: wf.id ?? "", active: wf.active ?? false });
+        byName.set(wf.name, list);
+      }
+      cursor = body.nextCursor ?? undefined;
+      if (!cursor) break;
+    }
+
+    return byName;
+  }
+}

--- a/src/proxy/enforcer.ts
+++ b/src/proxy/enforcer.ts
@@ -1,6 +1,6 @@
 import type { Workflow } from "@/api/types.ts";
 import type { LintConfig } from "@/lint/config.ts";
-import { hasErrors, lintWorkflow } from "@/lint/engine.ts";
+import { hasErrorViolations, lintWorkflow } from "@/lint/engine.ts";
 import type { RuleWithConfig } from "@/lint/registry.ts";
 import type { Violation } from "@/lint/rules/violation.ts";
 import type { EnforceLevel } from "./config.ts";
@@ -16,9 +16,12 @@ export interface EnforcementVerdict {
  * Runs the linter against a workflow JSON body and decides whether the request
  * should be blocked. The decision policy is:
  *
- * - `off`   never blocks; violations are returned for logging only.
+ * - `off`   skips lint entirely (no CPU cost, no violations returned).
  * - `warn`  never blocks; violations are returned (caller may attach a header).
  * - `error` blocks when any error-level violation is found.
+ *
+ * Rules are user-supplied (organization policy) and may throw on malformed
+ * inputs — defensively catch so a single bad rule cannot crash the request.
  */
 export function evaluate(
   workflow: Workflow | null,
@@ -27,9 +30,26 @@ export function evaluate(
   config: LintConfig | null,
   level: EnforceLevel,
 ): EnforcementVerdict {
-  const violations = lintWorkflow(workflow, rawJSON, rules, config);
-  if (level === "off" || level === "warn") {
+  if (level === "off") {
+    return { block: false, violations: [] };
+  }
+
+  let violations: Violation[];
+  try {
+    violations = lintWorkflow(workflow, rawJSON, rules, config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    violations = [
+      {
+        rule: "linter-internal-error",
+        severity: "error",
+        message: `Linter threw an exception while evaluating this workflow: ${message}`,
+      },
+    ];
+  }
+
+  if (level === "warn") {
     return { block: false, violations };
   }
-  return { block: hasErrors(violations), violations };
+  return { block: hasErrorViolations(violations), violations };
 }

--- a/src/proxy/enforcer.ts
+++ b/src/proxy/enforcer.ts
@@ -1,0 +1,35 @@
+import type { Workflow } from "@/api/types.ts";
+import type { LintConfig } from "@/lint/config.ts";
+import { hasErrors, lintWorkflow } from "@/lint/engine.ts";
+import type { RuleWithConfig } from "@/lint/registry.ts";
+import type { Violation } from "@/lint/rules/violation.ts";
+import type { EnforceLevel } from "./config.ts";
+
+export interface EnforcementVerdict {
+  /** Should the request be blocked (not forwarded to upstream)? */
+  block: boolean;
+  /** All violations regardless of severity. */
+  violations: Violation[];
+}
+
+/**
+ * Runs the linter against a workflow JSON body and decides whether the request
+ * should be blocked. The decision policy is:
+ *
+ * - `off`   never blocks; violations are returned for logging only.
+ * - `warn`  never blocks; violations are returned (caller may attach a header).
+ * - `error` blocks when any error-level violation is found.
+ */
+export function evaluate(
+  workflow: Workflow | null,
+  rawJSON: string,
+  rules: RuleWithConfig[],
+  config: LintConfig | null,
+  level: EnforceLevel,
+): EnforcementVerdict {
+  const violations = lintWorkflow(workflow, rawJSON, rules, config);
+  if (level === "off" || level === "warn") {
+    return { block: false, violations };
+  }
+  return { block: hasErrors(violations), violations };
+}

--- a/src/proxy/logging.ts
+++ b/src/proxy/logging.ts
@@ -1,0 +1,48 @@
+import type { Violation } from "@/lint/rules/violation.ts";
+
+/** Action taken on a request, used in audit logs. */
+export type LogAction = "pass" | "block" | "warn" | "forward" | "error";
+
+export interface LogEntry {
+  ts: string;
+  action: LogAction;
+  method: string;
+  path: string;
+  status: number;
+  upstreamMs?: number;
+  violations?: Array<Pick<Violation, "rule" | "severity" | "message">>;
+  workflowName?: string;
+  message?: string;
+}
+
+const SENSITIVE_HEADERS = new Set(["x-n8n-api-key", "authorization", "cookie"]);
+
+/** Strips secrets from header maps before logging. */
+export function redactHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? "<redacted>" : value;
+  });
+  return out;
+}
+
+export type LogFormat = "text" | "json";
+
+export class Logger {
+  constructor(private format: LogFormat = "text") {}
+
+  log(entry: Omit<LogEntry, "ts">): void {
+    const full: LogEntry = { ts: new Date().toISOString(), ...entry };
+    if (this.format === "json") {
+      process.stdout.write(`${JSON.stringify(full)}\n`);
+    } else {
+      const v = full.violations?.length ? ` violations=${full.violations.length}` : "";
+      const ms = full.upstreamMs !== undefined ? ` upstreamMs=${full.upstreamMs}` : "";
+      const wf = full.workflowName ? ` workflow="${full.workflowName}"` : "";
+      const msg = full.message ? ` msg="${full.message}"` : "";
+      process.stdout.write(
+        `${full.ts} ${full.action.toUpperCase()} ${full.method} ${full.path} ${full.status}${ms}${wf}${v}${msg}\n`,
+      );
+    }
+  }
+}

--- a/src/proxy/response.ts
+++ b/src/proxy/response.ts
@@ -1,0 +1,41 @@
+import type { Violation } from "@/lint/rules/violation.ts";
+
+export interface LintErrorBody {
+  error: "workflow_lint_failed";
+  message: string;
+  violations: Array<Pick<Violation, "rule" | "severity" | "message" | "line" | "column">>;
+  docs: string;
+}
+
+const DOCS_URL = "https://github.com/ubie-oss/n8n-cli#lint";
+
+/** Builds a 422 response body advertising the lint failure to the caller. */
+export function buildLintErrorResponse(violations: Violation[]): Response {
+  const errorViolations = violations.filter((v) => v.severity === "error" || !v.severity);
+  const body: LintErrorBody = {
+    error: "workflow_lint_failed",
+    message: `Workflow violates ${errorViolations.length} linter rule${
+      errorViolations.length === 1 ? "" : "s"
+    } and was not forwarded to n8n`,
+    violations: errorViolations.map((v) => ({
+      rule: v.rule,
+      severity: v.severity,
+      message: v.message,
+      line: v.line,
+      column: v.column,
+    })),
+    docs: DOCS_URL,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 422,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Builds a generic 500 response for unexpected proxy failures. */
+export function buildErrorResponse(message: string): Response {
+  return new Response(JSON.stringify({ error: "proxy_error", message }), {
+    status: 502,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/proxy/response.ts
+++ b/src/proxy/response.ts
@@ -9,15 +9,22 @@ export interface LintErrorBody {
 
 const DOCS_URL = "https://github.com/ubie-oss/n8n-cli#lint";
 
-/** Builds a 422 response body advertising the lint failure to the caller. */
+/**
+ * Builds a 422 response body advertising the lint failure to the caller.
+ *
+ * Includes ALL violations (both error and warning) so callers can fix them in
+ * a single round-trip rather than discovering warnings only after they fix the
+ * blocking errors. The message count refers to error-level violations because
+ * those are what actually caused the block.
+ */
 export function buildLintErrorResponse(violations: Violation[]): Response {
-  const errorViolations = violations.filter((v) => v.severity === "error" || !v.severity);
+  const errorCount = violations.filter((v) => v.severity === "error" || !v.severity).length;
   const body: LintErrorBody = {
     error: "workflow_lint_failed",
-    message: `Workflow violates ${errorViolations.length} linter rule${
-      errorViolations.length === 1 ? "" : "s"
+    message: `Workflow violates ${errorCount} linter rule${
+      errorCount === 1 ? "" : "s"
     } and was not forwarded to n8n`,
-    violations: errorViolations.map((v) => ({
+    violations: violations.map((v) => ({
       rule: v.rule,
       severity: v.severity,
       message: v.message,
@@ -28,6 +35,44 @@ export function buildLintErrorResponse(violations: Violation[]): Response {
   };
   return new Response(JSON.stringify(body), {
     status: 422,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Builds a 400 response for requests whose body is not valid JSON. The proxy
+ * returns this directly rather than forwarding to upstream because n8n would
+ * also reject malformed JSON, and a single clear error is friendlier than two
+ * layered ones (upstream 400 + proxy lint header).
+ */
+export function buildBadJSONResponse(parseError: string): Response {
+  const body = {
+    error: "workflow_invalid_json",
+    message: "Request body is not valid JSON; refusing to forward to n8n",
+    parseError,
+    docs: DOCS_URL,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Builds a 409 response when a duplicate workflow name is detected upstream. */
+export function buildDuplicateResponse(
+  workflowName: string,
+  upstreamMatches: Array<{ id: string; active: boolean }>,
+): Response {
+  const body = {
+    error: "workflow_duplicate_name",
+    message: `A workflow named "${workflowName}" already exists upstream (${upstreamMatches.length} match${
+      upstreamMatches.length === 1 ? "" : "es"
+    }). Rename locally or update the existing workflow by ID instead of creating a new one.`,
+    duplicates: upstreamMatches,
+    docs: DOCS_URL,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 409,
     headers: { "content-type": "application/json" },
   });
 }

--- a/src/proxy/rest/router.ts
+++ b/src/proxy/rest/router.ts
@@ -1,0 +1,24 @@
+/** Recognized n8n public-API endpoints that mutate workflow definitions. */
+export type WorkflowMutation =
+  | { kind: "create" } // POST /api/v1/workflows
+  | { kind: "update"; id: string }; // PUT /api/v1/workflows/:id
+
+/**
+ * Identifies if a request targets a workflow mutation endpoint on the public
+ * n8n API. Returns null for any other request (which should be transparently
+ * forwarded).
+ */
+export function matchWorkflowMutation(method: string, pathname: string): WorkflowMutation | null {
+  const normalized = pathname.replace(/\/+$/, "");
+
+  if (method === "POST" && normalized === "/api/v1/workflows") {
+    return { kind: "create" };
+  }
+
+  if (method === "PUT") {
+    const m = normalized.match(/^\/api\/v1\/workflows\/([^/]+)$/);
+    if (m) return { kind: "update", id: decodeURIComponent(m[1] as string) };
+  }
+
+  return null;
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -39,9 +39,10 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   const lintConfig: LintConfig = loadLintConfig(config.lintConfigPath);
   const rules: RuleWithConfig[] = registry.enabledRulesWithConfig(lintConfig, config.disableRules);
 
-  const duplicates = config.warnDuplicates
-    ? new DuplicateChecker(upstream, config.duplicateTtlMs)
-    : null;
+  // Duplicate-name detection is on by default; opt out with allowDuplicates.
+  const duplicates = config.allowDuplicates
+    ? null
+    : new DuplicateChecker(upstream, config.duplicateTtlMs);
 
   const deps: HandlerDeps = { upstream, rules, lintConfig, config, logger, duplicates };
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,0 +1,153 @@
+import type { Workflow } from "@/api/types.ts";
+import { type LintConfig, loadLintConfig } from "@/lint/config.ts";
+import type { RuleWithConfig } from "@/lint/registry.ts";
+import { registerDefaultRules } from "@/lint/rules/index.ts";
+import { normalizeUpstream, type ProxyConfig, parseListenAddr } from "./config.ts";
+import { evaluate } from "./enforcer.ts";
+import { Logger } from "./logging.ts";
+import { buildErrorResponse, buildLintErrorResponse } from "./response.ts";
+import { matchWorkflowMutation } from "./rest/router.ts";
+import { forwardRequest } from "./upstream.ts";
+
+export interface ProxyHandle {
+  port: number;
+  stop: () => Promise<void>;
+}
+
+/** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
+export function startProxy(config: ProxyConfig): ProxyHandle {
+  const { host, port } = parseListenAddr(config.listen);
+  const upstream = normalizeUpstream(config.upstream);
+  const logger = new Logger(config.logFormat);
+
+  const registry = registerDefaultRules();
+  const lintConfig: LintConfig = loadLintConfig(config.lintConfigPath);
+  const enabledRules: RuleWithConfig[] = registry.enabledRulesWithConfig(
+    lintConfig,
+    config.disableRules,
+  );
+
+  const server = Bun.serve({
+    hostname: host,
+    port,
+    fetch: (req) => handle(req, upstream, enabledRules, lintConfig, config, logger),
+  });
+
+  return {
+    port: server.port ?? port,
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+async function handle(
+  req: Request,
+  upstream: string,
+  rules: RuleWithConfig[],
+  lintConfig: LintConfig,
+  config: ProxyConfig,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+
+  // Internal health endpoint — never forwarded.
+  if (pathname === "/healthz" && req.method === "GET") {
+    return new Response("ok\n", { status: 200, headers: { "content-type": "text/plain" } });
+  }
+
+  const mutation = matchWorkflowMutation(req.method, pathname);
+
+  if (mutation) {
+    return handleWorkflowMutation(req, upstream, rules, lintConfig, config, logger, pathname);
+  }
+
+  // Transparent forward.
+  try {
+    const { response, elapsedMs } = await forwardRequest(req, upstream);
+    logger.log({
+      action: "forward",
+      method: req.method,
+      path: pathname,
+      status: response.status,
+      upstreamMs: elapsedMs,
+    });
+    return response;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
+    return buildErrorResponse(message);
+  }
+}
+
+async function handleWorkflowMutation(
+  req: Request,
+  upstream: string,
+  rules: RuleWithConfig[],
+  lintConfig: LintConfig,
+  config: ProxyConfig,
+  logger: Logger,
+  pathname: string,
+): Promise<Response> {
+  const rawJSON = await req.text();
+  let workflow: Workflow | null = null;
+  try {
+    workflow = JSON.parse(rawJSON) as Workflow;
+  } catch {
+    // Leave null; json-syntax rule will flag it. The upstream would also reject
+    // malformed JSON, so we still forward when enforcement is off/warn.
+  }
+
+  const verdict = evaluate(workflow, rawJSON, rules, lintConfig, config.enforce);
+  const workflowName = workflow?.name;
+
+  if (verdict.block) {
+    logger.log({
+      action: "block",
+      method: req.method,
+      path: pathname,
+      status: 422,
+      workflowName,
+      violations: verdict.violations.map((v) => ({
+        rule: v.rule,
+        severity: v.severity,
+        message: v.message,
+      })),
+    });
+    return buildLintErrorResponse(verdict.violations);
+  }
+
+  try {
+    const { response, elapsedMs } = await forwardRequest(req, upstream, rawJSON);
+    const action = verdict.violations.length > 0 ? "warn" : "pass";
+    const status = response.status;
+    if (verdict.violations.length > 0) {
+      const errCount = verdict.violations.filter(
+        (v) => v.severity === "error" || !v.severity,
+      ).length;
+      response.headers.set("x-n8n-lint-violations", String(verdict.violations.length));
+      response.headers.set("x-n8n-lint-errors", String(errCount));
+    }
+    logger.log({
+      action,
+      method: req.method,
+      path: pathname,
+      status,
+      upstreamMs: elapsedMs,
+      workflowName,
+      violations: verdict.violations.length
+        ? verdict.violations.map((v) => ({
+            rule: v.rule,
+            severity: v.severity,
+            message: v.message,
+          }))
+        : undefined,
+    });
+    return response;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
+    return buildErrorResponse(message);
+  }
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3,15 +3,30 @@ import { type LintConfig, loadLintConfig } from "@/lint/config.ts";
 import type { RuleWithConfig } from "@/lint/registry.ts";
 import { registerDefaultRules } from "@/lint/rules/index.ts";
 import { normalizeUpstream, type ProxyConfig, parseListenAddr } from "./config.ts";
+import { DuplicateChecker } from "./duplicate.ts";
 import { evaluate } from "./enforcer.ts";
 import { Logger } from "./logging.ts";
-import { buildErrorResponse, buildLintErrorResponse } from "./response.ts";
-import { matchWorkflowMutation } from "./rest/router.ts";
+import {
+  buildBadJSONResponse,
+  buildDuplicateResponse,
+  buildErrorResponse,
+  buildLintErrorResponse,
+} from "./response.ts";
+import { matchWorkflowMutation, type WorkflowMutation } from "./rest/router.ts";
 import { forwardRequest } from "./upstream.ts";
 
 export interface ProxyHandle {
   port: number;
   stop: () => Promise<void>;
+}
+
+interface HandlerDeps {
+  upstream: string;
+  rules: RuleWithConfig[];
+  lintConfig: LintConfig;
+  config: ProxyConfig;
+  logger: Logger;
+  duplicates: DuplicateChecker | null;
 }
 
 /** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
@@ -22,15 +37,18 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
 
   const registry = registerDefaultRules();
   const lintConfig: LintConfig = loadLintConfig(config.lintConfigPath);
-  const enabledRules: RuleWithConfig[] = registry.enabledRulesWithConfig(
-    lintConfig,
-    config.disableRules,
-  );
+  const rules: RuleWithConfig[] = registry.enabledRulesWithConfig(lintConfig, config.disableRules);
+
+  const duplicates = config.warnDuplicates
+    ? new DuplicateChecker(upstream, config.duplicateTtlMs)
+    : null;
+
+  const deps: HandlerDeps = { upstream, rules, lintConfig, config, logger, duplicates };
 
   const server = Bun.serve({
     hostname: host,
     port,
-    fetch: (req) => handle(req, upstream, enabledRules, lintConfig, config, logger),
+    fetch: (req) => handle(req, deps),
   });
 
   return {
@@ -41,32 +59,37 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   };
 }
 
-async function handle(
-  req: Request,
-  upstream: string,
-  rules: RuleWithConfig[],
-  lintConfig: LintConfig,
-  config: ProxyConfig,
-  logger: Logger,
-): Promise<Response> {
+async function handle(req: Request, deps: HandlerDeps): Promise<Response> {
   const url = new URL(req.url);
   const pathname = url.pathname;
 
-  // Internal health endpoint — never forwarded.
-  if (pathname === "/healthz" && req.method === "GET") {
-    return new Response("ok\n", { status: 200, headers: { "content-type": "text/plain" } });
+  // Internal endpoints — never forwarded. Allow GET and HEAD so load
+  // balancers using HEAD probes don't accidentally hit the upstream.
+  if (pathname === "/healthz" && (req.method === "GET" || req.method === "HEAD")) {
+    return new Response(req.method === "HEAD" ? null : "ok\n", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
   }
 
   const mutation = matchWorkflowMutation(req.method, pathname);
-
   if (mutation) {
-    return handleWorkflowMutation(req, upstream, rules, lintConfig, config, logger, pathname);
+    return handleWorkflowMutation(req, mutation, pathname, deps);
   }
 
-  // Transparent forward.
+  return handleTransparentForward(req, pathname, deps);
+}
+
+async function handleTransparentForward(
+  req: Request,
+  pathname: string,
+  deps: HandlerDeps,
+): Promise<Response> {
   try {
-    const { response, elapsedMs } = await forwardRequest(req, upstream);
-    logger.log({
+    const { response, elapsedMs } = await forwardRequest(req, deps.upstream, undefined, {
+      timeoutMs: deps.config.upstreamTimeoutMs,
+    });
+    deps.logger.log({
       action: "forward",
       method: req.method,
       path: pathname,
@@ -75,35 +98,42 @@ async function handle(
     });
     return response;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
-    return buildErrorResponse(message);
+    return reportError(err, req, pathname, deps);
   }
 }
 
 async function handleWorkflowMutation(
   req: Request,
-  upstream: string,
-  rules: RuleWithConfig[],
-  lintConfig: LintConfig,
-  config: ProxyConfig,
-  logger: Logger,
+  mutation: WorkflowMutation,
   pathname: string,
+  deps: HandlerDeps,
 ): Promise<Response> {
   const rawJSON = await req.text();
+  const apiKey = req.headers.get("x-n8n-api-key");
+
+  // Malformed JSON: return 400 from the proxy itself rather than layering on
+  // an upstream 400. n8n would also reject it; one clear error beats two.
   let workflow: Workflow | null = null;
   try {
     workflow = JSON.parse(rawJSON) as Workflow;
-  } catch {
-    // Leave null; json-syntax rule will flag it. The upstream would also reject
-    // malformed JSON, so we still forward when enforcement is off/warn.
+  } catch (parseErr) {
+    const message = parseErr instanceof Error ? parseErr.message : String(parseErr);
+    deps.logger.log({
+      action: "block",
+      method: req.method,
+      path: pathname,
+      status: 400,
+      message: `invalid JSON: ${message}`,
+    });
+    return buildBadJSONResponse(message);
   }
 
-  const verdict = evaluate(workflow, rawJSON, rules, lintConfig, config.enforce);
+  // Lint
+  const verdict = evaluate(workflow, rawJSON, deps.rules, deps.lintConfig, deps.config.enforce);
   const workflowName = workflow?.name;
 
   if (verdict.block) {
-    logger.log({
+    deps.logger.log({
       action: "block",
       method: req.method,
       path: pathname,
@@ -118,10 +148,32 @@ async function handleWorkflowMutation(
     return buildLintErrorResponse(verdict.violations);
   }
 
+  // Duplicate detection (creates only — updates target a specific id).
+  let duplicateMatches: Awaited<ReturnType<DuplicateChecker["findByName"]>> = [];
+  if (mutation.kind === "create" && deps.duplicates && workflow?.name) {
+    try {
+      duplicateMatches = await deps.duplicates.findByName(workflow.name, apiKey);
+    } catch {
+      // Treat lookup failure as "no duplicate" — see DuplicateChecker for rationale.
+    }
+    if (duplicateMatches.length > 0 && deps.config.enforce === "error") {
+      deps.logger.log({
+        action: "block",
+        method: req.method,
+        path: pathname,
+        status: 409,
+        workflowName,
+        message: `duplicate name: ${duplicateMatches.length} match(es)`,
+      });
+      return buildDuplicateResponse(workflow.name, duplicateMatches);
+    }
+  }
+
+  // Forward
   try {
-    const { response, elapsedMs } = await forwardRequest(req, upstream, rawJSON);
-    const action = verdict.violations.length > 0 ? "warn" : "pass";
-    const status = response.status;
+    const { response, elapsedMs } = await forwardRequest(req, deps.upstream, rawJSON, {
+      timeoutMs: deps.config.upstreamTimeoutMs,
+    });
     if (verdict.violations.length > 0) {
       const errCount = verdict.violations.filter(
         (v) => v.severity === "error" || !v.severity,
@@ -129,11 +181,15 @@ async function handleWorkflowMutation(
       response.headers.set("x-n8n-lint-violations", String(verdict.violations.length));
       response.headers.set("x-n8n-lint-errors", String(errCount));
     }
-    logger.log({
+    if (duplicateMatches.length > 0) {
+      response.headers.set("x-n8n-duplicate-warning", String(duplicateMatches.length));
+    }
+    const action = verdict.violations.length > 0 || duplicateMatches.length > 0 ? "warn" : "pass";
+    deps.logger.log({
       action,
       method: req.method,
       path: pathname,
-      status,
+      status: response.status,
       upstreamMs: elapsedMs,
       workflowName,
       violations: verdict.violations.length
@@ -143,11 +199,19 @@ async function handleWorkflowMutation(
             message: v.message,
           }))
         : undefined,
+      message:
+        duplicateMatches.length > 0
+          ? `duplicate name: ${duplicateMatches.length} upstream match(es)`
+          : undefined,
     });
     return response;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
-    return buildErrorResponse(message);
+    return reportError(err, req, pathname, deps);
   }
+}
+
+function reportError(err: unknown, req: Request, pathname: string, deps: HandlerDeps): Response {
+  const message = err instanceof Error ? err.message : String(err);
+  deps.logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
+  return buildErrorResponse(message);
 }

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -1,23 +1,64 @@
 /**
  * Forwards a Request to the upstream n8n server transparently.
  *
- * Strips hop-by-hop headers and the original `host` header (it would carry the
- * proxy's host into the upstream call). Preserves auth headers including
- * `X-N8N-API-KEY` since the client is expected to supply them and the upstream
- * needs them to authenticate.
+ * Strips RFC 7230 §6.1 hop-by-hop headers (`Connection`, `Keep-Alive`, `TE`,
+ * `Transfer-Encoding`, `Trailer`, `Upgrade`, `Proxy-Authorization`,
+ * `Proxy-Authenticate`) plus any header named in the incoming `Connection:`
+ * header, and the original `Host` header (it would carry the proxy's host into
+ * the upstream call). `Content-Length` is also stripped because fetch
+ * recomputes it from the actual body.
+ *
+ * Preserves auth headers including `X-N8N-API-KEY` and `Authorization` since
+ * the client is expected to supply them and the upstream needs them to
+ * authenticate.
  */
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function buildUpstreamHeaders(req: Request): Headers {
+  const headers = new Headers(req.headers);
+
+  // Any header name listed in `Connection:` is also hop-by-hop per RFC 7230.
+  const connection = headers.get("connection");
+  if (connection) {
+    for (const name of connection.split(",")) {
+      const trimmed = name.trim().toLowerCase();
+      if (trimmed) headers.delete(trimmed);
+    }
+  }
+
+  for (const h of HOP_BY_HOP_HEADERS) {
+    headers.delete(h);
+  }
+  return headers;
+}
+
+export interface ForwardOptions {
+  /** Total request timeout in milliseconds; 0 disables timeout. */
+  timeoutMs?: number;
+}
+
 export async function forwardRequest(
   req: Request,
   upstreamBase: string,
   body?: string | ArrayBuffer | null,
+  options?: ForwardOptions,
 ): Promise<{ response: Response; elapsedMs: number }> {
   const incomingUrl = new URL(req.url);
   const upstreamUrl = `${upstreamBase}${incomingUrl.pathname}${incomingUrl.search}`;
 
-  const headers = new Headers(req.headers);
-  headers.delete("host");
-  headers.delete("connection");
-  headers.delete("content-length");
+  const headers = buildUpstreamHeaders(req);
 
   const init: RequestInit = {
     method: req.method,
@@ -31,8 +72,20 @@ export async function forwardRequest(
     init.body = await req.arrayBuffer();
   }
 
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const controller = timeoutMs > 0 ? new AbortController() : null;
+  const timer =
+    controller && timeoutMs > 0
+      ? setTimeout(() => controller.abort(new Error("upstream timeout")), timeoutMs)
+      : null;
+  if (controller) init.signal = controller.signal;
+
   const start = performance.now();
-  const response = await fetch(upstreamUrl, init);
-  const elapsedMs = Math.round(performance.now() - start);
-  return { response, elapsedMs };
+  try {
+    const response = await fetch(upstreamUrl, init);
+    const elapsedMs = Math.round(performance.now() - start);
+    return { response, elapsedMs };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -1,0 +1,38 @@
+/**
+ * Forwards a Request to the upstream n8n server transparently.
+ *
+ * Strips hop-by-hop headers and the original `host` header (it would carry the
+ * proxy's host into the upstream call). Preserves auth headers including
+ * `X-N8N-API-KEY` since the client is expected to supply them and the upstream
+ * needs them to authenticate.
+ */
+export async function forwardRequest(
+  req: Request,
+  upstreamBase: string,
+  body?: string | ArrayBuffer | null,
+): Promise<{ response: Response; elapsedMs: number }> {
+  const incomingUrl = new URL(req.url);
+  const upstreamUrl = `${upstreamBase}${incomingUrl.pathname}${incomingUrl.search}`;
+
+  const headers = new Headers(req.headers);
+  headers.delete("host");
+  headers.delete("connection");
+  headers.delete("content-length");
+
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: "manual",
+  };
+
+  if (body !== undefined) {
+    init.body = body;
+  } else if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer();
+  }
+
+  const start = performance.now();
+  const response = await fetch(upstreamUrl, init);
+  const elapsedMs = Math.round(performance.now() - start);
+  return { response, elapsedMs };
+}

--- a/tests/proxy/proxy-extra.test.ts
+++ b/tests/proxy/proxy-extra.test.ts
@@ -17,12 +17,15 @@ interface MockUpstream {
   setWorkflows: (workflows: Array<{ id: string; name: string; active?: boolean }>) => void;
   /** Make the next request hang forever, simulating a stuck upstream. */
   hangNext: () => void;
+  /** Make the next GET /api/v1/workflows return the given status. */
+  failNextList: (status: number) => void;
 }
 
 function startMockUpstream(): MockUpstream {
   const captured: CapturedRequest[] = [];
   let workflows: Array<{ id: string; name: string; active?: boolean }> = [];
   let hang = false;
+  let nextListFailStatus: number | null = null;
 
   const server = Bun.serve({
     port: 0,
@@ -42,6 +45,14 @@ function startMockUpstream(): MockUpstream {
       }
 
       if (req.method === "GET" && url.pathname === "/api/v1/workflows") {
+        if (nextListFailStatus !== null) {
+          const status = nextListFailStatus;
+          nextListFailStatus = null;
+          return new Response(JSON.stringify({ error: "denied" }), {
+            status,
+            headers: { "content-type": "application/json" },
+          });
+        }
         return new Response(JSON.stringify({ data: workflows, nextCursor: null }), {
           headers: { "content-type": "application/json" },
         });
@@ -62,6 +73,9 @@ function startMockUpstream(): MockUpstream {
     },
     hangNext() {
       hang = true;
+    },
+    failNextList(status) {
+      nextListFailStatus = status;
     },
   };
 }
@@ -329,4 +343,47 @@ describe("proxy: enforce=off short-circuits lint", () => {
     // an empty violations array under enforce=off.
     expect(res.headers.get("x-n8n-lint-violations")).toBeNull();
   });
+});
+
+describe("proxy: duplicate-check hardening", () => {
+  test("POST without X-N8N-API-KEY skips the upstream lookup entirely", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "Conflict", active: false }]);
+    start();
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" }, // no api key
+      body: JSON.stringify({ name: "Conflict", nodes: [], connections: {} }),
+    });
+
+    // No api key → no duplicate lookup → no GET to upstream, request forwarded.
+    expect(res.status).toBe(200);
+    expect(upstream.captured.filter((c) => c.method === "GET")).toHaveLength(0);
+  });
+
+  test("upstream list failure is cached with a short TTL, not the full 60s", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "Conflict", active: false }]);
+    upstream.failNextList(401);
+    start({ duplicateTtlMs: 60_000 });
+
+    // First POST hits the 401 → duplicate check is a "no match" (failure-mode
+    // empty index) AND the result is cached only for FAILURE_TTL_MS (5s).
+    const res1 = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: JSON.stringify({ name: "Conflict", nodes: [], connections: {} }),
+    });
+    expect(res1.status).toBe(200); // not blocked because lookup failed
+
+    // Wait past the failure TTL, then retry — the proxy should re-query and
+    // this time catch the duplicate.
+    await Bun.sleep(5100);
+
+    const res2 = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: JSON.stringify({ name: "Conflict", nodes: [], connections: {} }),
+    });
+    expect(res2.status).toBe(409);
+  }, 15_000);
 });

--- a/tests/proxy/proxy-extra.test.ts
+++ b/tests/proxy/proxy-extra.test.ts
@@ -236,10 +236,10 @@ describe("proxy: upstream timeout", () => {
   }, 5000);
 });
 
-describe("proxy: --warn-duplicates", () => {
+describe("proxy: duplicate-name check is on by default", () => {
   test("enforce=error blocks with 409 when name already exists upstream", async () => {
     upstream.setWorkflows([{ id: "wf-existing", name: "My Workflow", active: true }]);
-    start({ warnDuplicates: true });
+    start();
 
     const res = await fetch(url("/api/v1/workflows"), {
       method: "POST",
@@ -257,7 +257,7 @@ describe("proxy: --warn-duplicates", () => {
 
   test("enforce=warn attaches a duplicate-warning header and still forwards", async () => {
     upstream.setWorkflows([{ id: "wf-existing", name: "Same Name", active: false }]);
-    start({ warnDuplicates: true, enforce: "warn" });
+    start({ enforce: "warn" });
 
     const res = await fetch(url("/api/v1/workflows"), {
       method: "POST",
@@ -272,7 +272,7 @@ describe("proxy: --warn-duplicates", () => {
 
   test("PUT (update) is never duplicate-checked", async () => {
     upstream.setWorkflows([{ id: "wf-existing", name: "X", active: false }]);
-    start({ warnDuplicates: true });
+    start();
 
     const res = await fetch(url("/api/v1/workflows/wf-existing"), {
       method: "PUT",
@@ -286,7 +286,7 @@ describe("proxy: --warn-duplicates", () => {
 
   test("no upstream match → forwards normally", async () => {
     upstream.setWorkflows([{ id: "wf-other", name: "Different", active: false }]);
-    start({ warnDuplicates: true });
+    start();
 
     const res = await fetch(url("/api/v1/workflows"), {
       method: "POST",
@@ -296,6 +296,23 @@ describe("proxy: --warn-duplicates", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get("x-n8n-duplicate-warning")).toBeNull();
+  });
+
+  test("--allow-duplicates skips the check entirely, even on a match", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "Same Name", active: true }]);
+    start({ allowDuplicates: true });
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Same Name", nodes: [], connections: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-n8n-duplicate-warning")).toBeNull();
+    // The proxy must not have queried the upstream workflow list at all
+    // when the check is disabled.
+    expect(upstream.captured.filter((c) => c.method === "GET")).toHaveLength(0);
   });
 });
 

--- a/tests/proxy/proxy-extra.test.ts
+++ b/tests/proxy/proxy-extra.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { parseListenAddr } from "@/proxy/config.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: CapturedRequest[];
+  /** Override the workflow listing returned for the next GET /api/v1/workflows. */
+  setWorkflows: (workflows: Array<{ id: string; name: string; active?: boolean }>) => void;
+  /** Make the next request hang forever, simulating a stuck upstream. */
+  hangNext: () => void;
+}
+
+function startMockUpstream(): MockUpstream {
+  const captured: CapturedRequest[] = [];
+  let workflows: Array<{ id: string; name: string; active?: boolean }> = [];
+  let hang = false;
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ method: req.method, pathname: url.pathname, headers, body });
+
+      if (hang) {
+        return new Promise<Response>(() => {
+          /* never resolves */
+        });
+      }
+
+      if (req.method === "GET" && url.pathname === "/api/v1/workflows") {
+        return new Response(JSON.stringify({ data: workflows, nextCursor: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  return {
+    server,
+    port: server.port as number,
+    captured,
+    setWorkflows(w) {
+      workflows = w;
+    },
+    hangNext() {
+      hang = true;
+    },
+  };
+}
+
+let proxy: ProxyHandle;
+let upstream: MockUpstream;
+
+beforeEach(() => {
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+});
+
+function start(extra: Partial<Parameters<typeof startProxy>[0]> = {}): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "error",
+    disableRules: [],
+    logFormat: "json",
+    ...extra,
+  });
+  return proxy;
+}
+
+function url(p: string): string {
+  return `http://127.0.0.1:${proxy.port}${p}`;
+}
+
+const VIOLATING = JSON.stringify({ active: true, nodes: [], connections: {} });
+
+describe("proxy: parseListenAddr", () => {
+  test("rejects port with trailing garbage", () => {
+    expect(() => parseListenAddr(":8080abc")).toThrow(/expected digits only/);
+  });
+
+  test("accepts bracketed IPv6", () => {
+    expect(parseListenAddr("[::1]:9000")).toEqual({ host: "::1", port: 9000 });
+  });
+
+  test("rejects bracketed IPv6 missing port", () => {
+    expect(() => parseListenAddr("[::1]")).toThrow();
+  });
+
+  test(":port resolves to 0.0.0.0", () => {
+    expect(parseListenAddr(":8080")).toEqual({ host: "0.0.0.0", port: 8080 });
+  });
+});
+
+describe("proxy: malformed JSON", () => {
+  test("returns 400 from the proxy, never forwards", async () => {
+    start();
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"name":"x","nodes', // truncated
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; parseError?: string };
+    expect(body.error).toBe("workflow_invalid_json");
+    expect(upstream.captured.filter((c) => c.method !== "GET")).toHaveLength(0);
+  });
+});
+
+describe("proxy: 422 body includes warnings", () => {
+  test("warnings appear alongside errors in the 422 violations array", async () => {
+    // banned-node defaults to warning. Combine with required-fields (error) by
+    // providing an empty name + a node of a banned type.
+    const cfg: Record<string, unknown> = {
+      "banned-node": ["warning", { nodes: [{ type: "n8n-nodes-base.httpRequest" }] }],
+    };
+    const lintPath = `${process.env.TMPDIR ?? "/tmp"}/n8n-cli-warn-test-${Date.now()}.json`;
+    await Bun.write(lintPath, JSON.stringify({ rules: cfg }));
+    start({ lintConfigPath: lintPath });
+
+    const body = JSON.stringify({
+      // missing name → required-fields error
+      active: true,
+      nodes: [
+        {
+          id: "n1",
+          name: "HTTP",
+          type: "n8n-nodes-base.httpRequest",
+          typeVersion: 1,
+          position: [0, 0],
+        },
+      ],
+      connections: {},
+    });
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(422);
+    const parsed = (await res.json()) as {
+      violations: Array<{ rule: string; severity: string }>;
+    };
+    const severities = new Set(parsed.violations.map((v) => v.severity));
+    expect(severities.has("error")).toBe(true);
+    expect(severities.has("warning")).toBe(true);
+  });
+});
+
+describe("proxy: linter exception is caught", () => {
+  test("workflow lacking required structure does not crash with 500", async () => {
+    start();
+    // A workflow shape that some rules iterate on but is missing nodes.
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "x", connections: {} }),
+    });
+    // The required-fields rule will flag the missing nodes; even if a rule
+    // throws on it, the proxy returns 422 (not 500).
+    expect([400, 422]).toContain(res.status);
+  });
+});
+
+describe("proxy: HEAD /healthz", () => {
+  test("responds locally with 200, never forwards", async () => {
+    start();
+    const res = await fetch(url("/healthz"), { method: "HEAD" });
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(0);
+  });
+});
+
+describe("proxy: hop-by-hop headers", () => {
+  test("Transfer-Encoding and Connection-listed headers are stripped", async () => {
+    start({ enforce: "off" });
+    await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // Connection lists "x-custom-hop"; that header must also be stripped.
+        connection: "close, x-custom-hop",
+        "x-custom-hop": "secret",
+        te: "trailers",
+      },
+      body: VIOLATING,
+    });
+    const forwarded = upstream.captured.find((c) => c.method === "POST");
+    expect(forwarded).toBeDefined();
+    // The Connection header from fetch's own network layer may still be
+    // present (e.g. "keep-alive"). What we care about is that we stripped
+    // the original client values: "close" and the listed x-custom-hop header.
+    expect(forwarded?.headers.connection ?? "").not.toContain("close");
+    expect(forwarded?.headers.connection ?? "").not.toContain("x-custom-hop");
+    expect(forwarded?.headers.te).toBeUndefined();
+    expect(forwarded?.headers["x-custom-hop"]).toBeUndefined();
+  });
+});
+
+describe("proxy: upstream timeout", () => {
+  test("hung upstream produces a 502 within the timeout", async () => {
+    upstream.hangNext();
+    start({ upstreamTimeoutMs: 250 });
+
+    const start_t = performance.now();
+    const res = await fetch(url("/api/v1/workflows"), { method: "GET" });
+    const elapsed = performance.now() - start_t;
+
+    expect(res.status).toBe(502);
+    expect(elapsed).toBeLessThan(2000);
+  }, 5000);
+});
+
+describe("proxy: --warn-duplicates", () => {
+  test("enforce=error blocks with 409 when name already exists upstream", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "My Workflow", active: true }]);
+    start({ warnDuplicates: true });
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: JSON.stringify({ name: "My Workflow", nodes: [], connections: {} }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; duplicates: unknown[] };
+    expect(body.error).toBe("workflow_duplicate_name");
+    expect(body.duplicates).toHaveLength(1);
+    // POST never reached upstream (only the GET that built the index).
+    expect(upstream.captured.filter((c) => c.method === "POST")).toHaveLength(0);
+  });
+
+  test("enforce=warn attaches a duplicate-warning header and still forwards", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "Same Name", active: false }]);
+    start({ warnDuplicates: true, enforce: "warn" });
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: JSON.stringify({ name: "Same Name", nodes: [], connections: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-n8n-duplicate-warning")).toBe("1");
+    expect(upstream.captured.filter((c) => c.method === "POST")).toHaveLength(1);
+  });
+
+  test("PUT (update) is never duplicate-checked", async () => {
+    upstream.setWorkflows([{ id: "wf-existing", name: "X", active: false }]);
+    start({ warnDuplicates: true });
+
+    const res = await fetch(url("/api/v1/workflows/wf-existing"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "X", nodes: [], connections: {} }),
+    });
+
+    // No duplicate-related block on update.
+    expect(res.status).toBe(200);
+  });
+
+  test("no upstream match → forwards normally", async () => {
+    upstream.setWorkflows([{ id: "wf-other", name: "Different", active: false }]);
+    start({ warnDuplicates: true });
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Brand New", nodes: [], connections: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-n8n-duplicate-warning")).toBeNull();
+  });
+});
+
+describe("proxy: enforce=off short-circuits lint", () => {
+  test("violating workflow forwards without running rules", async () => {
+    start({ enforce: "off" });
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING,
+    });
+    expect(res.status).toBe(200);
+    // No lint headers on the forwarded response, because evaluate returns
+    // an empty violations array under enforce=off.
+    expect(res.headers.get("x-n8n-lint-violations")).toBeNull();
+  });
+});

--- a/tests/proxy/proxy.test.ts
+++ b/tests/proxy/proxy.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { matchWorkflowMutation } from "@/proxy/rest/router.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: CapturedRequest[];
+  /** Override the response returned for the next request. */
+  respondWith: (status: number, body: string, headers?: Record<string, string>) => void;
+}
+
+function startMockUpstream(): MockUpstream {
+  const captured: CapturedRequest[] = [];
+  let nextResponse: { status: number; body: string; headers: Record<string, string> } | null = null;
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ method: req.method, pathname: url.pathname, headers, body });
+
+      if (nextResponse) {
+        const r = nextResponse;
+        nextResponse = null;
+        return new Response(r.body, { status: r.status, headers: r.headers });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  return {
+    server,
+    port: server.port as number,
+    captured,
+    respondWith(status, body, headers = {}) {
+      nextResponse = { status, body, headers: { "content-type": "application/json", ...headers } };
+    },
+  };
+}
+
+const VIOLATING_WORKFLOW = JSON.stringify({
+  // missing "name" → required-fields error
+  active: true,
+  nodes: [],
+  connections: {},
+});
+
+const CLEAN_WORKFLOW = JSON.stringify({
+  name: "Clean WF",
+  active: false,
+  nodes: [],
+  connections: {},
+});
+
+let tmpDir: string;
+let proxy: ProxyHandle;
+let upstream: MockUpstream;
+
+function writeConfig(rules: Record<string, unknown>): string {
+  const configPath = path.join(tmpDir, ".n8nlintrc.json");
+  fs.writeFileSync(configPath, JSON.stringify({ rules }));
+  return configPath;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "n8n-cli-proxy-"));
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function startWithEnforce(enforce: "off" | "warn" | "error", configPath?: string): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    lintConfigPath: configPath,
+    enforce,
+    disableRules: [],
+    logFormat: "json",
+  });
+  return proxy;
+}
+
+function proxyURL(p: string): string {
+  return `http://127.0.0.1:${proxy.port}${p}`;
+}
+
+describe("proxy: route matcher", () => {
+  test("POST /api/v1/workflows is recognized as create", () => {
+    expect(matchWorkflowMutation("POST", "/api/v1/workflows")).toEqual({ kind: "create" });
+  });
+
+  test("PUT /api/v1/workflows/:id is recognized as update", () => {
+    expect(matchWorkflowMutation("PUT", "/api/v1/workflows/abc123")).toEqual({
+      kind: "update",
+      id: "abc123",
+    });
+  });
+
+  test("Other endpoints are not matched", () => {
+    expect(matchWorkflowMutation("GET", "/api/v1/workflows")).toBeNull();
+    expect(matchWorkflowMutation("DELETE", "/api/v1/workflows/abc")).toBeNull();
+    expect(matchWorkflowMutation("POST", "/api/v1/credentials")).toBeNull();
+    expect(matchWorkflowMutation("POST", "/api/v1/workflows/abc/activate")).toBeNull();
+  });
+
+  test("URL-encoded ids are decoded", () => {
+    expect(matchWorkflowMutation("PUT", "/api/v1/workflows/wf%20a")).toEqual({
+      kind: "update",
+      id: "wf a",
+    });
+  });
+});
+
+describe("proxy: transparent forwarding", () => {
+  test("GET is forwarded to upstream and response is returned", async () => {
+    startWithEnforce("error");
+    upstream.respondWith(200, JSON.stringify({ data: ["x"] }));
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      headers: { "x-n8n-api-key": "test-key" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: ["x"] });
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]?.method).toBe("GET");
+    expect(upstream.captured[0]?.pathname).toBe("/api/v1/workflows");
+  });
+
+  test("Auth header X-N8N-API-KEY is forwarded to upstream", async () => {
+    startWithEnforce("error");
+    await fetch(proxyURL("/api/v1/workflows"), {
+      headers: { "x-n8n-api-key": "my-secret-key" },
+    });
+    expect(upstream.captured[0]?.headers["x-n8n-api-key"]).toBe("my-secret-key");
+  });
+
+  test("Healthz is handled locally, never forwarded", async () => {
+    startWithEnforce("error");
+    const res = await fetch(proxyURL("/healthz"));
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(0);
+  });
+});
+
+describe("proxy: workflow create lint enforcement", () => {
+  test("clean workflow is forwarded with body intact", async () => {
+    startWithEnforce("error");
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: CLEAN_WORKFLOW,
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]?.method).toBe("POST");
+    expect(JSON.parse(upstream.captured[0]?.body ?? "")).toMatchObject({ name: "Clean WF" });
+  });
+
+  test("violating workflow is blocked with 422 + violations JSON", async () => {
+    startWithEnforce("error");
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: VIOLATING_WORKFLOW,
+    });
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as {
+      error: string;
+      violations: Array<{ rule: string; severity: string }>;
+    };
+    expect(body.error).toBe("workflow_lint_failed");
+    expect(body.violations.some((v) => v.rule === "required-fields")).toBe(true);
+    expect(upstream.captured).toHaveLength(0); // upstream never reached
+  });
+
+  test("PUT workflow update is intercepted the same way", async () => {
+    startWithEnforce("error");
+
+    const res = await fetch(proxyURL("/api/v1/workflows/wf-1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: VIOLATING_WORKFLOW,
+    });
+
+    expect(res.status).toBe(422);
+    expect(upstream.captured).toHaveLength(0);
+  });
+});
+
+describe("proxy: enforce modes", () => {
+  test("enforce=off forwards even on violations", async () => {
+    startWithEnforce("off");
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: VIOLATING_WORKFLOW,
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+  });
+
+  test("enforce=warn forwards but attaches x-n8n-lint-violations header", async () => {
+    startWithEnforce("warn");
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: VIOLATING_WORKFLOW,
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+    expect(res.headers.get("x-n8n-lint-violations")).not.toBeNull();
+    const errCount = Number.parseInt(res.headers.get("x-n8n-lint-errors") ?? "0", 10);
+    expect(errCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("proxy: lint config", () => {
+  test("disabled rules via .n8nlintrc.json do not block", async () => {
+    const configPath = writeConfig({ "required-fields": "off" });
+    startWithEnforce("error", configPath);
+
+    const res = await fetch(proxyURL("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: VIOLATING_WORKFLOW,
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+  });
+});

--- a/tests/proxy/proxy.test.ts
+++ b/tests/proxy/proxy.test.ts
@@ -100,6 +100,9 @@ function startWithEnforce(enforce: "off" | "warn" | "error", configPath?: string
     enforce,
     disableRules: [],
     logFormat: "json",
+    // Duplicate-name detection is on by default; these older tests focus on
+    // lint enforcement and don't assert duplicate behavior, so opt out.
+    allowDuplicates: true,
   });
   return proxy;
 }


### PR DESCRIPTION
## Summary

- Add `n8n-cli proxy` subcommand — a transparent HTTP proxy that sits between clients and the n8n public REST API and runs the existing linter server-side. Workflows violating error-severity rules are rejected with HTTP 422 before they reach n8n.
- Extract `lintWorkflow()` from the lint command as a reusable in-memory entry point so the proxy (and future TypeScript-SDK integrations) can run rules without going through file I/O.
- Bump minor version 2.1.3 → **2.2.0**.

### Why

When humans or AI agents push workflows directly to the n8n API, client-side lint is silently bypassed and low-quality definitions end up in production. The proxy makes lint enforcement structural rather than convention-based.

### Behavior

- Intercepts `POST /api/v1/workflows` and `PUT /api/v1/workflows/:id` only — every other path is forwarded transparently
- `--enforce off|warn|error` (default `error`):
  - `error`: blocks with 422 + violations JSON when any error-level violation is present
  - `warn`: forwards with `X-N8n-Lint-Violations` / `X-N8n-Lint-Errors` response headers
  - `off`: never blocks, lint runs for audit logging only
- `X-N8N-API-KEY` is passed through to the upstream as-is
- Existing `.n8nlintrc.json` is auto-discovered (same precedence as the `lint` command)
- Structured `text` / `json` audit logs, `GET /healthz` for liveness probes

### Out of scope (follow-ups)

- n8n MCP Server interception (different protocol layer; will land in a separate PR)
- n8n internal `/rest/*` endpoints (UI-only, not used by the agentic clients we want to police)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean
- [x] `bun test` — 721 pass / 0 fail
- [x] `bun run build` — compiles to standalone binary
- [x] `./n8n-cli proxy --help` — subcommand registered
- [x] 13 new tests cover: route matcher, GET passthrough, auth header passthrough, healthz, clean POST → upstream, violating POST → 422, PUT update → 422, enforce=off / enforce=warn semantics, config-based rule disabling
- [ ] Manual smoke against a real n8n instance (recommend running in `--enforce warn` first to audit before flipping to `error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFHitnpE7LpwQsGYRKrDCV