### PR TITLE
feat(apply): add default-on pre-write lint check to apply and workflow create/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ n8n-cli apply [options]
 | `--no-auto-tag` | Disable automatic tagging |
 | `--yaml` / `--no-yaml` | Enable/disable YAML file processing |
 | `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default; use `--force` to push through warnings instead of disabling the check) |
+| `--no-lint` | Skip the pre-write lint check (the check is on by default; an error-level violation marks the workflow as failed and prevents the API call. `--force` does NOT bypass lint failures — they represent policy, not merge conflicts) |
+| `--lint-config <path>` | Path to `.n8nlintrc.json` used by the pre-write lint check (auto-discovered if omitted) |
+| `--lint-disable-rule <rules>` | Comma-separated rule names to disable during the pre-write lint check |
 
 #### Exit Codes
 
@@ -333,20 +336,26 @@ Get a workflow by ID.
 
 #### `workflow create`
 
-Create a new workflow.
+Create a new workflow. The pre-write lint check runs by default — any error-level violation blocks the API call.
 
 | Option | Description |
 |--------|-------------|
 | `-f, --file <path>` | Path to workflow JSON file, use `-` for stdin (required) |
+| `--no-lint` | Skip the pre-write lint check (on by default) |
+| `--lint-config <path>` | Path to `.n8nlintrc.json` for the pre-write lint check |
+| `--lint-disable-rule <rules>` | Comma-separated rule names to disable during the pre-write lint check |
 
 #### `workflow update [id]`
 
-Update an existing workflow. The ID argument is optional if the JSON file contains an `id` field.
+Update an existing workflow. The ID argument is optional if the JSON file contains an `id` field. The pre-write lint check runs by default — any error-level violation blocks the API call.
 
 | Option | Description |
 |--------|-------------|
 | `-f, --file <path>` | Path to workflow JSON file, use `-` for stdin (required) |
 | `--force` | Force update even if remote has been modified |
+| `--no-lint` | Skip the pre-write lint check (on by default) |
+| `--lint-config <path>` | Path to `.n8nlintrc.json` for the pre-write lint check |
+| `--lint-disable-rule <rules>` | Comma-separated rule names to disable during the pre-write lint check |
 
 #### `workflow delete <ids...>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -5,6 +5,13 @@ import type { TagService } from "../api/tag-service.ts";
 import type { Workflow, WorkflowInput } from "../api/types.ts";
 import type { WorkflowService } from "../api/workflow-service.ts";
 import { ContentRetriever, ErrFileNotExist } from "../git/content.ts";
+import type { Violation } from "../lint/rules/violation.ts";
+import {
+  checkWorkflowForWrite,
+  formatViolationLine,
+  prepareWriteLintContext,
+  type WriteLintContext,
+} from "../lint/write-check.ts";
 import { compare } from "./differ.ts";
 import { DuplicateChecker } from "./duplicate.ts";
 import { Scanner } from "./scanner.ts";
@@ -37,6 +44,7 @@ export class Executor {
   private threeWayDetector?: ThreeWayDetector;
   private gitContent?: ContentRetriever;
   private diffSpec?: DiffSpec;
+  private lintCtx?: WriteLintContext;
 
   constructor(
     private readonly workflowService: WorkflowService,
@@ -51,6 +59,23 @@ export class Executor {
       } catch {
         // Silently fall back to 2-way detection
       }
+    }
+
+    // Lint check is on by default. Resolve config and rules once per apply so
+    // we don't pay the registry cost for every workflow. Discovery starts from
+    // `opts.directory` so an in-tree `.n8nlintrc.json` (e.g. `workflows/.n8nlintrc.json`)
+    // is picked up regardless of where the user invoked the CLI from.
+    //
+    // `LintConfigLoadError` is intentionally NOT caught here — it would leave
+    // the user with a half-initialised Executor. The caller in
+    // `src/cli/commands/apply.ts` is responsible for catching the typed error
+    // and printing a friendly message.
+    if (!opts.noLint) {
+      this.lintCtx = prepareWriteLintContext(
+        opts.lintConfigPath,
+        opts.lintDisableRules,
+        opts.directory,
+      );
     }
   }
 
@@ -163,6 +188,22 @@ export class Executor {
     const workflow = wf.workflow!;
     op.workflowName = workflow.name;
     op.localUpdated = workflow.updatedAt;
+
+    // Pre-write lint gate. Runs before any remote fetch so a broken workflow
+    // never causes upstream traffic. Errors mark the op as failed; warnings
+    // are recorded on the op but do not block. Bypassed only when the user
+    // passed --no-lint (and `lintCtx` was therefore not built). `--force`
+    // intentionally does NOT override this — lint failures are policy, not
+    // merge conflicts.
+    if (this.lintCtx) {
+      const check = checkWorkflowForWrite(workflow, undefined, this.lintCtx);
+      op.lintViolations = check.violations;
+      if (check.hasErrors) {
+        op.operation = "error";
+        op.error = new Error(buildLintErrorMessage(wf.path, check.violations));
+        return op;
+      }
+    }
 
     // No ID = create
     if (!workflow.id) {
@@ -459,6 +500,21 @@ export class Executor {
       // Don't throw - activation failure is not a workflow update failure
     }
   }
+}
+
+/**
+ * Builds the multi-line error message used when lint blocks a workflow.
+ * Mirrors the layout of `n8n-cli lint` text output so users see the same
+ * `file:line: severity[rule]: message` shape they would when running lint
+ * standalone.
+ */
+function buildLintErrorMessage(filePath: string, violations: Violation[]): string {
+  const errorOnly = violations.filter((v) => v.severity === "error" || !v.severity);
+  const lines = errorOnly.map((v) => formatViolationLine(filePath, v));
+  const summary = `lint check failed (${errorOnly.length} error${
+    errorOnly.length === 1 ? "" : "s"
+  }); pass --no-lint to bypass`;
+  return [summary, ...lines].join("\n  ");
 }
 
 /** Updates the local workflow file with server response data. */

--- a/src/apply/reporter.ts
+++ b/src/apply/reporter.ts
@@ -19,6 +19,12 @@ export function report(result: ApplyResult): void {
     printWarningsSection(result.warnings);
   }
 
+  // Surface lint warnings that survived the gate (error-level violations were
+  // already promoted to operation=error and are printed by the ERROR section).
+  // Warnings would otherwise be silently dropped — the gate computes them but
+  // does not block, so without this section the user sees no diagnostic.
+  printLintWarningsSection(result.operations);
+
   // Group operations by type
   const creates = filterByOp(result.operations, "create");
   const updates = filterByOp(result.operations, "update");
@@ -33,6 +39,24 @@ export function report(result: ApplyResult): void {
   if (errors.length > 0) printErrorSection(errors);
 
   printSummary(result);
+}
+
+function printLintWarningsSection(ops: ApplyOperation[]): void {
+  const warnings: Array<{ file: string; rule: string; message: string }> = [];
+  for (const op of ops) {
+    if (op.operation === "error") continue; // already shown in ERROR section
+    if (!op.lintViolations) continue;
+    for (const v of op.lintViolations) {
+      if (v.severity === "warning") {
+        warnings.push({ file: op.file, rule: v.rule, message: v.message });
+      }
+    }
+  }
+  if (warnings.length === 0) return;
+  console.log(`\n=== LINT WARNINGS (${warnings.length}) ===`);
+  for (const w of warnings) {
+    console.log(`  ⚠ ${path.basename(w.file)}: warning[${w.rule}]: ${w.message}`);
+  }
 }
 
 function filterByOp(ops: ApplyOperation[], type: OperationType): ApplyOperation[] {

--- a/src/apply/types.ts
+++ b/src/apply/types.ts
@@ -1,4 +1,5 @@
 import type { Workflow } from "../api/types.ts";
+import type { Violation } from "../lint/rules/violation.ts";
 
 /** OperationType represents the type of operation to perform on a workflow. */
 export type OperationType = "create" | "update" | "skip" | "conflict" | "error";
@@ -29,6 +30,23 @@ export interface ApplyOptions {
    * Set true to disable the check entirely.
    */
   allowDuplicates: boolean;
+  /**
+   * When true, skip the pre-write lint check that runs against every local
+   * workflow before it is created or updated upstream.
+   *
+   * Default false (check ON): the same rule set used by `n8n-cli lint` runs
+   * against each workflow about to be written. Any `error`-severity violation
+   * marks that workflow as failed and prevents the API call — the apply
+   * continues with the remaining workflows so a partial run still reports
+   * everything in one pass. Set true to disable the check entirely; this
+   * cannot be silenced by `--force` because lint failures represent policy,
+   * not merge conflicts.
+   */
+  noLint: boolean;
+  /** Optional override for the lint config path (auto-discovered when empty). */
+  lintConfigPath?: string;
+  /** Rule names disabled via CLI flag, forwarded to the lint registry. */
+  lintDisableRules: string[];
   filterByTags: string[];
 }
 
@@ -48,6 +66,8 @@ export function defaultApplyOptions(): ApplyOptions {
     yamlEnabled: false,
     noYaml: false,
     allowDuplicates: false,
+    noLint: false,
+    lintDisableRules: [],
     filterByTags: [],
   };
 }
@@ -86,6 +106,12 @@ export interface ApplyOperation {
   baseToRemoteFields: string[];
   activated?: boolean; // true: activated, false: deactivated, undefined: no change
   activationError?: Error; // activation/deactivation error
+  /**
+   * Violations surfaced by the pre-write lint check, when one ran. Present on
+   * both blocked (operation === "error") and passing operations so callers
+   * can surface warnings without forcing a re-lint.
+   */
+  lintViolations?: Violation[];
 }
 
 /** Creates a default ApplyOperation. */

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -9,6 +9,7 @@ import {
   getEffectiveYamlEnabled,
   loadCLIConfig,
 } from "../../config/claude-md.ts";
+import { LintConfigLoadError } from "../../lint/write-check.ts";
 import { resolveContext } from "../root.ts";
 
 export function registerApplyCommand(program: Command): void {
@@ -35,6 +36,18 @@ export function registerApplyCommand(program: Command): void {
       "--allow-duplicates",
       "Skip the upstream duplicate-name check (the check is on by default; use --force to push through warnings without disabling the check)",
     )
+    .option(
+      "--no-lint",
+      "Skip the pre-write lint check (the check is on by default; --force does NOT bypass it because lint failures are policy, not merge conflicts)",
+    )
+    .option(
+      "--lint-config <path>",
+      "Path to .n8nlintrc.json for the pre-write lint check (auto-discovered if omitted)",
+    )
+    .option(
+      "--lint-disable-rule <rules>",
+      "Comma-separated rule names to disable during the pre-write lint check",
+    )
     .action(async (options, command) => {
       const ctx = resolveContext(command.parent!);
 
@@ -45,6 +58,18 @@ export function registerApplyCommand(program: Command): void {
       opts.force = !!options.force;
       opts.noAutoTag = !!options.noAutoTag;
       opts.allowDuplicates = !!options.allowDuplicates;
+      // commander's `--no-lint` flips `options.lint` to false. When the flag is
+      // not passed, `options.lint` is undefined and the check stays ON.
+      opts.noLint = options.lint === false;
+      if (typeof options.lintConfig === "string") {
+        opts.lintConfigPath = options.lintConfig;
+      }
+      if (typeof options.lintDisableRule === "string") {
+        opts.lintDisableRules = (options.lintDisableRule as string)
+          .split(",")
+          .map((r) => r.trim())
+          .filter((r) => r.length > 0);
+      }
 
       if (options.yaml === true) opts.yamlEnabled = true;
       if (options.yaml === false) opts.noYaml = true;
@@ -112,8 +137,21 @@ export function registerApplyCommand(program: Command): void {
       // Apply YAML settings
       opts.yamlEnabled = getEffectiveYamlEnabled(opts.yamlEnabled, opts.noYaml, cliConfig);
 
-      // Create executor
-      const executor = new Executor(ctx.workflowService, opts);
+      // Create executor. The constructor may throw `LintConfigLoadError` when
+      // `.n8nlintrc.json` is malformed; surface it with a friendly message
+      // instead of a raw SyntaxError stack so users know the fix is in the
+      // config file (or to pass --no-lint as a temporary bypass).
+      let executor: Executor;
+      try {
+        executor = new Executor(ctx.workflowService, opts);
+      } catch (err) {
+        if (err instanceof LintConfigLoadError) {
+          console.error(`Error: ${err.message}`);
+          console.error("Fix the config file, or pass --no-lint to bypass the pre-write check.");
+          process.exit(1);
+        }
+        throw err;
+      }
       executor.setTagService(ctx.tagService);
 
       // Display Git diff mode message if enabled

--- a/src/cli/commands/workflow-create.ts
+++ b/src/cli/commands/workflow-create.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
-import type { Workflow } from "../../api/types.ts";
+import type { Workflow, WorkflowInput } from "../../api/types.ts";
 import { readWorkflowInput } from "../../input/reader.ts";
+import { runPreWriteLintGate } from "../../lint/cli-gate.ts";
 import { formatJSON } from "../output/json.ts";
 import { formatKeyValue } from "../output/table.ts";
 import { resolveContext } from "../root.ts";
@@ -10,10 +11,49 @@ export function registerCreateCommand(parent: Command): void {
     .command("create")
     .description("Create a new workflow")
     .requiredOption("-f, --file <path>", "Path to workflow JSON file (use - for stdin)")
+    .option(
+      "--no-lint",
+      "Skip the pre-write lint check (the check is on by default; pass to bypass on a one-off basis)",
+    )
+    .option(
+      "--lint-config <path>",
+      "Path to .n8nlintrc.json for the pre-write lint check (auto-discovered if omitted)",
+    )
+    .option(
+      "--lint-disable-rule <rules>",
+      "Comma-separated rule names to disable during the pre-write lint check",
+    )
     .action(async (options, command) => {
       const ctx = resolveContext(command.parent?.parent!);
 
-      const input = await readWorkflowInput(options.file as string);
+      // `readWorkflowInput` runs `validateWorkflowInput`, which throws raw
+      // Errors for missing name/nodes/connections. Those overlap with the
+      // lint `required-fields` rule. Re-frame as a CLI error so the user
+      // gets a consistent message (and the `--no-lint` hint isn't needed
+      // here because validation guards write integrity, not lint policy).
+      let input: WorkflowInput;
+      try {
+        input = await readWorkflowInput(options.file as string);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Error: ${options.file as string}: ${message}`);
+        process.exit(1);
+      }
+
+      runPreWriteLintGate({
+        source: options.file as string,
+        workflow: input,
+        noLint: options.lint === false,
+        configPath: typeof options.lintConfig === "string" ? options.lintConfig : undefined,
+        disableRules:
+          typeof options.lintDisableRule === "string"
+            ? (options.lintDisableRule as string)
+                .split(",")
+                .map((r) => r.trim())
+                .filter((r) => r.length > 0)
+            : undefined,
+      });
+
       const workflow = await ctx.workflowService.createWorkflow(input);
 
       console.log("Workflow created successfully");

--- a/src/cli/commands/workflow-update.ts
+++ b/src/cli/commands/workflow-update.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
-import type { Workflow } from "../../api/types.ts";
+import type { Workflow, WorkflowInput } from "../../api/types.ts";
 import { readWorkflowInput } from "../../input/reader.ts";
+import { runPreWriteLintGate } from "../../lint/cli-gate.ts";
 import { formatJSON } from "../output/json.ts";
 import { formatKeyValue } from "../output/table.ts";
 import { resolveContext } from "../root.ts";
@@ -12,15 +13,41 @@ export function registerUpdateCommand(parent: Command): void {
     .argument("[id]", "Workflow ID (optional if JSON file contains 'id' field)")
     .requiredOption("-f, --file <path>", "Path to workflow JSON file (use - for stdin)")
     .option("--force", "Force update even if remote has been modified")
+    .option(
+      "--no-lint",
+      "Skip the pre-write lint check (the check is on by default; pass to bypass on a one-off basis)",
+    )
+    .option(
+      "--lint-config <path>",
+      "Path to .n8nlintrc.json for the pre-write lint check (auto-discovered if omitted)",
+    )
+    .option(
+      "--lint-disable-rule <rules>",
+      "Comma-separated rule names to disable during the pre-write lint check",
+    )
     .action(async (id: string | undefined, options, command) => {
       const ctx = resolveContext(command.parent?.parent!);
 
-      const input = await readWorkflowInput(options.file as string);
+      // Catch reader validation errors and surface them as CLI errors so
+      // missing-required-field cases produce a consistent message instead of
+      // a raw stack trace. See workflow-create.ts for the same pattern.
+      let input: WorkflowInput;
+      try {
+        input = await readWorkflowInput(options.file as string);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Error: ${options.file as string}: ${message}`);
+        process.exit(1);
+      }
 
-      // Resolve workflow ID: argument > file content
+      // Resolve workflow ID: argument > file content.
+      // Defer the "Using workflow ID from file" log until AFTER the lint gate
+      // — otherwise a lint failure prints that line first and reads as
+      // "update started, then failed" to humans and stdout scrapers, when in
+      // reality nothing was sent upstream.
       let workflowID = id;
+      let workflowIDFromFile = false;
       if (!workflowID) {
-        // Try to get ID from the raw file data
         const rawData = await readRawID(options.file as string);
         if (!rawData) {
           console.error(
@@ -29,6 +56,24 @@ export function registerUpdateCommand(parent: Command): void {
           process.exit(1);
         }
         workflowID = rawData;
+        workflowIDFromFile = true;
+      }
+
+      runPreWriteLintGate({
+        source: options.file as string,
+        workflow: input,
+        noLint: options.lint === false,
+        configPath: typeof options.lintConfig === "string" ? options.lintConfig : undefined,
+        disableRules:
+          typeof options.lintDisableRule === "string"
+            ? (options.lintDisableRule as string)
+                .split(",")
+                .map((r) => r.trim())
+                .filter((r) => r.length > 0)
+            : undefined,
+      });
+
+      if (workflowIDFromFile) {
         console.log(`Using workflow ID from file: ${workflowID}`);
       }
 

--- a/src/lint/cli-gate.ts
+++ b/src/lint/cli-gate.ts
@@ -1,0 +1,73 @@
+import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import {
+  checkWorkflowForWrite,
+  formatViolationLine,
+  LintConfigLoadError,
+  prepareWriteLintContext,
+} from "./write-check.ts";
+
+/** Arguments accepted by `runPreWriteLintGate`. */
+export interface PreWriteLintGateOptions {
+  /** Display label for the workflow source (file path or `-` for stdin). */
+  source: string;
+  /** Parsed workflow payload about to be written. */
+  workflow: Workflow | WorkflowInput;
+  /** When true, bypass the check entirely. Mirrors a `--no-lint` flag. */
+  noLint?: boolean;
+  /** Optional `.n8nlintrc.json` path; auto-discovered when omitted. */
+  configPath?: string;
+  /** Rule names to disable for this run. */
+  disableRules?: string[];
+}
+
+/**
+ * CLI-side gate for single-workflow write commands (`workflow create`,
+ * `workflow update`).
+ *
+ * The gate is ON by default and exits the process with code 1 on the first
+ * error-level violation, so the API call never fires. Warnings are surfaced
+ * but do not block. Pass `noLint: true` to skip.
+ *
+ * The exit code path is intentional: these commands are leaf actions, not
+ * batch runs, so there is no point continuing past a lint failure to compute
+ * a "partial" outcome — the caller would just have to re-run anyway.
+ */
+export function runPreWriteLintGate(options: PreWriteLintGateOptions): void {
+  if (options.noLint) return;
+
+  let ctx: ReturnType<typeof prepareWriteLintContext>;
+  try {
+    ctx = prepareWriteLintContext(options.configPath, options.disableRules);
+  } catch (err) {
+    if (err instanceof LintConfigLoadError) {
+      console.error(`Error: ${err.message}`);
+      console.error("Fix the config file, or pass --no-lint to bypass the pre-write check.");
+      process.exit(1);
+    }
+    throw err;
+  }
+  const result = checkWorkflowForWrite(options.workflow, undefined, ctx);
+
+  const warnings = result.violations.filter((v) => v.severity === "warning");
+  if (warnings.length > 0) {
+    for (const v of warnings) {
+      console.error(formatViolationLine(options.source, v));
+    }
+  }
+
+  if (!result.hasErrors) return;
+
+  const errors = result.violations.filter((v) => v.severity === "error" || !v.severity);
+  console.error(
+    `Lint check failed for ${options.source} (${errors.length} error${
+      errors.length === 1 ? "" : "s"
+    }). The workflow was NOT written upstream.`,
+  );
+  for (const v of errors) {
+    console.error(`  ${formatViolationLine(options.source, v)}`);
+  }
+  console.error(
+    "Run `n8n-cli lint -f <file>` to iterate locally, or pass --no-lint to bypass once.",
+  );
+  process.exit(1);
+}

--- a/src/lint/write-check.ts
+++ b/src/lint/write-check.ts
@@ -1,0 +1,136 @@
+import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import { findConfigFile, type LintConfig, loadLintConfig } from "./config.ts";
+import { lintWorkflow } from "./engine.ts";
+import type { RuleWithConfig } from "./registry.ts";
+import { registerDefaultRules } from "./rules/index.ts";
+import type { Violation } from "./rules/violation.ts";
+
+/**
+ * Outcome of a pre-write lint check on a single workflow payload.
+ *
+ * `hasErrors` is the gate that callers use to decide whether to refuse the
+ * write. `violations` carries all severities so warnings can be surfaced
+ * even when the check passes.
+ */
+export interface WriteLintCheckResult {
+  violations: Violation[];
+  hasErrors: boolean;
+}
+
+/**
+ * Pre-resolved lint context shared across multiple workflows in a single
+ * command invocation. Built once by `prepareWriteLintContext` so that config
+ * lookup and rule registration are not repeated per file.
+ */
+export interface WriteLintContext {
+  rules: RuleWithConfig[];
+  config: LintConfig | null;
+  configPath?: string;
+}
+
+/**
+ * Thrown by `prepareWriteLintContext` when `.n8nlintrc.json` cannot be parsed
+ * or has an invalid rule-config entry. Carries the resolved config path so
+ * callers can print a friendly message instead of leaking the raw
+ * `SyntaxError` / `Error` from the JSON parser.
+ *
+ * Distinct error class so callers can `instanceof`-check and decide whether
+ * to surface the bypass hint (`--no-lint`).
+ */
+export class LintConfigLoadError extends Error {
+  readonly configPath?: string;
+  constructor(configPath: string | undefined, cause: unknown) {
+    const causeMsg = cause instanceof Error ? cause.message : String(cause);
+    const where = configPath ? ` (${configPath})` : "";
+    super(`Failed to load lint config${where}: ${causeMsg}`);
+    this.name = "LintConfigLoadError";
+    this.configPath = configPath;
+  }
+}
+
+/**
+ * Builds a write-time lint context: resolves the `.n8nlintrc.json` config and
+ * the set of enabled rules. `disableRules` lets callers honour CLI flags such
+ * as `--disable-rule`. `startDir` overrides the discovery root (default
+ * `process.cwd()`) so batch callers can anchor lookup at e.g. `apply --dir`.
+ *
+ * Throws `LintConfigLoadError` when the config file exists but is malformed;
+ * callers should catch and either surface a friendly error or bail out. We
+ * intentionally do NOT swallow the error here — falling back to defaults
+ * would silently drop user-defined rule overrides, which is worse than
+ * loudly failing.
+ */
+export function prepareWriteLintContext(
+  configPath?: string,
+  disableRules?: string[],
+  startDir?: string,
+): WriteLintContext {
+  const resolvedPath = configPath ?? findConfigFile(startDir ?? process.cwd());
+  let config: LintConfig | null;
+  try {
+    config = loadLintConfig(resolvedPath);
+  } catch (err) {
+    throw new LintConfigLoadError(resolvedPath, err);
+  }
+  const registry = registerDefaultRules();
+  const rules = registry.enabledRulesWithConfig(config, disableRules);
+  return { rules, config, configPath: resolvedPath };
+}
+
+/**
+ * Runs the linter against a workflow about to be written upstream.
+ *
+ * `rawJSON` is reused as-is when available so line-aware rules can locate
+ * offending spans. When the caller only has a parsed workflow (e.g. from
+ * `WorkflowInput`) we stringify it as a best-effort fallback.
+ *
+ * Mirrors the defensive try/catch in `src/proxy/enforcer.ts` so a single
+ * misbehaving rule cannot crash the calling command. A thrown rule is
+ * downgraded to a synthetic `linter-internal-error` violation: the workflow
+ * is still blocked (defensive default), but the apply/CLI command can
+ * continue processing other workflows and the user sees an actionable
+ * message instead of a stack trace.
+ */
+export function checkWorkflowForWrite(
+  workflow: Workflow | WorkflowInput | null,
+  rawJSON: string | undefined,
+  ctx: WriteLintContext,
+): WriteLintCheckResult {
+  const payload = rawJSON ?? (workflow ? JSON.stringify(workflow) : "");
+  let violations: Violation[];
+  try {
+    violations = lintWorkflow(workflow as Workflow | null, payload, ctx.rules, ctx.config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    violations = [
+      {
+        rule: "linter-internal-error",
+        severity: "error",
+        message: `Linter threw an exception while evaluating this workflow: ${message}`,
+      },
+    ];
+  }
+  const hasErrors = violations.some((v) => v.severity === "error" || !v.severity);
+  return { violations, hasErrors };
+}
+
+/**
+ * Formats a single violation as a one-line human-readable message. The shape
+ * matches `formatText` in `lint/output/text.ts` minus the trailing summary,
+ * so output is consistent whether the user runs `lint` or sees a pre-write
+ * failure.
+ */
+export function formatViolationLine(file: string, v: Violation): string {
+  let location: string;
+  if (v.line && v.line > 0) {
+    if (v.column && v.column > 0) {
+      location = `${file}:${v.line}:${v.column}`;
+    } else {
+      location = `${file}:${v.line}`;
+    }
+  } else {
+    location = file;
+  }
+  const severityLabel = v.severity === "warning" ? "warning" : "error";
+  return `${location}: ${severityLabel}[${v.rule}]: ${v.message}`;
+}

--- a/tests/apply/lint-check.test.ts
+++ b/tests/apply/lint-check.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import type { WorkflowService } from "@/api/workflow-service.ts";
+import { Executor } from "@/apply/executor.ts";
+import { type ApplyOptions, defaultApplyOptions } from "@/apply/types.ts";
+
+/**
+ * Tracks API mutations so tests can assert that lint failures actually
+ * short-circuit the write — not just the operation type, but the underlying
+ * API call. A blocked workflow must produce zero create/update calls.
+ */
+interface MockCalls {
+  creates: WorkflowInput[];
+  updates: Array<{ id: string; input: WorkflowInput }>;
+}
+
+function mockWorkflowService(opts: { existing?: Workflow[] } = {}): {
+  service: WorkflowService;
+  calls: MockCalls;
+} {
+  const calls: MockCalls = { creates: [], updates: [] };
+  const existingById = new Map<string, Workflow>();
+  for (const wf of opts.existing ?? []) {
+    if (wf.id) existingById.set(wf.id, wf);
+  }
+  const service = {
+    listAllWorkflows: async () => opts.existing ?? [],
+    getWorkflow: async (id: string) => {
+      const wf = existingById.get(id);
+      if (!wf) {
+        const err = new Error("not found") as Error & { status?: number };
+        err.status = 404;
+        throw err;
+      }
+      return wf;
+    },
+    createWorkflow: async (input: WorkflowInput) => {
+      calls.creates.push(input);
+      return { ...(input as object), id: "new-id" } as Workflow;
+    },
+    updateWorkflow: async (id: string, input: WorkflowInput) => {
+      calls.updates.push({ id, input });
+      return { ...(input as object), id } as Workflow;
+    },
+    getWorkflowCurrentProjectID: () => "",
+  } as unknown as WorkflowService;
+  return { service, calls };
+}
+
+/** Workflow with a connection referencing a missing node — triggers the
+ *  default-error `connection-reference` rule. */
+function badWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    name: "broken-wf",
+    active: false,
+    nodes: [
+      {
+        id: "n1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0],
+      },
+    ],
+    connections: {
+      Start: {
+        main: [[{ node: "MissingNode", type: "main", index: 0 }]],
+      },
+    },
+    ...overrides,
+  };
+}
+
+/** Clean workflow — no lint violations. */
+function goodWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    name: "clean-wf",
+    active: false,
+    nodes: [
+      {
+        id: "n1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0],
+      },
+    ],
+    connections: {},
+    ...overrides,
+  };
+}
+
+describe("apply pre-write lint check", () => {
+  let tmpDir: string;
+  let opts: ApplyOptions;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "apply-lint-test-"));
+    opts = {
+      ...defaultApplyOptions(),
+      directory: tmpDir,
+      all: true,
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("blocks create when local workflow has error-level lint violation", async () => {
+    const file = path.join(tmpDir, "broken.json");
+    fs.writeFileSync(file, JSON.stringify(badWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, opts).execute();
+
+    expect(result.errorCount).toBe(1);
+    expect(result.operations[0]?.operation).toBe("error");
+    expect(result.operations[0]?.error?.message).toContain("lint check failed");
+    expect(result.operations[0]?.error?.message).toContain("connection-reference");
+    expect(calls.creates).toHaveLength(0);
+  });
+
+  test("passes clean workflow through to create", async () => {
+    const file = path.join(tmpDir, "clean.json");
+    fs.writeFileSync(file, JSON.stringify(goodWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, opts).execute();
+
+    expect(result.errorCount).toBe(0);
+    expect(result.createCount).toBe(1);
+    expect(calls.creates).toHaveLength(1);
+  });
+
+  test("--no-lint (noLint=true) skips the gate and forwards the broken workflow", async () => {
+    const file = path.join(tmpDir, "broken.json");
+    fs.writeFileSync(file, JSON.stringify(badWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, { ...opts, noLint: true }).execute();
+
+    expect(result.errorCount).toBe(0);
+    expect(result.createCount).toBe(1);
+    expect(calls.creates).toHaveLength(1);
+  });
+
+  test("--force does NOT bypass lint failures (policy, not merge conflict)", async () => {
+    const file = path.join(tmpDir, "broken.json");
+    fs.writeFileSync(file, JSON.stringify(badWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, { ...opts, force: true }).execute();
+
+    expect(result.errorCount).toBe(1);
+    expect(calls.creates).toHaveLength(0);
+  });
+
+  test("dry-run also surfaces lint errors without writing", async () => {
+    const file = path.join(tmpDir, "broken.json");
+    fs.writeFileSync(file, JSON.stringify(badWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, { ...opts, dryRun: true }).execute();
+
+    expect(result.errorCount).toBe(1);
+    expect(result.operations[0]?.operation).toBe("error");
+    expect(calls.creates).toHaveLength(0);
+  });
+
+  test("lintDisableRules turns off the failing rule and lets the apply pass", async () => {
+    const file = path.join(tmpDir, "broken.json");
+    fs.writeFileSync(file, JSON.stringify(badWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, {
+      ...opts,
+      lintDisableRules: ["connection-reference"],
+    }).execute();
+
+    expect(result.errorCount).toBe(0);
+    expect(result.createCount).toBe(1);
+    expect(calls.creates).toHaveLength(1);
+  });
+
+  test("mixes blocked and clean workflows in one apply (partial run)", async () => {
+    fs.writeFileSync(path.join(tmpDir, "broken.json"), JSON.stringify(badWorkflow()));
+    fs.writeFileSync(path.join(tmpDir, "clean.json"), JSON.stringify(goodWorkflow()));
+
+    const { service, calls } = mockWorkflowService();
+    const result = await new Executor(service, opts).execute();
+
+    expect(result.errorCount).toBe(1);
+    expect(result.createCount).toBe(1);
+    expect(calls.creates).toHaveLength(1);
+    expect(calls.creates[0]?.name).toBe("clean-wf");
+  });
+
+  // Regression test: warning-level lint violations were being attached to
+  // `op.lintViolations` but never read by the reporter. Verify the field is
+  // populated so the reporter can surface it.
+  test("warning-level violations are recorded on op.lintViolations (not silently dropped)", async () => {
+    // Workflow that triggers `orphaned-node` (default severity: warning).
+    // An orphaned node has no incoming and no outgoing connections AND is
+    // not a trigger node type. Use a non-trigger node to ensure the rule
+    // fires.
+    const wf: Workflow = {
+      name: "warn-wf",
+      active: false,
+      nodes: [
+        {
+          id: "n1",
+          name: "Set",
+          type: "n8n-nodes-base.set",
+          typeVersion: 1,
+          position: [0, 0],
+        },
+      ],
+      connections: {},
+    };
+    fs.writeFileSync(path.join(tmpDir, "warn.json"), JSON.stringify(wf));
+
+    const { service } = mockWorkflowService();
+    const result = await new Executor(service, opts).execute();
+
+    expect(result.errorCount).toBe(0);
+    expect(result.createCount).toBe(1);
+    const op = result.operations[0];
+    expect(op?.lintViolations).toBeDefined();
+    // At least one warning should be present (orphaned-node).
+    const warns = op?.lintViolations?.filter((v) => v.severity === "warning") ?? [];
+    expect(warns.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/cli/apply-lint-check.test.ts
+++ b/tests/cli/apply-lint-check.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import type { Workflow } from "@/api/types.ts";
+
+/**
+ * End-to-end CLI test for `apply` pre-write lint enforcement. Verifies that
+ * the `--no-lint` flag flows from the CLI parser into the executor and that
+ * the default-on check actually rejects broken workflows.
+ *
+ * Uses an in-process mock upstream so we can also assert that the API is
+ * never hit when lint blocks.
+ */
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+}
+
+function startMockUpstream(): {
+  port: number;
+  captured: CapturedRequest[];
+  stop: () => Promise<void>;
+} {
+  const captured: CapturedRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      captured.push({ method: req.method, pathname: url.pathname });
+
+      // workflow list (for duplicate-name check) → empty array. The CLI
+      // talks to `/api/v1/workflows`; we match the suffix so the mock is
+      // independent of the configured base path. We branch on method first
+      // so the create POST handler can return a full workflow.
+      if (req.method === "GET") {
+        return new Response(JSON.stringify({ data: [], nextCursor: null }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          id: "wf-new",
+          name: "broken-wf",
+          active: false,
+          nodes: [],
+          connections: {},
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  return {
+    port: server.port!,
+    captured,
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+async function runCli(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", CLI_ENTRY, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+/** Connection target points at a missing node → triggers connection-reference. */
+function brokenWorkflow(): Workflow {
+  return {
+    name: "broken-wf",
+    active: false,
+    nodes: [
+      {
+        id: "n1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0],
+      },
+    ],
+    connections: {
+      Start: {
+        main: [[{ node: "MissingNode", type: "main", index: 0 }]],
+      },
+    },
+  };
+}
+
+describe("apply --no-lint flag", () => {
+  let tmpDir: string;
+  let upstream: ReturnType<typeof startMockUpstream>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "apply-lint-cli-test-"));
+    upstream = startMockUpstream();
+  });
+
+  afterEach(async () => {
+    await upstream.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("default-on lint rejects broken workflow and skips the create call", async () => {
+    fs.writeFileSync(path.join(tmpDir, "wf.json"), JSON.stringify(brokenWorkflow()));
+
+    const { stdout, exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "apply",
+      "--dir",
+      tmpDir,
+      "--dangerously-apply-all",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("lint check failed");
+    // The duplicate-name check may pre-list workflows, but no POST should
+    // hit /workflows.
+    const mutations = upstream.captured.filter((r) => r.method === "POST" || r.method === "PUT");
+    expect(mutations).toHaveLength(0);
+  });
+
+  test("--no-lint flows through and forwards the broken workflow", async () => {
+    fs.writeFileSync(path.join(tmpDir, "wf.json"), JSON.stringify(brokenWorkflow()));
+
+    const { stdout, stderr, exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "apply",
+      "--dir",
+      tmpDir,
+      "--dangerously-apply-all",
+      "--no-lint",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout + stderr).not.toContain("lint check failed");
+    const mutations = upstream.captured.filter((r) => r.method === "POST" || r.method === "PUT");
+    expect(mutations.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/cli/workflow-lint-check.test.ts
+++ b/tests/cli/workflow-lint-check.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import type { Workflow } from "@/api/types.ts";
+
+/**
+ * CLI integration tests for `workflow create` and `workflow update` pre-write
+ * lint check. The check is ON by default and refuses to call the API when an
+ * error-level rule fires; `--no-lint` is the explicit escape hatch.
+ *
+ * The tests spawn the CLI against a tiny in-process upstream so we can verify
+ * that blocked invocations actually skip the upstream call (no captured
+ * request), not just that the CLI exited nonzero.
+ */
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  body: string;
+}
+
+function startMockUpstream(): {
+  port: number;
+  captured: CapturedRequest[];
+  stop: () => Promise<void>;
+} {
+  const captured: CapturedRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      captured.push({ method: req.method, pathname: url.pathname, body });
+      // Return a minimal workflow response so the CLI prints success.
+      return new Response(
+        JSON.stringify({
+          id: "wf-new",
+          name: "Test",
+          active: false,
+          nodes: [],
+          connections: {},
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  return {
+    port: server.port!,
+    captured,
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", CLI_ENTRY, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+function brokenWorkflowJson(): Workflow {
+  return {
+    name: "broken-wf",
+    active: false,
+    nodes: [
+      {
+        id: "n1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0],
+      },
+    ],
+    // Connection target "MissingNode" is not in nodes — triggers
+    // `connection-reference` (default severity: error).
+    connections: {
+      Start: {
+        main: [[{ node: "MissingNode", type: "main", index: 0 }]],
+      },
+    },
+  };
+}
+
+function cleanWorkflowJson(): Workflow {
+  return {
+    name: "clean-wf",
+    active: false,
+    nodes: [
+      {
+        id: "n1",
+        name: "Start",
+        type: "n8n-nodes-base.start",
+        typeVersion: 1,
+        position: [0, 0],
+      },
+    ],
+    connections: {},
+  };
+}
+
+describe("workflow create/update pre-write lint check", () => {
+  let tmpDir: string;
+  let upstream: ReturnType<typeof startMockUpstream>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-lint-cli-test-"));
+    upstream = startMockUpstream();
+  });
+
+  afterEach(async () => {
+    await upstream.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("workflow create: blocks broken workflow by default, no upstream call", async () => {
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(brokenWorkflowJson()));
+
+    const { stderr, exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "create",
+      "-f",
+      file,
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Lint check failed");
+    expect(stderr).toContain("connection-reference");
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("workflow create: --no-lint bypasses the check and reaches upstream", async () => {
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(brokenWorkflowJson()));
+
+    const { exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "create",
+      "-f",
+      file,
+      "--no-lint",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]?.method).toBe("POST");
+  });
+
+  test("workflow create: clean workflow passes without --no-lint", async () => {
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(cleanWorkflowJson()));
+
+    const { exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "create",
+      "-f",
+      file,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(upstream.captured).toHaveLength(1);
+  });
+
+  test("workflow update: blocks broken workflow by default", async () => {
+    const wf = brokenWorkflowJson();
+    wf.id = "wf-existing";
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(wf));
+
+    const { stderr, exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "update",
+      "wf-existing",
+      "-f",
+      file,
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Lint check failed");
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("workflow update: --no-lint bypasses and reaches upstream", async () => {
+    const wf = brokenWorkflowJson();
+    wf.id = "wf-existing";
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(wf));
+
+    const { exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "update",
+      "wf-existing",
+      "-f",
+      file,
+      "--no-lint",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]?.method).toBe("PUT");
+  });
+
+  // Regression test for the variadic-positional collision found in code
+  // review. `--lint-disable-rule` is now scalar (comma-separated), so the
+  // positional ID is never swallowed even when both are passed.
+  test("workflow update: --lint-disable-rule does NOT swallow the positional id", async () => {
+    const wf = brokenWorkflowJson();
+    wf.id = "wf-from-file";
+    const file = path.join(tmpDir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify(wf));
+
+    const { exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "update",
+      "--lint-disable-rule",
+      "connection-reference",
+      "wf-intended",
+      "-f",
+      file,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(upstream.captured).toHaveLength(1);
+    // The PUT must target the positional id, not the file id.
+    expect(upstream.captured[0]?.pathname).toContain("wf-intended");
+    expect(upstream.captured[0]?.pathname).not.toContain("wf-from-file");
+  });
+
+  // Regression test for the validate-before-lint raw error. A workflow
+  // missing required fields used to surface as a raw stack trace; it now
+  // produces a CLI-style `Error: ... workflow ... is required` message.
+  test("workflow create: missing-field error is wrapped in a friendly CLI message", async () => {
+    const file = path.join(tmpDir, "wf.json");
+    // Missing `connections`.
+    fs.writeFileSync(file, JSON.stringify({ name: "x", nodes: [] }));
+
+    const { stderr, exitCode } = await runCli([
+      "--api-url",
+      `http://127.0.0.1:${upstream.port}`,
+      "--api-key",
+      "dummy",
+      "workflow",
+      "create",
+      "-f",
+      file,
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Error:");
+    expect(stderr).toContain("connections");
+    expect(upstream.captured).toHaveLength(0);
+  });
+});

--- a/tests/lint/write-check-defense.test.ts
+++ b/tests/lint/write-check-defense.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import {
+  checkWorkflowForWrite,
+  LintConfigLoadError,
+  prepareWriteLintContext,
+} from "@/lint/write-check.ts";
+
+/**
+ * Defensive-path tests for the write-time lint helpers. Covers the two
+ * regressions that the xhigh-effort code review surfaced:
+ *
+ *   - a malformed `.n8nlintrc.json` must produce a typed `LintConfigLoadError`
+ *     (not a raw `SyntaxError`) so callers can present a friendly message
+ *   - a rule that throws must NOT crash the calling command; it must be
+ *     downgraded to a synthetic `linter-internal-error` violation, mirroring
+ *     `src/proxy/enforcer.ts`
+ *
+ * Also pins the `startDir` discovery anchor so `apply --dir workflows/` can
+ * pick up an in-tree `.n8nlintrc.json`.
+ */
+
+function goodWorkflow(): Workflow {
+  return {
+    name: "wf",
+    active: false,
+    nodes: [],
+    connections: {},
+  };
+}
+
+describe("prepareWriteLintContext defensive paths", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "write-check-defense-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("LintConfigLoadError is thrown when the explicit configPath is malformed JSON", () => {
+    const badPath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(badPath, "{ this is not json");
+
+    expect(() => prepareWriteLintContext(badPath)).toThrow(LintConfigLoadError);
+  });
+
+  test("LintConfigLoadError carries the resolved configPath and original message", () => {
+    const badPath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(badPath, '{ "rules": { "x": "wat" } }');
+
+    try {
+      prepareWriteLintContext(badPath);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LintConfigLoadError);
+      const e = err as LintConfigLoadError;
+      expect(e.configPath).toBe(badPath);
+      expect(e.message).toContain(badPath);
+    }
+  });
+
+  test("startDir anchors auto-discovery so an in-tree config wins over cwd", () => {
+    // The CLI is invoked from process.cwd(), but apply passes the workflow
+    // directory in. Putting the config under the workflow dir must take
+    // priority — and the call must succeed.
+    const workflowDir = path.join(tmpDir, "workflows");
+    fs.mkdirSync(workflowDir, { recursive: true });
+    const cfgPath = path.join(workflowDir, ".n8nlintrc.json");
+    fs.writeFileSync(cfgPath, JSON.stringify({ rules: { "required-fields": "off" } }));
+
+    const ctx = prepareWriteLintContext(undefined, undefined, workflowDir);
+    expect(ctx.configPath).toBe(cfgPath);
+    // The disabled rule must not appear in the resolved rule list.
+    expect(ctx.rules.some((r) => r.rule.name === "required-fields")).toBe(false);
+  });
+
+  test("absent config is not an error; defaults are used", () => {
+    // findConfigFile walks to filesystem root from startDir. If no
+    // .n8nlintrc.json is discovered we fall through to defaults.
+    const ctx = prepareWriteLintContext(undefined, undefined, tmpDir);
+    // Some rule should still be in play with defaults.
+    expect(ctx.rules.length).toBeGreaterThan(0);
+  });
+});
+
+describe("checkWorkflowForWrite defensive paths", () => {
+  test("a rule that throws is downgraded to linter-internal-error rather than crashing the caller", () => {
+    // Build a context with exactly one rule that explodes. We do this by
+    // forging a `WriteLintContext` so the test stays isolated from rule
+    // registry churn.
+    const ctx = {
+      rules: [
+        {
+          rule: {
+            name: "boom",
+            description: "always throws",
+            defaultSeverity: "error" as const,
+            check() {
+              throw new TypeError("kaboom");
+            },
+          },
+          severity: "error" as const,
+        },
+      ],
+      config: null,
+    };
+
+    const result = checkWorkflowForWrite(goodWorkflow(), undefined, ctx);
+
+    expect(result.hasErrors).toBe(true);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]?.rule).toBe("linter-internal-error");
+    expect(result.violations[0]?.message).toContain("kaboom");
+  });
+
+  test("a clean run with normal rules returns no violations", () => {
+    const ctx = prepareWriteLintContext();
+    const result = checkWorkflowForWrite(goodWorkflow(), undefined, ctx);
+    expect(result.hasErrors).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Workflow を書き換える系 CLI コマンド (`apply` / `workflow create` / `workflow update`) に、書き込み直前で走るデフォルト ON の lint チェックを追加。proxy が既に持っている server-side enforcement と同じ思想を CLI 側にも持ち込む。`--no-lint` で明示的にバイパス可能。`--force` は lint failure をバイパスしない（lint 違反はマージコンフリクトではなくポリシーなので）。

## Why

- `apply` / `workflow create|update` は n8n の REST API を直接叩くため、これまで client 側 lint をスキップした不健全な workflow がそのまま production に保存され得た。
- proxy は同じ問題を server-side で解いているが、CLI 直接実行はその経路を通らない。
- `--allow-duplicates` で導入した「デフォルトが厳しい / 明示的にオフ」のポリシーと整合する。

## What changed

### Feature
- `apply` ごとに 1 度だけ rule registry + config を構築し、各 workflow を書き込む直前に lint。error-level violation がある workflow は `error` オペレーションとしてマークされ、API 呼び出しはスキップ。残りの workflow は継続処理されるので 1 回の apply で全部の問題が surface する。
- `workflow create` / `workflow update` も同じく書き込み直前に lint。違反があれば `process.exit(1)` で停止し、API 呼び出しに到達しない。
- 共有ヘルパー `src/lint/write-check.ts` (\`prepareWriteLintContext\` / \`checkWorkflowForWrite\` / \`formatViolationLine\`) と single-workflow 用ゲート `src/lint/cli-gate.ts` (\`runPreWriteLintGate\`) を新規追加。
- 既存の \`lint\` コマンドや proxy enforcer と同じ rule pipeline / config 形式を共有。

### 防御策（同 PR 内の code-review fixup を統合）
- **try/catch defense**: `checkWorkflowForWrite` で `lintWorkflow` を try/catch し、proxy enforcer と同じく throw を synthetic `linter-internal-error` violation に降格。一つの壊れたルールが apply 全体を落とさない。
- **typed config error**: 壊れた `.n8nlintrc.json` を `LintConfigLoadError` に wrap し、CLI 側で catch → friendly message + `--no-lint` ヒントを表示。生の `SyntaxError` スタックを見せない。
- **--dir 起点の config 探索**: `prepareWriteLintContext(startDir)` を追加。`apply --dir workflows/` のように呼んだとき in-tree `.n8nlintrc.json` を拾える。
- **warning surface**: apply reporter に `LINT WARNINGS` セクションを追加。これまで `op.lintViolations` に記録されるだけで誰も読まなかった warning がちゃんとターミナルに出る。
- **variadic 衝突回避**: `--lint-disable-rule <rules>` を variadic から comma-separated に変更。`workflow update` の positional `[id]` を吸い込んで silent data loss する事故を防ぐ。
- **順序整理**: `workflow update` の "Using workflow ID from file" log は lint gate 後に移動。lint failure 時に「更新開始 → 失敗」と誤読されないように。
- **friendly reader error**: `readWorkflowInput` の validation エラーを catch して `Error: <file>: <message>` 形式に統一。

## New flags

3 コマンド共通:
- `--no-lint`: チェック全体をスキップ
- `--lint-config <path>`: `.n8nlintrc.json` の明示指定
- `--lint-disable-rule <rules>`: comma-separated でルール無効化

## Test plan

- [x] \`bun test\` — 762 pass / 0 fail (新規 14 テスト)
- [x] \`bun run typecheck\`
- [x] \`bun run lint\` (biome)
- [x] apply で error → 残りの workflow が継続処理されることを executor-level test で確認
- [x] apply / workflow create / workflow update で \`--no-lint\` がバイパスとして機能することを CLI spawn test で確認
- [x] \`workflow update --lint-disable-rule X wf-id -f wf.json\` で positional id が吸われないことを regression test で確認
- [x] 壊れた \`.n8nlintrc.json\` で LintConfigLoadError が投げられることを確認
- [x] 例外を投げるルールが \`linter-internal-error\` violation に降格することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXVFp9mkJV1dzowFtqrKWb