### PR TITLE
feat(proxy): tag-based scope filter and liveness/readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,8 @@ n8n-cli proxy [options]
 | `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default) |
 | `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
+| `--middleware <list>` | Comma-separated middleware chain (default: `lint`; env: `N8N_MIDDLEWARES`). Example: `lint,authz` |
+| `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`). Non-matching saves are forwarded transparently |
 
 **Enforcement levels:**
 
@@ -881,7 +883,19 @@ Clients then point at `http://proxy-host:8080` instead of n8n directly. From the
 
 **Apply-style safety checks:** beyond lint, the proxy mirrors the same default-on duplicate-name safety that `apply` enforces. On every `POST /api/v1/workflows` the proxy fetches the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and rejects creates that collide with an existing remote name. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Pass `--allow-duplicates` to disable the check entirely (e.g. during a one-off bulk import). Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
 
-**Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations. The proxy exposes `GET /healthz` (and `HEAD /healthz`) for liveness probes.
+**Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations.
+
+**Scoping by tags:** pass `--tags managed,prod` (or set `PROXY_FILTER_BY_TAGS`) to constrain middleware enforcement to workflow saves whose `tags` contain every listed name. Saves outside that scope are forwarded transparently — no lint, no duplicate-name check, no authz. Useful when only a subset of workflows on the upstream is under policy. Filtering is AND across the listed names.
+
+> **Scope is advisory, not an enforcement boundary.** The filter reads tags from the request body the client sent, not from the existing upstream workflow, so a caller can bypass middleware by stripping the tag from the JSON they submit. Use it to opt subsets of workflows into policy (organizational scoping), not to defend against a hostile client; for hard enforcement keep the filter empty so every save is checked, or pair the filter with API-key / network-level access controls.
+
+**Health probes:**
+
+| Path | Method | Behavior |
+|------|--------|----------|
+| `GET`/`HEAD /livez` | Liveness | Always `200 ok` once the server is accepting connections. Use for Kubernetes `livenessProbe`. |
+| `GET`/`HEAD /readyz` | Readiness | `200 ready` once every middleware's `prepare()` resolves; `503 preparing` (or `503 not ready` with details) while resolvers are still warming up or have failed. Use for Kubernetes `readinessProbe` so traffic is held back until authz groups, lint config, etc. are usable. |
+| `GET`/`HEAD /healthz` | Generic | Always `200 ok`. Kept for backward compatibility with existing probes; new deployments should prefer `/livez` + `/readyz`. |
 
 ### `version`
 
@@ -917,6 +931,7 @@ n8n-cli version
 | `N8N_DEFAULT_PROJECT` | Default project ID for apply |
 | `APPLY_FILTER_BY_TAGS` | Comma-separated tags to filter apply targets |
 | `CHECKS_FILTER_BY_TAGS` | Comma-separated tags to filter lint/fmt targets (AND condition) |
+| `PROXY_FILTER_BY_TAGS` | Comma-separated tags to scope proxy middleware enforcement (AND condition) |
 
 ### CLAUDE.md Integration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { parseTagFilter } from "@/common/tags.ts";
 import { parseMiddlewareList } from "@/middleware/registry.ts";
 import { parseEnforceLevel } from "@/proxy/config.ts";
 import { startProxy } from "@/proxy/server.ts";
@@ -14,6 +15,7 @@ interface ProxyOptions {
   duplicateTtl?: string;
   upstreamTimeout?: string;
   middleware?: string;
+  tags?: string;
   // Authz middleware options (flat namespace so commander stays happy).
   authzEnforce?: string;
   authzOnError?: string;
@@ -58,6 +60,10 @@ export function registerProxyCommand(program: Command): void {
       "--middleware <list>",
       "Comma-separated middleware chain (default: lint; env: N8N_MIDDLEWARES). Example: lint,authz",
     )
+    .option(
+      "--tags <tags>",
+      "Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: PROXY_FILTER_BY_TAGS). Non-matching saves are forwarded transparently.",
+    )
     // Authz options — only meaningful when "authz" is in the middleware chain.
     .option("--authz-enforce <level>", "Authz enforcement level: off, warn, error")
     .option("--authz-on-error <mode>", "Behavior when groups API fails: deny, allow")
@@ -98,6 +104,7 @@ export function registerProxyCommand(program: Command): void {
       const upstreamTimeoutMs = parsePositiveInt(opts.upstreamTimeout, "--upstream-timeout");
 
       const middlewares = parseMiddlewareList(opts.middleware);
+      const filterByTags = parseTagFilter(opts.tags ?? process.env.PROXY_FILTER_BY_TAGS);
 
       const handle = startProxy({
         listen: opts.listen,
@@ -111,6 +118,7 @@ export function registerProxyCommand(program: Command): void {
         upstreamTimeoutMs,
         middlewares,
         middlewareCliOptions: extractMiddlewareCliOpts(opts),
+        filterByTags: filterByTags.length > 0 ? filterByTags : undefined,
       });
 
       // Friendly startup line on stderr so it never pollutes JSON log streams.
@@ -121,8 +129,9 @@ export function registerProxyCommand(program: Command): void {
       const mwDisplay = middlewares.length
         ? middlewares.join(",")
         : (process.env.N8N_MIDDLEWARES ?? "lint (default)");
+      const tagsDisplay = filterByTags.length > 0 ? `, tags=${filterByTags.join(",")}` : "";
       console.error(
-        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, middlewares=${mwDisplay})`,
+        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, middlewares=${mwDisplay}${tagsDisplay})`,
       );
 
       const shutdown = async (signal: string) => {

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -42,6 +42,14 @@ export interface ProxyConfig {
    * its own keys (`lintEnforce`, `authzGroupsUrl`, ...).
    */
   middlewareCliOptions?: Record<string, unknown>;
+  /**
+   * Tag-based scope filter (AND condition). When set, the proxy only runs
+   * middleware (lint / authz / ...) and duplicate detection against workflow
+   * saves whose `tags` contain every name listed here; non-matching saves
+   * are forwarded transparently. Empty / undefined means "process every
+   * intercepted save" (legacy behavior).
+   */
+  filterByTags?: string[];
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,4 +1,5 @@
 import type { Workflow } from "@/api/types.ts";
+import { hasAllTags } from "@/common/tags.ts";
 import { runPipeline } from "@/middleware/pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "@/middleware/registry.ts";
 import type { PreWriteMiddleware } from "@/middleware/types.ts";
@@ -17,6 +18,15 @@ import { forwardRequest } from "./upstream.ts";
 
 const MIDDLEWARES_ENV_VAR = "N8N_MIDDLEWARES";
 
+/**
+ * Tracks whether middleware `prepare()` has finished so `/readyz` can flip
+ * from 503 (not ready) to 200 (ready) once long-running resolvers finish.
+ */
+interface ReadinessState {
+  status: "preparing" | "ready" | "failed";
+  errors: Array<{ middleware: string; message: string }>;
+}
+
 export interface ProxyHandle {
   port: number;
   stop: () => Promise<void>;
@@ -28,6 +38,7 @@ interface HandlerDeps {
   logger: Logger;
   duplicates: DuplicateChecker | null;
   middlewares: PreWriteMiddleware[];
+  readiness: ReadinessState;
 }
 
 /** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
@@ -68,17 +79,41 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   });
 
   // Run prepare() up front so identity-resolution / config-load failures
-  // surface at startup rather than on the first request.
-  for (const mw of middlewares) {
-    void mw.prepare?.();
-  }
+  // surface at startup rather than on the first request. We also track the
+  // result so `/readyz` can report 503 until every middleware finishes
+  // (authz, for instance, prefetches groups from a remote endpoint).
+  //
+  // Failures are also written to stderr as they happen so deployments that
+  // don't probe `/readyz` (bare docker, local dev) still see the breakage
+  // — without this the proxy would run silently in a broken state.
+  const readiness: ReadinessState = { status: "preparing", errors: [] };
+  Promise.all(
+    middlewares.map(async (mw) => {
+      try {
+        await mw.prepare?.();
+        return null;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`n8n-cli proxy: middleware "${mw.name}" prepare() failed: ${message}`);
+        return { middleware: mw.name, message };
+      }
+    }),
+  ).then((results) => {
+    const failures = results.filter((r): r is { middleware: string; message: string } => !!r);
+    if (failures.length === 0) {
+      readiness.status = "ready";
+    } else {
+      readiness.status = "failed";
+      readiness.errors = failures;
+    }
+  });
 
   // Duplicate-name detection is on by default; opt out with allowDuplicates.
   const duplicates = config.allowDuplicates
     ? null
     : new DuplicateChecker(upstream, config.duplicateTtlMs);
 
-  const deps: HandlerDeps = { upstream, config, logger, duplicates, middlewares };
+  const deps: HandlerDeps = { upstream, config, logger, duplicates, middlewares, readiness };
 
   const server = Bun.serve({
     hostname: host,
@@ -101,11 +136,16 @@ async function handle(req: Request, deps: HandlerDeps): Promise<Response> {
 
   // Internal endpoints — never forwarded. Allow GET and HEAD so load
   // balancers using HEAD probes don't accidentally hit the upstream.
-  if (pathname === "/healthz" && (req.method === "GET" || req.method === "HEAD")) {
-    return new Response(req.method === "HEAD" ? null : "ok\n", {
-      status: 200,
-      headers: { "content-type": "text/plain" },
-    });
+  //
+  // - /livez:   process is alive (always 200 once we're serving)
+  // - /readyz:  middleware prepare() finished; 503 while preparing or on
+  //             failure so Kubernetes / LB removes us from the pool until
+  //             dependencies (authz groups fetch, lint config load, ...)
+  //             are usable.
+  // - /healthz: legacy generic check, kept as 200 for backward compat with
+  //             existing probes. Use /livez or /readyz for new deployments.
+  if (isProbeRequest(req.method, pathname)) {
+    return handleProbe(req.method, pathname, deps);
   }
 
   const mutation = matchWorkflowMutation(req.method, pathname);
@@ -114,6 +154,36 @@ async function handle(req: Request, deps: HandlerDeps): Promise<Response> {
   }
 
   return handleTransparentForward(req, pathname, deps);
+}
+
+function isProbeRequest(method: string, pathname: string): boolean {
+  if (method !== "GET" && method !== "HEAD") return false;
+  return pathname === "/healthz" || pathname === "/livez" || pathname === "/readyz";
+}
+
+function handleProbe(method: string, pathname: string, deps: HandlerDeps): Response {
+  // /readyz reflects the prepare() state; everything else just says alive.
+  if (pathname === "/readyz") {
+    const { status, errors } = deps.readiness;
+    if (status === "ready") {
+      return new Response(method === "HEAD" ? null : "ready\n", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    const body =
+      status === "preparing"
+        ? "preparing\n"
+        : `not ready\n${errors.map((e) => `  ${e.middleware}: ${e.message}`).join("\n")}\n`;
+    return new Response(method === "HEAD" ? null : body, {
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+  }
+  return new Response(method === "HEAD" ? null : "ok\n", {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+  });
 }
 
 async function handleTransparentForward(
@@ -162,6 +232,15 @@ async function handleWorkflowMutation(
       message: `invalid JSON: ${message}`,
     });
     return buildBadJSONResponse(message);
+  }
+
+  // Scope filter: when --tags / PROXY_FILTER_BY_TAGS is set, only workflows
+  // carrying every named tag get middleware + duplicate processing. Other
+  // saves are forwarded transparently so the proxy can be deployed in front
+  // of an instance whose workflows are only partially under policy.
+  const filterTags = deps.config.filterByTags ?? [];
+  if (filterTags.length > 0 && !hasAllTags(workflow?.tags, filterTags)) {
+    return handleSkippedMutation(req, rawJSON, pathname, workflow, filterTags, deps);
   }
 
   // Middleware pipeline (lint + authz + future policies).
@@ -260,4 +339,36 @@ function reportError(err: unknown, req: Request, pathname: string, deps: Handler
   const message = err instanceof Error ? err.message : String(err);
   deps.logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
   return buildErrorResponse(message);
+}
+
+/**
+ * Forwards a workflow mutation that fell outside the configured tag filter.
+ * No middleware runs, no duplicate check fires — the proxy logs the skip and
+ * passes the body to upstream verbatim.
+ */
+async function handleSkippedMutation(
+  req: Request,
+  rawJSON: string,
+  pathname: string,
+  workflow: Workflow | null,
+  filterTags: string[],
+  deps: HandlerDeps,
+): Promise<Response> {
+  try {
+    const { response, elapsedMs } = await forwardRequest(req, deps.upstream, rawJSON, {
+      timeoutMs: deps.config.upstreamTimeoutMs,
+    });
+    deps.logger.log({
+      action: "forward",
+      method: req.method,
+      path: pathname,
+      status: response.status,
+      upstreamMs: elapsedMs,
+      workflowName: workflow?.name,
+      message: `skipped by tag filter (requires: ${filterTags.join(", ")})`,
+    });
+    return response;
+  } catch (err) {
+    return reportError(err, req, pathname, deps);
+  }
 }

--- a/tests/proxy/proxy.tags-and-probes.test.ts
+++ b/tests/proxy/proxy.tags-and-probes.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  body: string;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: CapturedRequest[];
+}
+
+function startMockUpstream(): MockUpstream {
+  const captured: CapturedRequest[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      captured.push({ method: req.method, pathname: url.pathname, body });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { server, port: server.port as number, captured };
+}
+
+let proxy: ProxyHandle;
+let upstream: MockUpstream;
+
+beforeEach(() => {
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+});
+
+function start(extra: Partial<Parameters<typeof startProxy>[0]> = {}): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "error",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    ...extra,
+  });
+  return proxy;
+}
+
+function url(p: string): string {
+  return `http://127.0.0.1:${proxy.port}${p}`;
+}
+
+const VIOLATING_BODY = JSON.stringify({
+  // missing "name" → required-fields error
+  active: true,
+  nodes: [],
+  connections: {},
+});
+
+const VIOLATING_WITH_TAGS = (tags: Array<{ name: string }>) =>
+  JSON.stringify({
+    active: true,
+    nodes: [],
+    connections: {},
+    tags,
+  });
+
+describe("proxy: tag-based scope filter", () => {
+  test("workflow without matching tags is forwarded transparently (no lint block)", async () => {
+    start({ filterByTags: ["managed"] });
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING_BODY, // would normally 422 — but outside scope
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured.filter((c) => c.method === "POST")).toHaveLength(1);
+    // Body forwarded verbatim
+    const forwarded = upstream.captured.find((c) => c.method === "POST");
+    expect(forwarded?.body).toBe(VIOLATING_BODY);
+  });
+
+  test("workflow with all required tags is processed by middleware", async () => {
+    start({ filterByTags: ["managed"] });
+
+    const body = VIOLATING_WITH_TAGS([{ name: "managed" }]);
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(422);
+    const parsed = (await res.json()) as { error: string };
+    expect(parsed.error).toBe("workflow_lint_failed");
+    expect(upstream.captured.filter((c) => c.method === "POST")).toHaveLength(0);
+  });
+
+  test("AND condition: missing one of multiple required tags is skipped", async () => {
+    start({ filterByTags: ["managed", "prod"] });
+
+    const body = VIOLATING_WITH_TAGS([{ name: "managed" }]); // missing "prod"
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(200); // forwarded
+  });
+
+  test("AND condition: all required tags present → middleware applied", async () => {
+    start({ filterByTags: ["managed", "prod"] });
+
+    const body = VIOLATING_WITH_TAGS([{ name: "managed" }, { name: "prod" }, { name: "extra" }]);
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(422);
+  });
+
+  test("filter applies to PUT updates as well", async () => {
+    start({ filterByTags: ["managed"] });
+
+    const res = await fetch(url("/api/v1/workflows/wf-1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING_BODY, // no tags, skipped
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstream.captured.filter((c) => c.method === "PUT")).toHaveLength(1);
+  });
+
+  test("undefined filterByTags preserves legacy behavior (all saves checked)", async () => {
+    start(); // no filterByTags
+
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING_BODY,
+    });
+
+    expect(res.status).toBe(422);
+  });
+});
+
+describe("proxy: liveness/readiness probes", () => {
+  test("GET /livez returns 200", async () => {
+    start();
+    const res = await fetch(url("/livez"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("ok");
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("HEAD /livez returns 200 with no body", async () => {
+    start();
+    const res = await fetch(url("/livez"), { method: "HEAD" });
+    expect(res.status).toBe(200);
+  });
+
+  test("GET /readyz returns 200 once middleware prepare() resolves", async () => {
+    start();
+    // prepare() runs at startup; for the lint middleware it's synchronous,
+    // so by the time we issue the request the proxy should already be ready.
+    // Allow a microtask to flush before polling.
+    await Bun.sleep(20);
+
+    const res = await fetch(url("/readyz"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("ready");
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("HEAD /readyz returns 200 with no body once ready", async () => {
+    start();
+    await Bun.sleep(20);
+
+    const res = await fetch(url("/readyz"), { method: "HEAD" });
+    expect(res.status).toBe(200);
+  });
+
+  test("legacy /healthz still returns 200", async () => {
+    start();
+    const res = await fetch(url("/healthz"));
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("non-GET/HEAD methods on probe paths fall through to forwarding", async () => {
+    start();
+    // POST /healthz isn't a probe; it should be forwarded transparently.
+    const res = await fetch(url("/healthz"), { method: "POST", body: "x" });
+    // The upstream returned 200 from the mock.
+    expect(res.status).toBe(200);
+    expect(upstream.captured.some((c) => c.pathname === "/healthz" && c.method === "POST")).toBe(
+      true,
+    );
+  });
+
+  test("/readyz returns 503 + stderr log when middleware prepare() fails", async () => {
+    // Point lint config at a path that exists but contains invalid JSON so
+    // prepareWriteLintContext throws — this is the canonical operator
+    // misconfiguration the old code crashed on at startup.
+    const badConfig = `${process.env.TMPDIR ?? "/tmp"}/n8n-cli-broken-lint-${Date.now()}.json`;
+    await Bun.write(badConfig, "{ not valid json");
+
+    // Capture console.error so we can assert the failure was surfaced
+    // loudly even for deployments that don't probe /readyz.
+    const originalConsoleError = console.error;
+    const stderrLines: string[] = [];
+    console.error = (...args: unknown[]) => {
+      stderrLines.push(args.map((a) => String(a)).join(" "));
+    };
+
+    try {
+      start({ lintConfigPath: badConfig });
+      // Let the prepare() promise resolve.
+      await Bun.sleep(50);
+
+      const res = await fetch(url("/readyz"));
+      expect(res.status).toBe(503);
+      const body = await res.text();
+      expect(body).toContain("not ready");
+      expect(body).toContain("lint");
+
+      // Stderr saw the failure too.
+      expect(stderrLines.join("\n")).toMatch(/middleware "lint" prepare\(\) failed/);
+
+      // /livez is unaffected — the process is alive even when not ready.
+      const livez = await fetch(url("/livez"));
+      expect(livez.status).toBe(200);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--tags <tags>` / `PROXY_FILTER_BY_TAGS` (AND condition) to proxy mode. Only workflow saves whose tags contain every listed name go through middleware (lint / authz / duplicate-name check); other saves are forwarded transparently
- Add `/livez` (always 200) and `/readyz` (200 once every middleware's `prepare()` resolves; 503 with details while preparing or on failure) for Kubernetes-style probes. Legacy `/healthz` is preserved for backward compatibility
- Surface middleware `prepare()` failures on stderr so deployments without a `/readyz` consumer (docker run, local dev) still see misconfiguration loudly at startup
- Bump patch version 2.2.2 → 2.2.3

## Design notes

- The tag filter reads tags from the request body, so a hostile client can bypass middleware by stripping the tag from the JSON they submit. Documented in the README as an organizational scope, not an enforcement boundary. For hard enforcement, leave the filter empty or pair it with API-key / network-level access controls
- The old `void mw.prepare?.()` loop crashed `startProxy` on synchronous throws; the new code wraps each prepare in a Promise and stores the outcome in readiness state. The stderr log preserves the previous loud-failure behavior without crashing the process

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (859 / 859 passing)
- [x] New tests in `tests/proxy/proxy.tags-and-probes.test.ts` (13 cases)
  - Tag filter AND condition / PUT updates / legacy behavior when unset
  - `/livez` `/readyz` `/healthz` over GET / HEAD / other methods
  - Broken lint config → `/readyz` returns 503 with details + stderr log, while `/livez` stays 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LChcVV7AmMTi8Twj2cKbyS