### PR TITLE
feat(proxy): add ClientMiddleware pipeline with iap-auth and api-key-inject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -9,8 +9,8 @@ import type { Violation } from "../lint/rules/violation.ts";
 import { formatViolationLine } from "../lint/write-check.ts";
 import { disposePipeline, preparePipeline, runPipeline } from "../middleware/pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "../middleware/registry.ts";
-import type { PreWriteMiddleware } from "../middleware/types.ts";
-import { DEFAULT_MIDDLEWARE_CHAIN, registerBuiltins } from "../middleware/wiring.ts";
+import type { ServerMiddleware } from "../middleware/types.ts";
+import { DEFAULT_SERVER_MIDDLEWARE_CHAIN, registerBuiltins } from "../middleware/wiring.ts";
 import { compare } from "./differ.ts";
 import { DuplicateChecker } from "./duplicate.ts";
 import { Scanner } from "./scanner.ts";
@@ -43,7 +43,7 @@ export class Executor {
   private threeWayDetector?: ThreeWayDetector;
   private gitContent?: ContentRetriever;
   private diffSpec?: DiffSpec;
-  private middlewares: PreWriteMiddleware[] = [];
+  private middlewares: ServerMiddleware[] = [];
   private preparedNames = new Set<string>();
 
   constructor(
@@ -61,9 +61,9 @@ export class Executor {
       }
     }
 
-    // Build the middleware pipeline. Default chain is ["lint"] for legacy
-    // compatibility; users opt-in to authz (or future policies) via
-    // --middleware or N8N_MIDDLEWARES.
+    // Build the server-middleware pipeline. Default chain is ["lint"] for
+    // legacy compatibility; users opt-in to authz (or future policies) via
+    // --server-middleware or N8N_SERVER_MIDDLEWARES.
     //
     // `--no-lint` is honored by *removing* lint from the chain rather than
     // by passing enforce=off, so users keep getting backwards-compatible
@@ -77,8 +77,8 @@ export class Executor {
     const enabled = resolveEnabledList({
       cliValue: opts.middlewares.join(","),
       env: process.env,
-      envVar: "N8N_MIDDLEWARES",
-      fallback: DEFAULT_MIDDLEWARE_CHAIN,
+      envVar: "N8N_SERVER_MIDDLEWARES",
+      fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
     });
     const filtered = opts.noLint ? enabled.filter((n) => n !== "lint") : enabled;
 
@@ -574,8 +574,8 @@ export class Executor {
  * running lint standalone.
  *
  * The summary line names the blocking middleware so users know whether to
- * pass `--no-lint`, drop the authz middleware from `--middleware`, or fix
- * the workflow.
+ * pass `--no-lint`, drop the authz middleware from `--server-middleware`,
+ * or fix the workflow.
  */
 function buildMiddlewareErrorMessage(
   filePath: string,
@@ -586,10 +586,10 @@ function buildMiddlewareErrorMessage(
   const lines = errorOnly.map((v) => formatViolationLine(filePath, v));
   const mwLabel = blockedBy ?? "middleware";
   // Append the bypass hint for the known middleware. Authz has no
-  // equivalent bypass flag (dropping it from --middleware is an explicit
-  // declarative action, not a per-run override), so we only add the lint
-  // hint here. The legacy `buildLintErrorMessage` always emitted this
-  // tail; keeping it preserves the existing CLI UX and any consumers
+  // equivalent bypass flag (dropping it from --server-middleware is an
+  // explicit declarative action, not a per-run override), so we only add
+  // the lint hint here. The legacy `buildLintErrorMessage` always emitted
+  // this tail; keeping it preserves the existing CLI UX and any consumers
   // grepping for "--no-lint to bypass" in apply output.
   const hint = blockedBy === "lint" ? "; pass --no-lint to bypass" : "";
   const summary = `${mwLabel} check failed (${errorOnly.length} error${

--- a/src/apply/types.ts
+++ b/src/apply/types.ts
@@ -49,15 +49,15 @@ export interface ApplyOptions {
   lintDisableRules: string[];
   filterByTags: string[];
   /**
-   * Ordered list of middleware names to run before writing each workflow
-   * upstream. Defaults to ["lint"] when empty for legacy compatibility.
-   * Set via --middleware or N8N_MIDDLEWARES.
+   * Ordered list of server-middleware names to run before writing each
+   * workflow upstream. Defaults to ["lint"] when empty for legacy
+   * compatibility. Set via --server-middleware or N8N_SERVER_MIDDLEWARES.
    */
   middlewares: string[];
   /**
-   * Flat commander-style options bag forwarded to each middleware factory.
-   * Populated by `cli/commands/apply.ts` so each middleware can pick out
-   * its own keys (e.g. authzGroupsUrl).
+   * Flat commander-style options bag forwarded to each server-middleware
+   * factory. Populated by `cli/commands/apply.ts` so each middleware can
+   * pick out its own keys (e.g. authzGroupsUrl).
    */
   middlewareCliOptions: Record<string, unknown>;
 }

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -49,8 +49,8 @@ export function registerApplyCommand(program: Command): void {
       "Comma-separated rule names to disable during the pre-write lint check",
     )
     .option(
-      "--middleware <list>",
-      "Comma-separated middleware chain (default: lint; env: N8N_MIDDLEWARES). Example: lint,authz",
+      "--server-middleware <list>",
+      "Comma-separated server-middleware chain (default: lint; env: N8N_SERVER_MIDDLEWARES). Example: lint,authz",
     )
     // Authz options (relevant when "authz" is in the middleware chain).
     .option("--authz-enforce <level>", "Authz enforcement level: off, warn, error")
@@ -97,10 +97,10 @@ export function registerApplyCommand(program: Command): void {
           .filter((r) => r.length > 0);
       }
 
-      // Middleware chain. Parsed lazily — the executor falls back to
+      // Server-middleware chain. Parsed lazily — the executor falls back to
       // env / default when this is empty.
-      if (typeof options.middleware === "string") {
-        opts.middlewares = (options.middleware as string)
+      if (typeof options.serverMiddleware === "string") {
+        opts.middlewares = (options.serverMiddleware as string)
           .split(",")
           .map((s) => s.trim())
           .filter((s) => s.length > 0);

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -14,7 +14,8 @@ interface ProxyOptions {
   allowDuplicates?: boolean;
   duplicateTtl?: string;
   upstreamTimeout?: string;
-  middleware?: string;
+  serverMiddleware?: string;
+  clientMiddleware?: string;
   tags?: string;
   // Authz middleware options (flat namespace so commander stays happy).
   authzEnforce?: string;
@@ -57,14 +58,18 @@ export function registerProxyCommand(program: Command): void {
       "30000",
     )
     .option(
-      "--middleware <list>",
-      "Comma-separated middleware chain (default: lint; env: N8N_MIDDLEWARES). Example: lint,authz",
+      "--server-middleware <list>",
+      "Comma-separated server-middleware chain (default: lint; env: N8N_SERVER_MIDDLEWARES). Example: lint,authz",
+    )
+    .option(
+      "--client-middleware <list>",
+      "Comma-separated client-middleware chain run on outgoing upstream requests (default: empty; env: N8N_CLIENT_MIDDLEWARES). Example: iap-auth,api-key-inject",
     )
     .option(
       "--tags <tags>",
       "Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: PROXY_FILTER_BY_TAGS). Non-matching saves are forwarded transparently.",
     )
-    // Authz options — only meaningful when "authz" is in the middleware chain.
+    // Authz options — only meaningful when "authz" is in the server-middleware chain.
     .option("--authz-enforce <level>", "Authz enforcement level: off, warn, error")
     .option("--authz-on-error <mode>", "Behavior when groups API fails: deny, allow")
     .option("--authz-identity-source <kind>", "Where to read identity from: header, env, none")
@@ -103,7 +108,8 @@ export function registerProxyCommand(program: Command): void {
       const duplicateTtlMs = parsePositiveInt(opts.duplicateTtl, "--duplicate-ttl");
       const upstreamTimeoutMs = parsePositiveInt(opts.upstreamTimeout, "--upstream-timeout");
 
-      const middlewares = parseMiddlewareList(opts.middleware);
+      const middlewares = parseMiddlewareList(opts.serverMiddleware);
+      const clientMiddlewares = parseMiddlewareList(opts.clientMiddleware);
       const filterByTags = parseTagFilter(opts.tags ?? process.env.PROXY_FILTER_BY_TAGS);
 
       const handle = startProxy({
@@ -118,20 +124,25 @@ export function registerProxyCommand(program: Command): void {
         upstreamTimeoutMs,
         middlewares,
         middlewareCliOptions: extractMiddlewareCliOpts(opts),
+        clientMiddlewares: clientMiddlewares.length > 0 ? clientMiddlewares : undefined,
+        clientMiddlewareCliOptions: extractClientMiddlewareCliOpts(opts),
         filterByTags: filterByTags.length > 0 ? filterByTags : undefined,
       });
 
       // Friendly startup line on stderr so it never pollutes JSON log streams.
-      // The displayed middleware list reflects what was passed via --middleware;
-      // when empty, the env-var (N8N_MIDDLEWARES) or default chain wins inside
-      // startProxy, so this line just says "(env/default)" to avoid lying about
-      // an empty chain.
+      // The displayed middleware list reflects what was passed via
+      // --server-middleware; when empty, the env-var (N8N_SERVER_MIDDLEWARES)
+      // or default chain wins inside startProxy, so this line just says
+      // "(env/default)" to avoid lying about an empty chain.
       const mwDisplay = middlewares.length
         ? middlewares.join(",")
-        : (process.env.N8N_MIDDLEWARES ?? "lint (default)");
+        : (process.env.N8N_SERVER_MIDDLEWARES ?? "lint (default)");
+      const clientMwDisplay = clientMiddlewares.length
+        ? clientMiddlewares.join(",")
+        : (process.env.N8N_CLIENT_MIDDLEWARES ?? "(none)");
       const tagsDisplay = filterByTags.length > 0 ? `, tags=${filterByTags.join(",")}` : "";
       console.error(
-        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, middlewares=${mwDisplay}${tagsDisplay})`,
+        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, server-middlewares=${mwDisplay}, client-middlewares=${clientMwDisplay}${tagsDisplay})`,
       );
 
       const shutdown = async (signal: string) => {
@@ -170,6 +181,16 @@ function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
   copy("authzWorkflowExtract");
   copy("authzWorkflowStripPrefix");
   return out;
+}
+
+/**
+ * Strips the `opts` bag down to keys that client-middleware factories
+ * read. Empty for now — builtin-specific keys land alongside their
+ * builtins in follow-up commits. The placeholder keeps the wiring
+ * uniform with the server-side surface.
+ */
+function extractClientMiddlewareCliOpts(_opts: ProxyOptions): Record<string, unknown> {
+  return {};
 }
 
 function parsePositiveInt(value: string | undefined, flag: string): number | undefined {

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -100,10 +100,7 @@ export function registerProxyCommand(program: Command): void {
       "--iap-auth-timeout-ms <ms>",
       "HTTP timeout per metadata-server call in milliseconds (default: 5000)",
     )
-    .option(
-      "--iap-auth-metadata-base-url <url>",
-      "Override the metadata server base URL (testing)",
-    )
+    .option("--iap-auth-metadata-base-url <url>", "Override the metadata server base URL (testing)")
     .option(
       "--iap-auth-impersonate-service-account <email>",
       "Target service-account email to impersonate. When set, the proxy mints id_tokens for THIS SA via iamcredentials.googleapis.com:generateIdToken. The workload SA needs roles/iam.serviceAccountTokenCreator on it.",

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -17,6 +17,20 @@ interface ProxyOptions {
   serverMiddleware?: string;
   clientMiddleware?: string;
   tags?: string;
+  // iap-auth client-middleware options.
+  iapAuthAudience?: string;
+  iapAuthTokenSource?: string;
+  iapAuthTokenEnvVar?: string;
+  iapAuthCacheTtlMs?: string;
+  iapAuthTimeoutMs?: string;
+  iapAuthMetadataBaseUrl?: string;
+  iapAuthImpersonateServiceAccount?: string;
+  iapAuthIamCredentialsBaseUrl?: string;
+  // api-key-inject client-middleware options. The key value is NEVER taken
+  // directly on the CLI — only the name of an env var that holds it.
+  apiKeyInjectKeyEnvVar?: string;
+  apiKeyInjectHeader?: string;
+  apiKeyInjectConflictPolicy?: string;
   // Authz middleware options (flat namespace so commander stays happy).
   authzEnforce?: string;
   authzOnError?: string;
@@ -64,6 +78,52 @@ export function registerProxyCommand(program: Command): void {
     .option(
       "--client-middleware <list>",
       "Comma-separated client-middleware chain run on outgoing upstream requests (default: empty; env: N8N_CLIENT_MIDDLEWARES). Example: iap-auth,api-key-inject",
+    )
+    // iap-auth options — only meaningful when "iap-auth" is in the client-middleware chain.
+    .option(
+      "--iap-auth-audience <id>",
+      "OAuth2 client_id of the IAP-protected upstream backend (sets the id_token aud claim)",
+    )
+    .option(
+      "--iap-auth-token-source <kind>",
+      "Where to obtain the id_token: metadata (GCE metadata server, default), env, static",
+    )
+    .option(
+      "--iap-auth-token-env-var <name>",
+      "Env var holding a pre-minted id_token (token-source=env)",
+    )
+    .option(
+      "--iap-auth-cache-ttl-ms <ms>",
+      "Id-token cache lifetime in milliseconds (default: 3000000, i.e. 50 min)",
+    )
+    .option(
+      "--iap-auth-timeout-ms <ms>",
+      "HTTP timeout per metadata-server call in milliseconds (default: 5000)",
+    )
+    .option(
+      "--iap-auth-metadata-base-url <url>",
+      "Override the metadata server base URL (testing)",
+    )
+    .option(
+      "--iap-auth-impersonate-service-account <email>",
+      "Target service-account email to impersonate. When set, the proxy mints id_tokens for THIS SA via iamcredentials.googleapis.com:generateIdToken. The workload SA needs roles/iam.serviceAccountTokenCreator on it.",
+    )
+    .option(
+      "--iap-auth-iam-credentials-base-url <url>",
+      "Override the iamcredentials API base URL (testing)",
+    )
+    // api-key-inject options — only meaningful when "api-key-inject" is in the client-middleware chain.
+    .option(
+      "--api-key-inject-key-env-var <name>",
+      "Name of the env var holding the shared API key value (the raw key is never accepted on the CLI). env: N8N_API_KEY_INJECT_KEY or N8N_API_KEY_INJECT_KEY_ENV_VAR.",
+    )
+    .option(
+      "--api-key-inject-header <name>",
+      "Header to inject the shared API key into (default: X-N8N-API-KEY)",
+    )
+    .option(
+      "--api-key-inject-conflict-policy <policy>",
+      "Behavior when the incoming request already carries the header: replace (default) or set-if-absent",
     )
     .option(
       "--tags <tags>",
@@ -185,12 +245,26 @@ function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
 
 /**
  * Strips the `opts` bag down to keys that client-middleware factories
- * read. Empty for now — builtin-specific keys land alongside their
- * builtins in follow-up commits. The placeholder keeps the wiring
- * uniform with the server-side surface.
+ * read. Keeping the projection explicit prevents commander artifacts
+ * (`_optionValues`, etc.) from leaking into factory inputs.
  */
-function extractClientMiddlewareCliOpts(_opts: ProxyOptions): Record<string, unknown> {
-  return {};
+function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const copy = (k: keyof ProxyOptions) => {
+    if (opts[k] !== undefined) out[k] = opts[k];
+  };
+  copy("iapAuthAudience");
+  copy("iapAuthTokenSource");
+  copy("iapAuthTokenEnvVar");
+  copy("iapAuthCacheTtlMs");
+  copy("iapAuthTimeoutMs");
+  copy("iapAuthMetadataBaseUrl");
+  copy("iapAuthImpersonateServiceAccount");
+  copy("iapAuthIamCredentialsBaseUrl");
+  copy("apiKeyInjectKeyEnvVar");
+  copy("apiKeyInjectHeader");
+  copy("apiKeyInjectConflictPolicy");
+  return out;
 }
 
 function parsePositiveInt(value: string | undefined, flag: string): number | undefined {

--- a/src/cli/commands/workflow-create.ts
+++ b/src/cli/commands/workflow-create.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { Workflow, WorkflowInput } from "../../api/types.ts";
 import { readWorkflowInput } from "../../input/reader.ts";
-import { runPreWriteGate } from "../../middleware/cli-gate.ts";
+import { runServerMiddlewareGate } from "../../middleware/cli-gate.ts";
 import { formatJSON } from "../output/json.ts";
 import { formatKeyValue } from "../output/table.ts";
 import { resolveContext } from "../root.ts";
@@ -40,7 +40,7 @@ export function registerCreateCommand(parent: Command): void {
         process.exit(1);
       }
 
-      await runPreWriteGate({
+      await runServerMiddlewareGate({
         source: options.file as string,
         workflow: input,
         noLint: options.lint === false,

--- a/src/cli/commands/workflow-update.ts
+++ b/src/cli/commands/workflow-update.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { Workflow, WorkflowInput } from "../../api/types.ts";
 import { readWorkflowInput } from "../../input/reader.ts";
-import { runPreWriteGate } from "../../middleware/cli-gate.ts";
+import { runServerMiddlewareGate } from "../../middleware/cli-gate.ts";
 import { formatJSON } from "../output/json.ts";
 import { formatKeyValue } from "../output/table.ts";
 import { resolveContext } from "../root.ts";
@@ -59,7 +59,7 @@ export function registerUpdateCommand(parent: Command): void {
         workflowIDFromFile = true;
       }
 
-      await runPreWriteGate({
+      await runServerMiddlewareGate({
         source: options.file as string,
         workflow: input,
         noLint: options.lint === false,

--- a/src/middleware/builtin/api-key-inject/factory.ts
+++ b/src/middleware/builtin/api-key-inject/factory.ts
@@ -31,7 +31,8 @@ function fromEnv(env: NodeJS.ProcessEnv): Partial<ApiKeyInjectRawOptions> {
   }
   if (env.N8N_API_KEY_INJECT_HEADER) out.header = env.N8N_API_KEY_INJECT_HEADER;
   if (env.N8N_API_KEY_INJECT_CONFLICT_POLICY) {
-    out.conflictPolicy = env.N8N_API_KEY_INJECT_CONFLICT_POLICY as ApiKeyInjectRawOptions["conflictPolicy"];
+    out.conflictPolicy =
+      env.N8N_API_KEY_INJECT_CONFLICT_POLICY as ApiKeyInjectRawOptions["conflictPolicy"];
   }
   return out;
 }
@@ -49,7 +50,9 @@ function fromCLI(opts: Record<string, unknown>): Partial<ApiKeyInjectRawOptions>
   }
   if (s("apiKeyInjectHeader")) out.header = s("apiKeyInjectHeader");
   if (s("apiKeyInjectConflictPolicy")) {
-    out.conflictPolicy = s("apiKeyInjectConflictPolicy") as ApiKeyInjectRawOptions["conflictPolicy"];
+    out.conflictPolicy = s(
+      "apiKeyInjectConflictPolicy",
+    ) as ApiKeyInjectRawOptions["conflictPolicy"];
   }
   return out;
 }

--- a/src/middleware/builtin/api-key-inject/factory.ts
+++ b/src/middleware/builtin/api-key-inject/factory.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { ApiKeyInjectMiddleware } from "./middleware.ts";
+
+/**
+ * Raw config shape parsed from env/CLI. `apiKey` is intentionally NOT
+ * accepted directly on the CLI — secret values must come through an env
+ * var so they don't end up in shell history, process listings, or
+ * ps-style observability tooling.
+ */
+const optionsSchema = z.object({
+  apiKey: z
+    .string({ message: "api-key-inject: apiKey is required (set via N8N_API_KEY_INJECT_KEY env)" })
+    .min(1, { message: "api-key-inject: apiKey must not be empty" }),
+  header: z.string().default("X-N8N-API-KEY"),
+  conflictPolicy: z.union([z.literal("replace"), z.literal("set-if-absent")]).default("replace"),
+});
+
+type ApiKeyInjectRawOptions = z.infer<typeof optionsSchema>;
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<ApiKeyInjectRawOptions> {
+  const out: Partial<ApiKeyInjectRawOptions> = {};
+  // Direct key value via env. This is the canonical way to supply the key.
+  if (env.N8N_API_KEY_INJECT_KEY) out.apiKey = env.N8N_API_KEY_INJECT_KEY;
+  // Indirect: name of an env var that holds the key. Allows separating the
+  // operator-chosen var name from this middleware's contract (e.g. when an
+  // existing secret in the deployment env is named differently).
+  if (!out.apiKey && env.N8N_API_KEY_INJECT_KEY_ENV_VAR) {
+    const referenced = env[env.N8N_API_KEY_INJECT_KEY_ENV_VAR];
+    if (referenced) out.apiKey = referenced;
+  }
+  if (env.N8N_API_KEY_INJECT_HEADER) out.header = env.N8N_API_KEY_INJECT_HEADER;
+  if (env.N8N_API_KEY_INJECT_CONFLICT_POLICY) {
+    out.conflictPolicy = env.N8N_API_KEY_INJECT_CONFLICT_POLICY as ApiKeyInjectRawOptions["conflictPolicy"];
+  }
+  return out;
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<ApiKeyInjectRawOptions> {
+  const out: Partial<ApiKeyInjectRawOptions> = {};
+  const s = (k: string) => (typeof opts[k] === "string" ? (opts[k] as string) : undefined);
+  // CLI-level indirection only — `--api-key-inject-key-env-var <VAR>` resolves
+  // the value from process.env at build time. The raw key never appears on
+  // the CLI for the reasons described in the schema comment above.
+  const envVarName = s("apiKeyInjectKeyEnvVar");
+  if (envVarName) {
+    const value = process.env[envVarName];
+    if (value) out.apiKey = value;
+  }
+  if (s("apiKeyInjectHeader")) out.header = s("apiKeyInjectHeader");
+  if (s("apiKeyInjectConflictPolicy")) {
+    out.conflictPolicy = s("apiKeyInjectConflictPolicy") as ApiKeyInjectRawOptions["conflictPolicy"];
+  }
+  return out;
+}
+
+export const apiKeyInjectFactory: ClientMiddlewareFactory<ApiKeyInjectRawOptions> = {
+  name: "api-key-inject",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    return new ApiKeyInjectMiddleware(parsed);
+  },
+};
+
+/** Exposed for unit tests that build options directly. */
+export const apiKeyInjectOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/api-key-inject/middleware.ts
+++ b/src/middleware/builtin/api-key-inject/middleware.ts
@@ -1,0 +1,35 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
+
+export interface ApiKeyInjectOptions {
+  /** Header name (default: X-N8N-API-KEY). */
+  header: string;
+  /** Concrete API key value. Never logged. */
+  apiKey: string;
+  /**
+   * Behavior when the incoming request already carries a value for `header`:
+   *   - "replace": overwrite. Default — the proxy is the single key holder.
+   *   - "set-if-absent": leave existing values intact. Useful during a
+   *     migration where some clients still bring their own key.
+   */
+  conflictPolicy: "replace" | "set-if-absent";
+}
+
+/**
+ * Client middleware that injects a (typically shared) n8n API key into
+ * every outgoing upstream request. Used together with `iap-auth` to make
+ * the proxy the single authentication terminator — clients only need to
+ * authenticate against IAP (or whatever fronts the proxy); they don't
+ * need an n8n API key of their own.
+ */
+export class ApiKeyInjectMiddleware implements ClientMiddleware {
+  readonly name = "api-key-inject";
+
+  constructor(private readonly options: ApiKeyInjectOptions) {}
+
+  apply(headers: Headers, _ctx: ClientMiddlewareContext): void {
+    if (this.options.conflictPolicy === "set-if-absent" && headers.has(this.options.header)) {
+      return;
+    }
+    headers.set(this.options.header, this.options.apiKey);
+  }
+}

--- a/src/middleware/builtin/authz/factory.ts
+++ b/src/middleware/builtin/authz/factory.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { MiddlewareFactory } from "@/middleware/types.ts";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
 import { AuthzMiddleware } from "./middleware.ts";
 import type {
   AuthzEnforce,
@@ -52,8 +52,9 @@ const optionsSchema = z.object({
   enforce: enforceSchema.default("error"),
   onError: onErrorSchema.default("deny"),
   // Default identity to "none" so users that pass the per-request identity
-  // on PreWriteContext directly (e.g. tests, custom callers) don't have to
-  // declare extraction. Real proxy/apply runs always set this explicitly.
+  // on ServerMiddlewareContext directly (e.g. tests, custom callers) don't
+  // have to declare extraction. Real proxy/apply runs always set this
+  // explicitly.
   identity: identitySchema.default({ source: "none", decode: "raw" }),
   groups: groupsSchema,
   workflow: workflowSchema,
@@ -162,7 +163,7 @@ function fromCLI(opts: Record<string, unknown>): Partial<AuthzOptions> {
   return out;
 }
 
-export const authzFactory: MiddlewareFactory<AuthzOptions> = {
+export const authzFactory: ServerMiddlewareFactory<AuthzOptions> = {
   name: "authz",
   loadFromEnv: fromEnv,
   loadFromCLI: fromCLI,

--- a/src/middleware/builtin/authz/middleware.ts
+++ b/src/middleware/builtin/authz/middleware.ts
@@ -1,5 +1,9 @@
 import { resolveIdentity } from "@/middleware/identity.ts";
-import type { MiddlewareVerdict, PreWriteContext, PreWriteMiddleware } from "@/middleware/types.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
 import { GroupsResolver, type GroupsResolverDeps } from "./groups-resolver.ts";
 import type { AuthzOptions } from "./types.ts";
 import { WorkflowACLExtractor } from "./workflow-acl.ts";
@@ -8,8 +12,8 @@ import { WorkflowACLExtractor } from "./workflow-acl.ts";
  * Authorization middleware: gates workflow writes based on whether the
  * actor's groups intersect with the workflow's allowed groups.
  *
- * Design note: identity may already be present on the PreWriteContext when
- * the pipeline runner resolved it upstream (proxy does this in one place
+ * Design note: identity may already be present on the ServerMiddlewareContext
+ * when the pipeline runner resolved it upstream (proxy does this in one place
  * for every middleware). If not, the middleware re-resolves using its own
  * identity spec — this lets unit tests target the middleware in isolation
  * without standing up the pipeline.
@@ -18,7 +22,7 @@ import { WorkflowACLExtractor } from "./workflow-acl.ts";
  * middleware's 422 shape so proxy clients can distinguish them by status
  * and `error` code.
  */
-export class AuthzMiddleware implements PreWriteMiddleware {
+export class AuthzMiddleware implements ServerMiddleware {
   readonly name = "authz";
   private readonly resolver: GroupsResolver;
   private readonly acl: WorkflowACLExtractor;
@@ -31,7 +35,7 @@ export class AuthzMiddleware implements PreWriteMiddleware {
     this.acl = new WorkflowACLExtractor(options.workflow);
   }
 
-  async evaluate(ctx: PreWriteContext): Promise<MiddlewareVerdict> {
+  async evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> {
     if (this.options.enforce === "off") {
       return { block: false, violations: [] };
     }

--- a/src/middleware/builtin/iap-auth/factory.ts
+++ b/src/middleware/builtin/iap-auth/factory.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { IapAuthMiddleware } from "./middleware.ts";
+import {
+  EnvTokenSource,
+  MetadataServerTokenSource,
+  StaticTokenSource,
+  type TokenSource,
+} from "./token-source.ts";
+
+/**
+ * Raw config shape parsed from env/CLI. The runtime middleware doesn't see
+ * this — the factory turns it into an `IapAuthOptions` with a concrete
+ * `tokenSource` selected.
+ */
+const optionsSchema = z.object({
+  audience: z
+    .string({ message: "iap-auth: audience is required (OAuth2 client_id of IAP backend)" })
+    .min(1, { message: "iap-auth: audience must not be empty" }),
+  /**
+   * Where to get the id_token from. Defaults to "metadata" (GCE metadata
+   * server) — the production path. "env" reads a pre-minted token from an
+   * env var for local development. "static" is reserved for tests.
+   */
+  tokenSourceKind: z
+    .union([z.literal("metadata"), z.literal("env"), z.literal("static")])
+    .default("metadata"),
+  /** Env var name when tokenSourceKind=env. */
+  tokenEnvVar: z.string().optional(),
+  /** Inline token value when tokenSourceKind=static (tests only). */
+  staticToken: z.string().optional(),
+  /** Cache TTL in ms (metadata source). Default 50 min — id_tokens live ~1h. */
+  cacheTtlMs: z.number().int().min(0).default(50 * 60 * 1000),
+  /** HTTP timeout per metadata call in ms. */
+  timeoutMs: z.number().int().min(1).default(5_000),
+  /** Override metadata host (testing). */
+  metadataBaseUrl: z.string().url().optional(),
+  /**
+   * Target service-account email to impersonate. When set, id_tokens are
+   * minted via `iamcredentials.googleapis.com:generateIdToken` rather than
+   * pulled directly from the metadata server. Only meaningful when
+   * tokenSourceKind=metadata (the default).
+   *
+   * The workload SA running this proxy must have
+   * `roles/iam.serviceAccountTokenCreator` on the target SA, and the target
+   * SA must have `roles/iap.httpsResourceAccessor` on the upstream IAP
+   * backend.
+   */
+  impersonateServiceAccount: z.string().min(1).optional(),
+  /** Override iamcredentials host (testing). */
+  iamCredentialsBaseUrl: z.string().url().optional(),
+});
+
+type IapAuthRawOptions = z.infer<typeof optionsSchema>;
+
+function buildTokenSource(opts: IapAuthRawOptions): TokenSource {
+  switch (opts.tokenSourceKind) {
+    case "static": {
+      if (!opts.staticToken) {
+        throw new Error("iap-auth: tokenSourceKind=static requires staticToken");
+      }
+      return new StaticTokenSource(opts.staticToken);
+    }
+    case "env": {
+      if (!opts.tokenEnvVar) {
+        throw new Error("iap-auth: tokenSourceKind=env requires tokenEnvVar");
+      }
+      return new EnvTokenSource(opts.tokenEnvVar);
+    }
+    case "metadata":
+      return new MetadataServerTokenSource({
+        cacheTtlMs: opts.cacheTtlMs,
+        timeoutMs: opts.timeoutMs,
+        baseUrl: opts.metadataBaseUrl,
+        impersonateServiceAccount: opts.impersonateServiceAccount,
+        iamCredentialsBaseUrl: opts.iamCredentialsBaseUrl,
+      });
+  }
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<IapAuthRawOptions> {
+  const out: Partial<IapAuthRawOptions> = {};
+  if (env.N8N_IAP_AUTH_AUDIENCE) out.audience = env.N8N_IAP_AUTH_AUDIENCE;
+  if (env.N8N_IAP_AUTH_TOKEN_SOURCE) {
+    out.tokenSourceKind = env.N8N_IAP_AUTH_TOKEN_SOURCE as IapAuthRawOptions["tokenSourceKind"];
+  }
+  if (env.N8N_IAP_AUTH_TOKEN_ENV_VAR) out.tokenEnvVar = env.N8N_IAP_AUTH_TOKEN_ENV_VAR;
+  if (env.N8N_IAP_AUTH_CACHE_TTL_MS) {
+    out.cacheTtlMs = Number.parseInt(env.N8N_IAP_AUTH_CACHE_TTL_MS, 10);
+  }
+  if (env.N8N_IAP_AUTH_TIMEOUT_MS) {
+    out.timeoutMs = Number.parseInt(env.N8N_IAP_AUTH_TIMEOUT_MS, 10);
+  }
+  if (env.N8N_IAP_AUTH_METADATA_BASE_URL) out.metadataBaseUrl = env.N8N_IAP_AUTH_METADATA_BASE_URL;
+  if (env.N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT) {
+    out.impersonateServiceAccount = env.N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT;
+  }
+  if (env.N8N_IAP_AUTH_IAM_CREDENTIALS_BASE_URL) {
+    out.iamCredentialsBaseUrl = env.N8N_IAP_AUTH_IAM_CREDENTIALS_BASE_URL;
+  }
+  return out;
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<IapAuthRawOptions> {
+  const out: Partial<IapAuthRawOptions> = {};
+  const s = (k: string) => (typeof opts[k] === "string" ? (opts[k] as string) : undefined);
+  const n = (k: string) => {
+    const v = opts[k];
+    if (typeof v === "string" && /^\d+$/.test(v)) return Number.parseInt(v, 10);
+    if (typeof v === "number") return v;
+    return undefined;
+  };
+  if (s("iapAuthAudience")) out.audience = s("iapAuthAudience");
+  if (s("iapAuthTokenSource")) {
+    out.tokenSourceKind = s("iapAuthTokenSource") as IapAuthRawOptions["tokenSourceKind"];
+  }
+  if (s("iapAuthTokenEnvVar")) out.tokenEnvVar = s("iapAuthTokenEnvVar");
+  const ttl = n("iapAuthCacheTtlMs");
+  if (ttl !== undefined) out.cacheTtlMs = ttl;
+  const t = n("iapAuthTimeoutMs");
+  if (t !== undefined) out.timeoutMs = t;
+  if (s("iapAuthMetadataBaseUrl")) out.metadataBaseUrl = s("iapAuthMetadataBaseUrl");
+  if (s("iapAuthImpersonateServiceAccount")) {
+    out.impersonateServiceAccount = s("iapAuthImpersonateServiceAccount");
+  }
+  if (s("iapAuthIamCredentialsBaseUrl")) {
+    out.iamCredentialsBaseUrl = s("iapAuthIamCredentialsBaseUrl");
+  }
+  return out;
+}
+
+export const iapAuthFactory: ClientMiddlewareFactory<IapAuthRawOptions> = {
+  name: "iap-auth",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    const tokenSource = buildTokenSource(parsed);
+    return new IapAuthMiddleware({ audience: parsed.audience, tokenSource });
+  },
+};
+
+/** Exposed for unit tests that build options directly. */
+export const iapAuthOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/iap-auth/factory.ts
+++ b/src/middleware/builtin/iap-auth/factory.ts
@@ -30,7 +30,11 @@ const optionsSchema = z.object({
   /** Inline token value when tokenSourceKind=static (tests only). */
   staticToken: z.string().optional(),
   /** Cache TTL in ms (metadata source). Default 50 min — id_tokens live ~1h. */
-  cacheTtlMs: z.number().int().min(0).default(50 * 60 * 1000),
+  cacheTtlMs: z
+    .number()
+    .int()
+    .min(0)
+    .default(50 * 60 * 1000),
   /** HTTP timeout per metadata call in ms. */
   timeoutMs: z.number().int().min(1).default(5_000),
   /** Override metadata host (testing). */

--- a/src/middleware/builtin/iap-auth/middleware.ts
+++ b/src/middleware/builtin/iap-auth/middleware.ts
@@ -1,0 +1,35 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
+import type { TokenSource } from "./token-source.ts";
+
+export interface IapAuthOptions {
+  /** OAuth2 client_id of the IAP-protected upstream — becomes the `aud` claim. */
+  audience: string;
+  /** Token source. Defaults to GCE metadata server in the factory. */
+  tokenSource: TokenSource;
+}
+
+/**
+ * Client middleware that mints a Google-signed id_token for an IAP-protected
+ * upstream and attaches it as `Authorization: Bearer <token>`.
+ *
+ * Always replaces any incoming `Authorization` — the client-side token (used
+ * to authenticate against the proxy's *own* IAP layer, IAP#1) has a different
+ * `aud` than the upstream's IAP (IAP#2), so passing it through would result
+ * in audience-mismatch 401s at the second hop.
+ *
+ * The previous `Authorization` value is dropped before the new one is set.
+ * If you need the user's identity to reach the upstream, configure IAP#1 to
+ * inject `X-Goog-Authenticated-User-Email` (which is a separate header and
+ * isn't touched here).
+ */
+export class IapAuthMiddleware implements ClientMiddleware {
+  readonly name = "iap-auth";
+
+  constructor(private readonly options: IapAuthOptions) {}
+
+  async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
+    const token = await this.options.tokenSource.getToken(this.options.audience);
+    headers.delete("authorization");
+    headers.set("authorization", `Bearer ${token}`);
+  }
+}

--- a/src/middleware/builtin/iap-auth/token-source.ts
+++ b/src/middleware/builtin/iap-auth/token-source.ts
@@ -1,0 +1,261 @@
+/**
+ * Pluggable source of GCP ID tokens for IAP authentication.
+ *
+ * The default implementation (`MetadataServerTokenSource`) hits the GCE
+ * metadata server, which is the only mechanism that works for a service
+ * account attached to a Cloud Run / GCE / GKE workload — no service-account
+ * key material on disk required.
+ *
+ * Tests inject `StaticTokenSource` or a custom implementation; production
+ * runs without configuration use the metadata server.
+ */
+export interface TokenSource {
+  /** Returns a (possibly cached) id_token with `aud=audience`. */
+  getToken(audience: string): Promise<string>;
+}
+
+/** Minimal fetch contract — kept narrow so tests can stub it cleanly. */
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+const METADATA_BASE = "http://metadata.google.internal/computeMetadata/v1";
+const IAM_CREDENTIALS_BASE = "https://iamcredentials.googleapis.com/v1";
+
+interface CacheEntry {
+  token: string;
+  /** Epoch millis at which the cached entry stops being usable. */
+  expiresAt: number;
+}
+
+interface MetadataSourceDeps {
+  fetcher?: FetchLike;
+  now?: () => number;
+  /**
+   * Cache lifetime in ms. GCP id_tokens are valid for ~1h; defaulting to
+   * 50 min keeps headroom for clock skew and in-flight requests.
+   */
+  cacheTtlMs?: number;
+  /**
+   * HTTP timeout per metadata-server call. Metadata calls are local IMDS
+   * and should be sub-100ms; we set 5s as a generous fail-safe.
+   */
+  timeoutMs?: number;
+  /** Override for the metadata host (testing). */
+  baseUrl?: string;
+  /**
+   * Target service-account email to impersonate. When set, the source mints
+   * id_tokens for THIS SA via `iamcredentials.googleapis.com:generateIdToken`,
+   * using the workload's own ADC access_token (also fetched from the metadata
+   * server) as the caller credential. When unset, id_tokens come directly
+   * from the metadata server for the workload's own SA.
+   *
+   * Required permission on the workload SA: `roles/iam.serviceAccountTokenCreator`
+   * on `impersonateServiceAccount`. The target SA itself needs
+   * `roles/iap.httpsResourceAccessor` on the IAP backend.
+   */
+  impersonateServiceAccount?: string;
+  /** Override for the iamcredentials API host (testing). */
+  iamCredentialsBaseUrl?: string;
+  /**
+   * Cache lifetime for the caller's access_token in ms. GCP access_tokens
+   * live ~1h; we cache for 50 min to leave headroom. Independent of the
+   * id_token cache because the two have different scopes/lifetimes.
+   */
+  accessTokenCacheTtlMs?: number;
+}
+
+/**
+ * Fetches id_tokens from the GCE metadata server. Caches per-audience.
+ *
+ * One instance serves one workload; cache is keyed by audience so a process
+ * that authenticates against multiple IAP-protected backends still hits the
+ * metadata server only once per audience per TTL window.
+ */
+export class MetadataServerTokenSource implements TokenSource {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inflight = new Map<string, Promise<string>>();
+  /**
+   * Single-entry cache for the caller's access_token. Only populated when
+   * impersonation is enabled — direct id_token fetches don't need it.
+   */
+  private accessTokenCache: CacheEntry | null = null;
+  private accessTokenInflight: Promise<string> | null = null;
+  private readonly fetcher: FetchLike;
+  private readonly now: () => number;
+  private readonly cacheTtlMs: number;
+  private readonly accessTokenCacheTtlMs: number;
+  private readonly timeoutMs: number;
+  private readonly baseUrl: string;
+  private readonly iamCredentialsBaseUrl: string;
+  private readonly impersonateServiceAccount?: string;
+
+  constructor(deps: MetadataSourceDeps = {}) {
+    this.fetcher = deps.fetcher ?? ((url, init) => fetch(url, init));
+    this.now = deps.now ?? (() => Date.now());
+    this.cacheTtlMs = deps.cacheTtlMs ?? 50 * 60 * 1000;
+    this.accessTokenCacheTtlMs = deps.accessTokenCacheTtlMs ?? 50 * 60 * 1000;
+    this.timeoutMs = deps.timeoutMs ?? 5_000;
+    this.baseUrl = deps.baseUrl ?? METADATA_BASE;
+    this.iamCredentialsBaseUrl = deps.iamCredentialsBaseUrl ?? IAM_CREDENTIALS_BASE;
+    this.impersonateServiceAccount = deps.impersonateServiceAccount;
+  }
+
+  async getToken(audience: string): Promise<string> {
+    const cached = this.cache.get(audience);
+    if (cached && cached.expiresAt > this.now()) {
+      return cached.token;
+    }
+    // Coalesce concurrent misses for the same audience into a single fetch.
+    const pending = this.inflight.get(audience);
+    if (pending) return pending;
+
+    const p = this.fetchAndCache(audience).finally(() => {
+      this.inflight.delete(audience);
+    });
+    this.inflight.set(audience, p);
+    return p;
+  }
+
+  private async fetchAndCache(audience: string): Promise<string> {
+    const token = this.impersonateServiceAccount
+      ? await this.mintViaImpersonation(audience, this.impersonateServiceAccount)
+      : await this.fetchMetadataIdToken(audience);
+    this.cache.set(audience, { token, expiresAt: this.now() + this.cacheTtlMs });
+    return token;
+  }
+
+  private async fetchMetadataIdToken(audience: string): Promise<string> {
+    const url = `${this.baseUrl}/instance/service-accounts/default/identity?audience=${encodeURIComponent(audience)}`;
+    const res = await this.callWithTimeout(url, {
+      method: "GET",
+      headers: { "Metadata-Flavor": "Google" },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`metadata server returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+    }
+    const token = (await res.text()).trim();
+    if (!token) {
+      throw new Error("metadata server returned empty id_token");
+    }
+    return token;
+  }
+
+  /**
+   * Caller-credential path: fetch the workload SA's access_token from the
+   * metadata server. Cached because every impersonation call needs it and
+   * the value is valid for ~1h.
+   */
+  private async getAccessToken(): Promise<string> {
+    if (this.accessTokenCache && this.accessTokenCache.expiresAt > this.now()) {
+      return this.accessTokenCache.token;
+    }
+    if (this.accessTokenInflight) return this.accessTokenInflight;
+    this.accessTokenInflight = this.fetchAccessToken().finally(() => {
+      this.accessTokenInflight = null;
+    });
+    return this.accessTokenInflight;
+  }
+
+  private async fetchAccessToken(): Promise<string> {
+    const url = `${this.baseUrl}/instance/service-accounts/default/token`;
+    const res = await this.callWithTimeout(url, {
+      method: "GET",
+      headers: { "Metadata-Flavor": "Google" },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `metadata server (access_token) returned HTTP ${res.status}: ${body.slice(0, 200)}`,
+      );
+    }
+    const parsed = (await res.json()) as { access_token?: string; expires_in?: number };
+    if (!parsed.access_token) {
+      throw new Error("metadata server returned no access_token");
+    }
+    // Honor the server's `expires_in` when present (minus ~10 min slack);
+    // fall back to the configured TTL otherwise.
+    const ttl =
+      typeof parsed.expires_in === "number" && parsed.expires_in > 60
+        ? (parsed.expires_in - 60) * 1000
+        : this.accessTokenCacheTtlMs;
+    this.accessTokenCache = { token: parsed.access_token, expiresAt: this.now() + ttl };
+    return parsed.access_token;
+  }
+
+  /**
+   * Impersonation path: use the caller's access_token to ask the IAM
+   * Credentials API to mint an id_token *as* the target service account,
+   * with the requested `aud` claim.
+   *
+   * The caller needs `roles/iam.serviceAccountTokenCreator` on the target SA
+   * — a 403 here usually points at that missing role.
+   */
+  private async mintViaImpersonation(audience: string, targetSa: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    const url = `${this.iamCredentialsBaseUrl}/projects/-/serviceAccounts/${encodeURIComponent(targetSa)}:generateIdToken`;
+    const res = await this.callWithTimeout(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ audience, includeEmail: false }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `iamcredentials.generateIdToken for ${targetSa} returned HTTP ${res.status}: ${body.slice(0, 200)}`,
+      );
+    }
+    const parsed = (await res.json()) as { token?: string };
+    if (!parsed.token) {
+      throw new Error(`iamcredentials.generateIdToken for ${targetSa} returned no token`);
+    }
+    return parsed.token;
+  }
+
+  private async callWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(new Error("metadata/iamcredentials timeout")),
+      this.timeoutMs,
+    );
+    try {
+      return await this.fetcher(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/** Static token returner — for tests and local-dev pre-minted tokens. */
+export class StaticTokenSource implements TokenSource {
+  constructor(private readonly token: string) {}
+  getToken(_audience: string): Promise<string> {
+    return Promise.resolve(this.token);
+  }
+}
+
+/**
+ * Reads a pre-minted id_token from an env var. Useful for local development
+ * against an IAP-protected endpoint when the metadata server isn't
+ * available — the operator obtains a token via gcloud and exports it.
+ *
+ * Re-reads on every call so rotating the env between requests works (rare
+ * but cheap).
+ */
+export class EnvTokenSource implements TokenSource {
+  constructor(
+    private readonly varName: string,
+    private readonly env: NodeJS.ProcessEnv = process.env,
+  ) {}
+  getToken(_audience: string): Promise<string> {
+    const value = this.env[this.varName];
+    if (!value) {
+      return Promise.reject(
+        new Error(`iap-auth: env var ${this.varName} is not set or empty`),
+      );
+    }
+    return Promise.resolve(value);
+  }
+}

--- a/src/middleware/builtin/iap-auth/token-source.ts
+++ b/src/middleware/builtin/iap-auth/token-source.ts
@@ -252,9 +252,7 @@ export class EnvTokenSource implements TokenSource {
   getToken(_audience: string): Promise<string> {
     const value = this.env[this.varName];
     if (!value) {
-      return Promise.reject(
-        new Error(`iap-auth: env var ${this.varName} is not set or empty`),
-      );
+      return Promise.reject(new Error(`iap-auth: env var ${this.varName} is not set or empty`));
     }
     return Promise.resolve(value);
   }

--- a/src/middleware/builtin/lint/factory.ts
+++ b/src/middleware/builtin/lint/factory.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { MiddlewareFactory } from "@/middleware/types.ts";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
 import { type LintEnforce, LintMiddleware, type LintMiddlewareOptions } from "./middleware.ts";
 
 const enforceSchema: z.ZodType<LintEnforce> = z.union([
@@ -16,7 +16,7 @@ const optionsSchema = z.object({
 });
 
 /** Factory for the `lint` builtin middleware. */
-export const lintFactory: MiddlewareFactory<LintMiddlewareOptions> = {
+export const lintFactory: ServerMiddlewareFactory<LintMiddlewareOptions> = {
   name: "lint",
 
   loadFromEnv(env) {

--- a/src/middleware/builtin/lint/middleware.ts
+++ b/src/middleware/builtin/lint/middleware.ts
@@ -5,7 +5,11 @@ import {
   prepareWriteLintContext,
   type WriteLintContext,
 } from "@/lint/write-check.ts";
-import type { MiddlewareVerdict, PreWriteContext, PreWriteMiddleware } from "@/middleware/types.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
 
 /**
  * Enforcement level for the lint middleware.
@@ -35,11 +39,11 @@ const DENIAL_DOCS = "https://github.com/ubie-oss/n8n-cli#lint";
 
 /**
  * The lint middleware reuses the existing engine and write-check helpers;
- * it adds nothing on top except wiring them into the PreWriteMiddleware
+ * it adds nothing on top except wiring them into the ServerMiddleware
  * contract. The historical 422 response shape (`workflow_lint_failed`) is
  * preserved through the `denial` hint so proxy clients see no change.
  */
-export class LintMiddleware implements PreWriteMiddleware {
+export class LintMiddleware implements ServerMiddleware {
   readonly name = "lint";
   private ctx?: WriteLintContext;
 
@@ -56,7 +60,7 @@ export class LintMiddleware implements PreWriteMiddleware {
     );
   }
 
-  evaluate(ctx: PreWriteContext): MiddlewareVerdict {
+  evaluate(ctx: ServerMiddlewareContext): MiddlewareVerdict {
     if (this.options.enforce === "off") {
       return { block: false, violations: [] };
     }

--- a/src/middleware/cli-gate.ts
+++ b/src/middleware/cli-gate.ts
@@ -2,10 +2,10 @@ import type { Workflow, WorkflowInput } from "@/api/types.ts";
 import { formatViolationLine } from "@/lint/write-check.ts";
 import { disposePipeline, preparePipeline, runPipeline } from "./pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "./registry.ts";
-import type { PreWriteMiddleware } from "./types.ts";
-import { DEFAULT_MIDDLEWARE_CHAIN, registerBuiltins } from "./wiring.ts";
+import type { ServerMiddleware } from "./types.ts";
+import { DEFAULT_SERVER_MIDDLEWARE_CHAIN, registerBuiltins } from "./wiring.ts";
 
-export interface PreWriteGateOptions {
+export interface ServerMiddlewareGateOptions {
   /** Display label for the workflow source (file path or `-` for stdin). */
   source: string;
   /** Parsed workflow payload about to be written. */
@@ -38,14 +38,14 @@ export interface PreWriteGateOptions {
  * not batch runs, so there is no point continuing past a policy failure
  * to compute a partial outcome — the caller would just re-run.
  */
-export async function runPreWriteGate(options: PreWriteGateOptions): Promise<void> {
+export async function runServerMiddlewareGate(options: ServerMiddlewareGateOptions): Promise<void> {
   registerBuiltins();
   const env = options.env ?? process.env;
   const enabled = resolveEnabledList({
     cliValue: options.middlewares?.join(","),
     env,
-    envVar: "N8N_MIDDLEWARES",
-    fallback: DEFAULT_MIDDLEWARE_CHAIN,
+    envVar: "N8N_SERVER_MIDDLEWARES",
+    fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
   });
   const filtered = options.noLint ? enabled.filter((n) => n !== "lint") : enabled;
   if (filtered.length === 0) return;
@@ -56,7 +56,7 @@ export async function runPreWriteGate(options: PreWriteGateOptions): Promise<voi
     ...(options.middlewareCliOptions ?? {}),
   };
 
-  let chain: PreWriteMiddleware[];
+  let chain: ServerMiddleware[];
   try {
     chain = buildMiddlewares({ enabled: filtered, env, cliOpts: legacyCliOpts });
   } catch (err) {

--- a/src/middleware/client-pipeline.ts
+++ b/src/middleware/client-pipeline.ts
@@ -1,0 +1,34 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "./types.ts";
+
+/**
+ * Runs every enabled client middleware against the outgoing request,
+ * mutating `headers` in place.
+ *
+ * Semantics:
+ * - Middlewares execute sequentially in the order they were registered.
+ *   Earlier middlewares can set headers that later ones read (rare in
+ *   practice, but supported).
+ * - A middleware that throws aborts the whole pipeline. The thrown error
+ *   bubbles up to the proxy, which translates it into a 502 — the upstream
+ *   fetch never fires, so the client sees one clean error rather than a
+ *   half-broken upstream call.
+ */
+export async function runClientPipeline(
+  chain: ClientMiddleware[],
+  headers: Headers,
+  ctx: ClientMiddlewareContext,
+): Promise<void> {
+  for (const mw of chain) {
+    await mw.apply(headers, ctx);
+  }
+}
+
+/** Convenience: runs prepare() on every client middleware that has one. */
+export async function prepareClientPipeline(chain: ClientMiddleware[]): Promise<void> {
+  await Promise.all(chain.map((m) => m.prepare?.()));
+}
+
+/** Convenience: runs dispose() on every client middleware that has one. */
+export async function disposeClientPipeline(chain: ClientMiddleware[]): Promise<void> {
+  await Promise.all(chain.map((m) => m.dispose?.()));
+}

--- a/src/middleware/client-registry.ts
+++ b/src/middleware/client-registry.ts
@@ -1,0 +1,88 @@
+import type { ClientMiddleware, ClientMiddlewareFactory } from "./types.ts";
+
+/**
+ * In-process registry of client-middleware factories. Mirrors `registry.ts`
+ * (the server-side registry) but stays in its own module so the two
+ * pipelines can be enabled/disabled independently.
+ *
+ * Singleton by design: one CLI process per invocation, identities are global.
+ * Tests reset via `resetClientRegistry`.
+ */
+const factories = new Map<string, ClientMiddlewareFactory<unknown>>();
+
+export function registerClientFactory<O>(factory: ClientMiddlewareFactory<O>): void {
+  factories.set(factory.name, factory as ClientMiddlewareFactory<unknown>);
+}
+
+export function getClientFactory(name: string): ClientMiddlewareFactory<unknown> | undefined {
+  return factories.get(name);
+}
+
+export function knownClientMiddlewareNames(): string[] {
+  return Array.from(factories.keys());
+}
+
+export function resetClientRegistry(): void {
+  factories.clear();
+}
+
+export interface BuildClientMiddlewaresInput {
+  /** Enabled client middleware names, ordered. */
+  enabled: string[];
+  /** Raw env, defaults to process.env when omitted. */
+  env?: NodeJS.ProcessEnv;
+  /** Flat commander-style options bag from the CLI action. */
+  cliOpts?: Record<string, unknown>;
+}
+
+/**
+ * Resolves and builds the enabled client middlewares.
+ *
+ * Same precedence model as `buildMiddlewares`: env < CLI flags, with deep
+ * merge per top-level key so partial CLI overrides don't wipe env-supplied
+ * fields inside nested option buckets.
+ */
+export function buildClientMiddlewares(input: BuildClientMiddlewaresInput): ClientMiddleware[] {
+  const env = input.env ?? process.env;
+  const cliOpts = input.cliOpts ?? {};
+  const built: ClientMiddleware[] = [];
+  for (const name of input.enabled) {
+    const factory = factories.get(name);
+    if (!factory) {
+      const known = Array.from(factories.keys()).sort().join(", ") || "(none registered)";
+      throw new Error(
+        `Unknown client middleware "${name}". Known: ${known}. ` +
+          "Did you typo --client-middleware or N8N_CLIENT_MIDDLEWARES?",
+      );
+    }
+    const fromEnv = factory.loadFromEnv(env);
+    const fromCli = factory.loadFromCLI(cliOpts);
+    const merged = mergeOptions(
+      fromEnv as Record<string, unknown>,
+      fromCli as Record<string, unknown>,
+    );
+    built.push(factory.build(merged));
+  }
+  return built;
+}
+
+function mergeOptions(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...base };
+  for (const [key, ovValue] of Object.entries(override)) {
+    if (ovValue === undefined) continue;
+    const baseValue = out[key];
+    if (isPlainObject(baseValue) && isPlainObject(ovValue)) {
+      out[key] = { ...baseValue, ...ovValue };
+    } else {
+      out[key] = ovValue;
+    }
+  }
+  return out;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/src/middleware/client-wiring.ts
+++ b/src/middleware/client-wiring.ts
@@ -1,0 +1,23 @@
+import { knownClientMiddlewareNames } from "./client-registry.ts";
+
+/**
+ * Registers every built-in client-middleware factory. Called once at process
+ * startup from the CLI entry point. Idempotent: re-registration replaces
+ * the previous factory under the same name, so tests can override builtins
+ * by re-registering after `resetClientRegistry()` if needed.
+ *
+ * Currently a no-op — builtins (iap-auth, api-key-inject, ...) land in
+ * follow-up commits and self-register here.
+ */
+export function registerClientBuiltins(): void {
+  // Intentionally empty. See module doc above.
+}
+
+/**
+ * Default client-middleware chain when neither --client-middleware nor
+ * N8N_CLIENT_MIDDLEWARES is provided. Empty — client middlewares are
+ * opt-in; deployments without IAP / shared API key don't need any.
+ */
+export const DEFAULT_CLIENT_MIDDLEWARE_CHAIN: string[] = [];
+
+export { knownClientMiddlewareNames };

--- a/src/middleware/client-wiring.ts
+++ b/src/middleware/client-wiring.ts
@@ -1,16 +1,16 @@
-import { knownClientMiddlewareNames } from "./client-registry.ts";
+import { apiKeyInjectFactory } from "./builtin/api-key-inject/factory.ts";
+import { iapAuthFactory } from "./builtin/iap-auth/factory.ts";
+import { knownClientMiddlewareNames, registerClientFactory } from "./client-registry.ts";
 
 /**
  * Registers every built-in client-middleware factory. Called once at process
  * startup from the CLI entry point. Idempotent: re-registration replaces
  * the previous factory under the same name, so tests can override builtins
  * by re-registering after `resetClientRegistry()` if needed.
- *
- * Currently a no-op — builtins (iap-auth, api-key-inject, ...) land in
- * follow-up commits and self-register here.
  */
 export function registerClientBuiltins(): void {
-  // Intentionally empty. See module doc above.
+  registerClientFactory(iapAuthFactory);
+  registerClientFactory(apiKeyInjectFactory);
 }
 
 /**

--- a/src/middleware/identity.ts
+++ b/src/middleware/identity.ts
@@ -10,7 +10,7 @@
  *            environment of the CLI invocation.
  *
  * To keep middleware code from caring about which is which, identity is
- * resolved once at the pipeline entry and stuffed into `PreWriteContext`.
+ * resolved once at the pipeline entry and stuffed into `ServerMiddlewareContext`.
  *
  * JWT support is minimal: base64url-decode the payload and pull a single
  * claim. We do NOT verify the signature — this is "guardrail" identity, not

--- a/src/middleware/pipeline.ts
+++ b/src/middleware/pipeline.ts
@@ -2,8 +2,8 @@ import type { Violation } from "@/lint/rules/violation.ts";
 import type {
   MiddlewareVerdict,
   PipelineVerdict,
-  PreWriteContext,
-  PreWriteMiddleware,
+  ServerMiddleware,
+  ServerMiddlewareContext,
 } from "./types.ts";
 
 /**
@@ -23,8 +23,8 @@ import type {
  *   a malformed authz config never crashes the proxy.
  */
 export async function runPipeline(
-  chain: PreWriteMiddleware[],
-  ctx: PreWriteContext,
+  chain: ServerMiddleware[],
+  ctx: ServerMiddlewareContext,
 ): Promise<PipelineVerdict> {
   const violations: Violation[] = [];
 
@@ -65,11 +65,11 @@ export async function runPipeline(
 }
 
 /** Convenience: runs prepare() on every middleware that has one. */
-export async function preparePipeline(chain: PreWriteMiddleware[]): Promise<void> {
+export async function preparePipeline(chain: ServerMiddleware[]): Promise<void> {
   await Promise.all(chain.map((m) => m.prepare?.()));
 }
 
 /** Convenience: runs dispose() on every middleware that has one. */
-export async function disposePipeline(chain: PreWriteMiddleware[]): Promise<void> {
+export async function disposePipeline(chain: ServerMiddleware[]): Promise<void> {
   await Promise.all(chain.map((m) => m.dispose?.()));
 }

--- a/src/middleware/registry.ts
+++ b/src/middleware/registry.ts
@@ -1,22 +1,22 @@
-import type { MiddlewareFactory, PreWriteMiddleware } from "./types.ts";
+import type { ServerMiddleware, ServerMiddlewareFactory } from "./types.ts";
 
 /**
- * In-process registry of middleware factories. Builtins register themselves
- * via `registerBuiltins` (called from cli/middleware-wiring); tests can
- * register fakes directly for isolation.
+ * In-process registry of server-middleware factories. Builtins register
+ * themselves via `registerBuiltins` (called from cli/middleware-wiring);
+ * tests can register fakes directly for isolation.
  *
  * The registry is intentionally a singleton: there is one CLI process per
  * invocation, and middleware identities ("lint", "authz") are inherently
  * global names. Per-test pollution is avoided via `resetRegistry` in
  * test helpers.
  */
-const factories = new Map<string, MiddlewareFactory<unknown>>();
+const factories = new Map<string, ServerMiddlewareFactory<unknown>>();
 
-export function registerFactory<O>(factory: MiddlewareFactory<O>): void {
-  factories.set(factory.name, factory as MiddlewareFactory<unknown>);
+export function registerFactory<O>(factory: ServerMiddlewareFactory<O>): void {
+  factories.set(factory.name, factory as ServerMiddlewareFactory<unknown>);
 }
 
-export function getFactory(name: string): MiddlewareFactory<unknown> | undefined {
+export function getFactory(name: string): ServerMiddlewareFactory<unknown> | undefined {
   return factories.get(name);
 }
 
@@ -48,17 +48,17 @@ export interface BuildMiddlewaresInput {
  * Unknown middleware names throw with a friendly list so users can't
  * silently disable the pipeline by typoing a name in env.
  */
-export function buildMiddlewares(input: BuildMiddlewaresInput): PreWriteMiddleware[] {
+export function buildMiddlewares(input: BuildMiddlewaresInput): ServerMiddleware[] {
   const env = input.env ?? process.env;
   const cliOpts = input.cliOpts ?? {};
-  const built: PreWriteMiddleware[] = [];
+  const built: ServerMiddleware[] = [];
   for (const name of input.enabled) {
     const factory = factories.get(name);
     if (!factory) {
       const known = Array.from(factories.keys()).sort().join(", ") || "(none registered)";
       throw new Error(
-        `Unknown middleware "${name}". Known middlewares: ${known}. ` +
-          "Did you typo --middleware or N8N_MIDDLEWARES?",
+        `Unknown server middleware "${name}". Known: ${known}. ` +
+          "Did you typo --server-middleware or N8N_SERVER_MIDDLEWARES?",
       );
     }
     const fromEnv = factory.loadFromEnv(env);
@@ -115,7 +115,7 @@ export function parseMiddlewareList(value: string | undefined): string[] {
  * Resolves the active middleware list from CLI/env with a fallback default.
  *
  * Precedence:
- *   1. `cliValue` (e.g. commander's --middleware) when non-empty
+ *   1. `cliValue` (e.g. commander's --server-middleware) when non-empty
  *   2. `env[envVar]` when non-empty
  *   3. `fallback` (typically ["lint"] for backwards compatibility)
  */

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -4,8 +4,8 @@ import type { Violation } from "@/lint/rules/violation.ts";
 /** Where the pipeline is running. Middlewares can adapt to context. */
 export type PipelineMode = "proxy" | "apply" | "single";
 
-/** Per-request input handed to each middleware. */
-export interface PreWriteContext {
+/** Per-request input handed to each server middleware. */
+export interface ServerMiddlewareContext {
   /** Parsed workflow. May be null when JSON parsing failed upstream. */
   workflow: Workflow | null;
   /**
@@ -54,9 +54,11 @@ export interface PipelineVerdict {
 }
 
 /**
- * Pre-write middleware contract. Implementations are constructed once per
- * pipeline (per-process for proxy, per-`apply` invocation otherwise) and
- * called for every workflow write.
+ * Server-side middleware contract. Runs on the ingress (proxy receive /
+ * apply read) side, where the responsibility is "should this write proceed
+ * at all?". Implementations are constructed once per pipeline (per-process
+ * for proxy, per-`apply` invocation otherwise) and called for every workflow
+ * write.
  *
  * `prepare` runs once before the first workflow is evaluated. Long-running
  * resolvers (e.g. authz fetching the actor's groups) belong here so the
@@ -64,26 +66,30 @@ export interface PipelineVerdict {
  *
  * `dispose` is invoked on process shutdown / apply end. Used by middlewares
  * that hold long-lived state such as caches or background timers.
+ *
+ * Mirrors gRPC's ServerInterceptor concept. The egress counterpart that
+ * rewrites the outgoing upstream request lives in `ClientMiddleware`.
  */
-export interface PreWriteMiddleware {
+export interface ServerMiddleware {
   readonly name: string;
-  evaluate(ctx: PreWriteContext): Promise<MiddlewareVerdict> | MiddlewareVerdict;
+  evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> | MiddlewareVerdict;
   prepare?(): Promise<void> | void;
   dispose?(): Promise<void> | void;
 }
 
 /**
- * Factory contract for registering a middleware with the CLI/env loader.
+ * Factory contract for registering a server middleware with the CLI/env
+ * loader.
  *
  * Each builtin lives behind one of these so the registry can:
- *   1. Discover whether the user enabled it (via `--middleware` or env list).
+ *   1. Discover whether the user enabled it (via `--server-middleware` or env list).
  *   2. Collect options from env / CLI flags.
  *   3. Validate via zod and build the runtime middleware.
  *
  * Splitting build from collection keeps the loader testable in isolation —
  * unit tests assemble Options objects directly without going through env.
  */
-export interface MiddlewareFactory<O> {
+export interface ServerMiddlewareFactory<O> {
   readonly name: string;
   /**
    * Returns a partial Options block parsed from process.env. Returning a
@@ -101,5 +107,65 @@ export interface MiddlewareFactory<O> {
    * Throws when required fields are missing or malformed; callers surface
    * the error message verbatim.
    */
-  build(options: unknown): PreWriteMiddleware;
+  build(options: unknown): ServerMiddleware;
+}
+
+/**
+ * Context handed to a `ClientMiddleware.apply()` call right before the
+ * proxy fetches the upstream. Mirrors what the proxy actually has on hand —
+ * the original incoming request (for headers/identity), the resolved
+ * upstream URL, the HTTP method, and the path being forwarded.
+ *
+ * Client middlewares mutate `headers` in place; the proxy then uses that
+ * (already hop-by-hop stripped) Headers instance for the upstream fetch.
+ */
+export interface ClientMiddlewareContext {
+  /** The original incoming Request from the proxy client. */
+  request: Request;
+  /** HTTP method that will be sent upstream. */
+  method: string;
+  /** Pathname (and query) of the upstream URL — useful for scope decisions. */
+  pathname: string;
+  /** Fully-resolved upstream URL the proxy is about to fetch. */
+  upstreamUrl: string;
+}
+
+/**
+ * Client-side middleware contract. Runs on the egress side, right before the
+ * proxy forwards a request to upstream. Used to rewrite outgoing headers —
+ * e.g. mint an IAP id_token, inject a shared n8n API key, propagate a trace
+ * header.
+ *
+ * Runs for EVERY upstream call the proxy makes (workflow mutations and
+ * transparent forwards alike) — distinct from `ServerMiddleware`, which only
+ * runs for the policy-gated workflow-mutation path.
+ *
+ * Mirrors gRPC's ClientInterceptor concept.
+ */
+export interface ClientMiddleware {
+  readonly name: string;
+  /**
+   * Mutate `headers` in place. The proxy has already stripped hop-by-hop
+   * headers, so callers can freely add/remove without re-checking that
+   * surface.
+   *
+   * Throwing here aborts the upstream fetch — the proxy will return 502 to
+   * the client with the error message. Use this for unrecoverable errors
+   * (e.g. failed id_token mint); for soft degradation, swallow and continue.
+   */
+  apply(headers: Headers, ctx: ClientMiddlewareContext): Promise<void> | void;
+  prepare?(): Promise<void> | void;
+  dispose?(): Promise<void> | void;
+}
+
+/**
+ * Factory contract for registering a client middleware with the CLI/env
+ * loader. Same shape as `ServerMiddlewareFactory`; kept as a separate type
+ * so the registry can stay statically split between the two pipelines.
+ */
+export interface ClientMiddlewareFactory<O> {
+  readonly name: string;
+  loadFromEnv(env: NodeJS.ProcessEnv): Partial<O>;
+  loadFromCLI(cliOpts: Record<string, unknown>): Partial<O>;
+  build(options: unknown): ClientMiddleware;
 }

--- a/src/middleware/wiring.ts
+++ b/src/middleware/wiring.ts
@@ -14,10 +14,11 @@ export function registerBuiltins(): void {
 }
 
 /**
- * Default middleware chain when neither --middleware nor N8N_MIDDLEWARES
- * is provided. Lint-only preserves backwards compatibility: every command
- * that used to run a lint check still runs exactly the same one.
+ * Default server-middleware chain when neither --server-middleware nor
+ * N8N_SERVER_MIDDLEWARES is provided. Lint-only preserves backwards
+ * compatibility: every command that used to run a lint check still runs
+ * exactly the same one.
  */
-export const DEFAULT_MIDDLEWARE_CHAIN = ["lint"];
+export const DEFAULT_SERVER_MIDDLEWARE_CHAIN = ["lint"];
 
 export { knownMiddlewareNames };

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -50,6 +50,21 @@ export interface ProxyConfig {
    * intercepted save" (legacy behavior).
    */
   filterByTags?: string[];
+  /**
+   * Ordered list of client middleware names to apply to every outgoing
+   * upstream request (mutation and transparent-forward paths alike).
+   *
+   * Defaults to [] when omitted. Use for outgoing-side concerns: IAP token
+   * minting (`iap-auth`), shared API-key injection (`api-key-inject`),
+   * trace-header propagation, etc.
+   */
+  clientMiddlewares?: string[];
+  /**
+   * Flat commander-style options bag forwarded to each client-middleware
+   * factory. Populated by `cli/commands/proxy.ts` so each middleware can
+   * pick out its own keys.
+   */
+  clientMiddlewareCliOptions?: Record<string, unknown>;
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,9 +1,14 @@
 import type { Workflow } from "@/api/types.ts";
 import { hasAllTags } from "@/common/tags.ts";
+import { buildClientMiddlewares } from "@/middleware/client-registry.ts";
+import {
+  DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
+  registerClientBuiltins,
+} from "@/middleware/client-wiring.ts";
 import { runPipeline } from "@/middleware/pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "@/middleware/registry.ts";
-import type { PreWriteMiddleware } from "@/middleware/types.ts";
-import { DEFAULT_MIDDLEWARE_CHAIN, registerBuiltins } from "@/middleware/wiring.ts";
+import type { ClientMiddleware, ServerMiddleware } from "@/middleware/types.ts";
+import { DEFAULT_SERVER_MIDDLEWARE_CHAIN, registerBuiltins } from "@/middleware/wiring.ts";
 import { normalizeUpstream, type ProxyConfig, parseListenAddr } from "./config.ts";
 import { DuplicateChecker } from "./duplicate.ts";
 import { Logger } from "./logging.ts";
@@ -16,7 +21,8 @@ import {
 import { matchWorkflowMutation, type WorkflowMutation } from "./rest/router.ts";
 import { forwardRequest } from "./upstream.ts";
 
-const MIDDLEWARES_ENV_VAR = "N8N_MIDDLEWARES";
+const SERVER_MIDDLEWARES_ENV_VAR = "N8N_SERVER_MIDDLEWARES";
+const CLIENT_MIDDLEWARES_ENV_VAR = "N8N_CLIENT_MIDDLEWARES";
 
 /**
  * Tracks whether middleware `prepare()` has finished so `/readyz` can flip
@@ -37,7 +43,8 @@ interface HandlerDeps {
   config: ProxyConfig;
   logger: Logger;
   duplicates: DuplicateChecker | null;
-  middlewares: PreWriteMiddleware[];
+  middlewares: ServerMiddleware[];
+  clientMiddlewares: ClientMiddleware[];
   readiness: ReadinessState;
 }
 
@@ -46,20 +53,22 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   // Register builtin middleware factories. Idempotent — safe to call once
   // per `startProxy` invocation (tests call this repeatedly).
   registerBuiltins();
+  registerClientBuiltins();
 
   const { host, port } = parseListenAddr(config.listen);
   const upstream = normalizeUpstream(config.upstream);
   const logger = new Logger(config.logFormat);
 
-  // Decide which middlewares to run. Precedence: explicit config (set by
-  // the CLI from --middleware) > N8N_MIDDLEWARES env var > legacy default
-  // ["lint"]. Matches apply's behavior so the env-var contract documented
-  // on --middleware ("env: N8N_MIDDLEWARES") holds for the proxy too.
+  // Decide which server middlewares to run. Precedence: explicit config (set
+  // by the CLI from --server-middleware) > N8N_SERVER_MIDDLEWARES env var >
+  // legacy default ["lint"]. Matches apply's behavior so the env-var contract
+  // documented on --server-middleware ("env: N8N_SERVER_MIDDLEWARES") holds
+  // for the proxy too.
   const enabled = resolveEnabledList({
     cliValue: config.middlewares?.join(","),
     env: process.env,
-    envVar: MIDDLEWARES_ENV_VAR,
-    fallback: DEFAULT_MIDDLEWARE_CHAIN,
+    envVar: SERVER_MIDDLEWARES_ENV_VAR,
+    fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
   });
 
   // Stitch the legacy --enforce / --lint-config / --disable-rule flags into
@@ -78,6 +87,20 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     cliOpts: legacyCliOpts,
   });
 
+  // Resolve and build the client-side (outgoing) middleware chain. Empty by
+  // default — deployments without IAP / shared API key skip this entirely.
+  const enabledClient = resolveEnabledList({
+    cliValue: config.clientMiddlewares?.join(","),
+    env: process.env,
+    envVar: CLIENT_MIDDLEWARES_ENV_VAR,
+    fallback: DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
+  });
+  const clientMiddlewares = buildClientMiddlewares({
+    enabled: enabledClient,
+    env: process.env,
+    cliOpts: config.clientMiddlewareCliOptions ?? {},
+  });
+
   // Run prepare() up front so identity-resolution / config-load failures
   // surface at startup rather than on the first request. We also track the
   // result so `/readyz` can report 503 until every middleware finishes
@@ -87,8 +110,12 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   // don't probe `/readyz` (bare docker, local dev) still see the breakage
   // — without this the proxy would run silently in a broken state.
   const readiness: ReadinessState = { status: "preparing", errors: [] };
+  const allForPrepare: Array<{ name: string; prepare?: () => unknown }> = [
+    ...middlewares,
+    ...clientMiddlewares,
+  ];
   Promise.all(
-    middlewares.map(async (mw) => {
+    allForPrepare.map(async (mw) => {
       try {
         await mw.prepare?.();
         return null;
@@ -113,7 +140,15 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     ? null
     : new DuplicateChecker(upstream, config.duplicateTtlMs);
 
-  const deps: HandlerDeps = { upstream, config, logger, duplicates, middlewares, readiness };
+  const deps: HandlerDeps = {
+    upstream,
+    config,
+    logger,
+    duplicates,
+    middlewares,
+    clientMiddlewares,
+    readiness,
+  };
 
   const server = Bun.serve({
     hostname: host,
@@ -125,7 +160,10 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     port: server.port ?? port,
     stop: async () => {
       await server.stop(true);
-      await Promise.all(middlewares.map((m) => m.dispose?.()));
+      await Promise.all([
+        ...middlewares.map((m) => m.dispose?.()),
+        ...clientMiddlewares.map((m) => m.dispose?.()),
+      ]);
     },
   };
 }
@@ -194,6 +232,7 @@ async function handleTransparentForward(
   try {
     const { response, elapsedMs } = await forwardRequest(req, deps.upstream, undefined, {
       timeoutMs: deps.config.upstreamTimeoutMs,
+      clientMiddlewares: deps.clientMiddlewares,
     });
     deps.logger.log({
       action: "forward",
@@ -298,6 +337,7 @@ async function handleWorkflowMutation(
   try {
     const { response, elapsedMs } = await forwardRequest(req, deps.upstream, rawJSON, {
       timeoutMs: deps.config.upstreamTimeoutMs,
+      clientMiddlewares: deps.clientMiddlewares,
     });
     if (verdict.violations.length > 0) {
       const errCount = verdict.violations.filter(
@@ -357,6 +397,7 @@ async function handleSkippedMutation(
   try {
     const { response, elapsedMs } = await forwardRequest(req, deps.upstream, rawJSON, {
       timeoutMs: deps.config.upstreamTimeoutMs,
+      clientMiddlewares: deps.clientMiddlewares,
     });
     deps.logger.log({
       action: "forward",

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -8,10 +8,13 @@
  * the upstream call). `Content-Length` is also stripped because fetch
  * recomputes it from the actual body.
  *
- * Preserves auth headers including `X-N8N-API-KEY` and `Authorization` since
- * the client is expected to supply them and the upstream needs them to
- * authenticate.
+ * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) by default — the
+ * client is expected to supply them and the upstream needs them to
+ * authenticate. Client middlewares (see `ClientMiddleware`) can rewrite or
+ * replace these after the strip step but before fetch.
  */
+import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -47,6 +50,16 @@ function buildUpstreamHeaders(req: Request): Headers {
 export interface ForwardOptions {
   /** Total request timeout in milliseconds; 0 disables timeout. */
   timeoutMs?: number;
+  /**
+   * Ordered list of client middlewares to apply to the outgoing request,
+   * after hop-by-hop stripping and before fetch. Each middleware can mutate
+   * the outgoing Headers (e.g. mint an IAP id_token, inject a shared n8n
+   * API key, propagate a trace header).
+   *
+   * A middleware that throws aborts the upstream fetch — the caller sees
+   * the error and translates it into a 502.
+   */
+  clientMiddlewares?: ClientMiddleware[];
 }
 
 export async function forwardRequest(
@@ -59,6 +72,16 @@ export async function forwardRequest(
   const upstreamUrl = `${upstreamBase}${incomingUrl.pathname}${incomingUrl.search}`;
 
   const headers = buildUpstreamHeaders(req);
+
+  const clientMiddlewares = options?.clientMiddlewares ?? [];
+  if (clientMiddlewares.length > 0) {
+    await runClientPipeline(clientMiddlewares, headers, {
+      request: req,
+      method: req.method,
+      pathname: incomingUrl.pathname,
+      upstreamUrl,
+    });
+  }
 
   const init: RequestInit = {
     method: req.method,

--- a/tests/middleware/builtin/api-key-inject/middleware.test.ts
+++ b/tests/middleware/builtin/api-key-inject/middleware.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { apiKeyInjectFactory } from "@/middleware/builtin/api-key-inject/factory.ts";
+import { ApiKeyInjectMiddleware } from "@/middleware/builtin/api-key-inject/middleware.ts";
+
+const baseCtx = {
+  request: new Request("http://proxy.local/api/v1/workflows"),
+  method: "GET",
+  pathname: "/api/v1/workflows",
+  upstreamUrl: "http://upstream.local/api/v1/workflows",
+};
+
+describe("ApiKeyInjectMiddleware", () => {
+  test("sets the configured header to the key value", () => {
+    const mw = new ApiKeyInjectMiddleware({
+      header: "X-N8N-API-KEY",
+      apiKey: "key-1",
+      conflictPolicy: "replace",
+    });
+    const headers = new Headers();
+    mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("key-1");
+  });
+
+  test("replace policy overwrites an incoming header value", () => {
+    const mw = new ApiKeyInjectMiddleware({
+      header: "X-N8N-API-KEY",
+      apiKey: "shared",
+      conflictPolicy: "replace",
+    });
+    const headers = new Headers({ "X-N8N-API-KEY": "client-supplied" });
+    mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("shared");
+  });
+
+  test("set-if-absent policy leaves an incoming value intact", () => {
+    const mw = new ApiKeyInjectMiddleware({
+      header: "X-N8N-API-KEY",
+      apiKey: "shared",
+      conflictPolicy: "set-if-absent",
+    });
+    const headers = new Headers({ "X-N8N-API-KEY": "client-supplied" });
+    mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("client-supplied");
+  });
+
+  test("set-if-absent policy sets when missing", () => {
+    const mw = new ApiKeyInjectMiddleware({
+      header: "X-N8N-API-KEY",
+      apiKey: "shared",
+      conflictPolicy: "set-if-absent",
+    });
+    const headers = new Headers();
+    mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("shared");
+  });
+
+  test("custom header name", () => {
+    const mw = new ApiKeyInjectMiddleware({
+      header: "X-Custom-Key",
+      apiKey: "v",
+      conflictPolicy: "replace",
+    });
+    const headers = new Headers();
+    mw.apply(headers, baseCtx);
+    expect(headers.get("X-Custom-Key")).toBe("v");
+    expect(headers.has("X-N8N-API-KEY")).toBe(false);
+  });
+});
+
+describe("apiKeyInjectFactory", () => {
+  test("rejects when apiKey missing", () => {
+    expect(() => apiKeyInjectFactory.build({})).toThrow();
+  });
+
+  test("loadFromEnv reads N8N_API_KEY_INJECT_KEY directly", () => {
+    const partial = apiKeyInjectFactory.loadFromEnv({ N8N_API_KEY_INJECT_KEY: "direct-key" });
+    expect(partial.apiKey).toBe("direct-key");
+  });
+
+  test("loadFromEnv resolves indirection via N8N_API_KEY_INJECT_KEY_ENV_VAR", () => {
+    const partial = apiKeyInjectFactory.loadFromEnv({
+      N8N_API_KEY_INJECT_KEY_ENV_VAR: "MY_SECRET",
+      MY_SECRET: "resolved-key",
+    });
+    expect(partial.apiKey).toBe("resolved-key");
+  });
+
+  test("direct key wins over indirection when both present", () => {
+    const partial = apiKeyInjectFactory.loadFromEnv({
+      N8N_API_KEY_INJECT_KEY: "direct",
+      N8N_API_KEY_INJECT_KEY_ENV_VAR: "OTHER",
+      OTHER: "indirect",
+    });
+    expect(partial.apiKey).toBe("direct");
+  });
+
+  describe("loadFromCLI", () => {
+    const savedEnv = process.env.SHARED_N8N_KEY_FOR_TESTS;
+
+    beforeEach(() => {
+      process.env.SHARED_N8N_KEY_FOR_TESTS = "cli-resolved";
+    });
+    afterEach(() => {
+      if (savedEnv === undefined) delete process.env.SHARED_N8N_KEY_FOR_TESTS;
+      else process.env.SHARED_N8N_KEY_FOR_TESTS = savedEnv;
+    });
+
+    test("resolves the key via the named env var", () => {
+      const partial = apiKeyInjectFactory.loadFromCLI({
+        apiKeyInjectKeyEnvVar: "SHARED_N8N_KEY_FOR_TESTS",
+      });
+      expect(partial.apiKey).toBe("cli-resolved");
+    });
+
+    test("does not surface the raw key under any other CLI key — only the env-var name is honored", () => {
+      // Even if a hypothetical "apiKeyInjectKey" is passed, the factory ignores it
+      // because the raw key must never come from the CLI.
+      const partial = apiKeyInjectFactory.loadFromCLI({
+        apiKeyInjectKey: "raw-on-cli",
+      } as Record<string, unknown>);
+      expect(partial.apiKey).toBeUndefined();
+    });
+  });
+
+  test("defaults header to X-N8N-API-KEY and conflictPolicy to replace", async () => {
+    const mw = apiKeyInjectFactory.build({ apiKey: "k" });
+    const headers = new Headers({ "X-N8N-API-KEY": "preexisting" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("k");
+  });
+
+  test("custom conflictPolicy from env", async () => {
+    const partial = apiKeyInjectFactory.loadFromEnv({
+      N8N_API_KEY_INJECT_KEY: "k",
+      N8N_API_KEY_INJECT_CONFLICT_POLICY: "set-if-absent",
+    });
+    const mw = apiKeyInjectFactory.build(partial);
+    const headers = new Headers({ "X-N8N-API-KEY": "user" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("X-N8N-API-KEY")).toBe("user");
+  });
+});

--- a/tests/middleware/builtin/authz.test.ts
+++ b/tests/middleware/builtin/authz.test.ts
@@ -5,7 +5,7 @@ import type { FetchLike } from "@/middleware/builtin/authz/groups-resolver.ts";
 import { AuthzMiddleware } from "@/middleware/builtin/authz/middleware.ts";
 import type { AuthzOptions } from "@/middleware/builtin/authz/types.ts";
 import { WorkflowACLExtractor } from "@/middleware/builtin/authz/workflow-acl.ts";
-import type { PreWriteContext } from "@/middleware/types.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
 
 const baseOptions: AuthzOptions = {
   enforce: "error",
@@ -43,7 +43,7 @@ function fetchReturning(json: unknown, status = 200): FetchLike {
     );
 }
 
-function ctxFor(workflow: Workflow, identity?: string): PreWriteContext {
+function ctxFor(workflow: Workflow, identity?: string): ServerMiddlewareContext {
   return { workflow, identity, mode: "proxy" };
 }
 

--- a/tests/middleware/builtin/iap-auth/middleware.test.ts
+++ b/tests/middleware/builtin/iap-auth/middleware.test.ts
@@ -83,15 +83,15 @@ describe("iapAuthFactory", () => {
   });
 
   test("env source requires tokenEnvVar", () => {
-    expect(() =>
-      iapAuthFactory.build({ audience: "a", tokenSourceKind: "env" }),
-    ).toThrow(/tokenEnvVar/);
+    expect(() => iapAuthFactory.build({ audience: "a", tokenSourceKind: "env" })).toThrow(
+      /tokenEnvVar/,
+    );
   });
 
   test("static source requires staticToken", () => {
-    expect(() =>
-      iapAuthFactory.build({ audience: "a", tokenSourceKind: "static" }),
-    ).toThrow(/staticToken/);
+    expect(() => iapAuthFactory.build({ audience: "a", tokenSourceKind: "static" })).toThrow(
+      /staticToken/,
+    );
   });
 
   test("static source builds a middleware that sets the configured token", async () => {

--- a/tests/middleware/builtin/iap-auth/middleware.test.ts
+++ b/tests/middleware/builtin/iap-auth/middleware.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { iapAuthFactory } from "@/middleware/builtin/iap-auth/factory.ts";
+import { IapAuthMiddleware } from "@/middleware/builtin/iap-auth/middleware.ts";
+import { StaticTokenSource, type TokenSource } from "@/middleware/builtin/iap-auth/token-source.ts";
+
+const baseCtx = {
+  request: new Request("http://proxy.local/api/v1/workflows"),
+  method: "GET",
+  pathname: "/api/v1/workflows",
+  upstreamUrl: "http://upstream.local/api/v1/workflows",
+};
+
+describe("IapAuthMiddleware", () => {
+  test("sets Authorization: Bearer <token>", async () => {
+    const mw = new IapAuthMiddleware({
+      audience: "aud",
+      tokenSource: new StaticTokenSource("tok-1"),
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer tok-1");
+  });
+
+  test("replaces an incoming Authorization header (the IAP#1 audience would mismatch IAP#2)", async () => {
+    const mw = new IapAuthMiddleware({
+      audience: "aud",
+      tokenSource: new StaticTokenSource("fresh-token"),
+    });
+    const headers = new Headers({
+      authorization: "Bearer client-supplied-token-for-iap-1",
+      "x-other": "preserved",
+    });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer fresh-token");
+    expect(headers.get("x-other")).toBe("preserved");
+  });
+
+  test("requests the token using the configured audience", async () => {
+    let seenAud: string | undefined;
+    const src: TokenSource = {
+      getToken(aud) {
+        seenAud = aud;
+        return Promise.resolve("t");
+      },
+    };
+    const mw = new IapAuthMiddleware({ audience: "https://example.com/iap", tokenSource: src });
+    await mw.apply(new Headers(), baseCtx);
+    expect(seenAud).toBe("https://example.com/iap");
+  });
+
+  test("propagates token-source errors", async () => {
+    const src: TokenSource = {
+      getToken: () => Promise.reject(new Error("metadata down")),
+    };
+    const mw = new IapAuthMiddleware({ audience: "a", tokenSource: src });
+    await expect(mw.apply(new Headers(), baseCtx)).rejects.toThrow(/metadata down/);
+  });
+});
+
+describe("iapAuthFactory", () => {
+  test("rejects when audience missing", () => {
+    expect(() => iapAuthFactory.build({})).toThrow();
+  });
+
+  test("loads audience and token-env-var from env", () => {
+    const partial = iapAuthFactory.loadFromEnv({
+      N8N_IAP_AUTH_AUDIENCE: "aud-from-env",
+      N8N_IAP_AUTH_TOKEN_SOURCE: "env",
+      N8N_IAP_AUTH_TOKEN_ENV_VAR: "MY_TOKEN",
+    });
+    expect(partial.audience).toBe("aud-from-env");
+    expect(partial.tokenSourceKind).toBe("env");
+    expect(partial.tokenEnvVar).toBe("MY_TOKEN");
+  });
+
+  test("loads from CLI", () => {
+    const partial = iapAuthFactory.loadFromCLI({
+      iapAuthAudience: "aud-cli",
+      iapAuthCacheTtlMs: "60000",
+    });
+    expect(partial.audience).toBe("aud-cli");
+    expect(partial.cacheTtlMs).toBe(60_000);
+  });
+
+  test("env source requires tokenEnvVar", () => {
+    expect(() =>
+      iapAuthFactory.build({ audience: "a", tokenSourceKind: "env" }),
+    ).toThrow(/tokenEnvVar/);
+  });
+
+  test("static source requires staticToken", () => {
+    expect(() =>
+      iapAuthFactory.build({ audience: "a", tokenSourceKind: "static" }),
+    ).toThrow(/staticToken/);
+  });
+
+  test("static source builds a middleware that sets the configured token", async () => {
+    const mw = iapAuthFactory.build({
+      audience: "a",
+      tokenSourceKind: "static",
+      staticToken: "fixed-token",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer fixed-token");
+  });
+
+  test("loadFromEnv picks up impersonation settings", () => {
+    const partial = iapAuthFactory.loadFromEnv({
+      N8N_IAP_AUTH_AUDIENCE: "a",
+      N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT: "target@p.iam.gserviceaccount.com",
+    });
+    expect(partial.impersonateServiceAccount).toBe("target@p.iam.gserviceaccount.com");
+  });
+
+  test("loadFromCLI picks up impersonation settings", () => {
+    const partial = iapAuthFactory.loadFromCLI({
+      iapAuthAudience: "a",
+      iapAuthImpersonateServiceAccount: "target@p.iam.gserviceaccount.com",
+    });
+    expect(partial.impersonateServiceAccount).toBe("target@p.iam.gserviceaccount.com");
+  });
+});

--- a/tests/middleware/builtin/iap-auth/token-source.test.ts
+++ b/tests/middleware/builtin/iap-auth/token-source.test.ts
@@ -110,7 +110,12 @@ describe("MetadataServerTokenSource impersonation", () => {
       const u = String(url);
       const h = new Headers(init?.headers);
       const body = typeof init?.body === "string" ? init.body : undefined;
-      calls.push({ url: u, method: init?.method ?? "GET", auth: h.get("authorization") ?? undefined, body });
+      calls.push({
+        url: u,
+        method: init?.method ?? "GET",
+        auth: h.get("authorization") ?? undefined,
+        body,
+      });
       if (u.endsWith("/token")) {
         return jsonResponse({ access_token: "caller-at", expires_in: 3600 });
       }

--- a/tests/middleware/builtin/iap-auth/token-source.test.ts
+++ b/tests/middleware/builtin/iap-auth/token-source.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EnvTokenSource,
+  type FetchLike,
+  MetadataServerTokenSource,
+  StaticTokenSource,
+} from "@/middleware/builtin/iap-auth/token-source.ts";
+
+function tokenResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { "content-type": "text/plain" } });
+}
+
+describe("MetadataServerTokenSource", () => {
+  test("fetches once and caches subsequent calls for the same audience", async () => {
+    let hits = 0;
+    const fetcher: FetchLike = (url) => {
+      hits++;
+      expect(url).toContain("audience=https%3A%2F%2Fexample.com");
+      return Promise.resolve(tokenResponse("token-1"));
+    };
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0, cacheTtlMs: 1_000_000 });
+    expect(await src.getToken("https://example.com")).toBe("token-1");
+    expect(await src.getToken("https://example.com")).toBe("token-1");
+    expect(hits).toBe(1);
+  });
+
+  test("refetches once cached entry expires", async () => {
+    let hits = 0;
+    let nowMs = 0;
+    const fetcher: FetchLike = () => {
+      hits++;
+      return Promise.resolve(tokenResponse(`token-${hits}`));
+    };
+    const src = new MetadataServerTokenSource({
+      fetcher,
+      now: () => nowMs,
+      cacheTtlMs: 1000,
+    });
+    expect(await src.getToken("aud")).toBe("token-1");
+    nowMs = 1500;
+    expect(await src.getToken("aud")).toBe("token-2");
+    expect(hits).toBe(2);
+  });
+
+  test("caches per audience independently", async () => {
+    let hits = 0;
+    const fetcher: FetchLike = (url) => {
+      hits++;
+      const u = new URL(url);
+      return Promise.resolve(tokenResponse(`tk-${u.searchParams.get("audience")}`));
+    };
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0, cacheTtlMs: 1_000_000 });
+    expect(await src.getToken("a")).toBe("tk-a");
+    expect(await src.getToken("b")).toBe("tk-b");
+    expect(await src.getToken("a")).toBe("tk-a");
+    expect(hits).toBe(2);
+  });
+
+  test("coalesces concurrent misses for the same audience into one fetch", async () => {
+    let hits = 0;
+    const fetcher: FetchLike = () => {
+      hits++;
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(tokenResponse("token-coal")), 5);
+      });
+    };
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0, cacheTtlMs: 1_000_000 });
+    const [a, b, c] = await Promise.all([src.getToken("x"), src.getToken("x"), src.getToken("x")]);
+    expect(a).toBe("token-coal");
+    expect(b).toBe("token-coal");
+    expect(c).toBe("token-coal");
+    expect(hits).toBe(1);
+  });
+
+  test("rejects with a clear message on non-200 metadata response", async () => {
+    const fetcher: FetchLike = () => Promise.resolve(tokenResponse("forbidden", 403));
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0 });
+    await expect(src.getToken("aud")).rejects.toThrow(/HTTP 403/);
+  });
+
+  test("rejects on empty token body", async () => {
+    const fetcher: FetchLike = () => Promise.resolve(tokenResponse("   "));
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0 });
+    await expect(src.getToken("aud")).rejects.toThrow(/empty/);
+  });
+
+  test("sends Metadata-Flavor: Google header", async () => {
+    let captured: Headers | undefined;
+    const fetcher: FetchLike = (_url, init) => {
+      captured = new Headers(init?.headers);
+      return Promise.resolve(tokenResponse("ok"));
+    };
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0 });
+    await src.getToken("aud");
+    expect(captured?.get("Metadata-Flavor")).toBe("Google");
+  });
+});
+
+describe("MetadataServerTokenSource impersonation", () => {
+  function jsonResponse(payload: unknown, status = 200): Response {
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  test("uses iamcredentials API and forwards the caller's access_token", async () => {
+    const calls: Array<{ url: string; method: string; auth?: string; body?: string }> = [];
+    const fetcher: FetchLike = async (url, init) => {
+      const u = String(url);
+      const h = new Headers(init?.headers);
+      const body = typeof init?.body === "string" ? init.body : undefined;
+      calls.push({ url: u, method: init?.method ?? "GET", auth: h.get("authorization") ?? undefined, body });
+      if (u.endsWith("/token")) {
+        return jsonResponse({ access_token: "caller-at", expires_in: 3600 });
+      }
+      if (u.includes(":generateIdToken")) {
+        return jsonResponse({ token: "impersonated-id-token" });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    };
+    const src = new MetadataServerTokenSource({
+      fetcher,
+      now: () => 0,
+      impersonateServiceAccount: "target-sa@proj.iam.gserviceaccount.com",
+      iamCredentialsBaseUrl: "https://iam.fake",
+    });
+    const token = await src.getToken("https://example.com/iap");
+    expect(token).toBe("impersonated-id-token");
+    // Two calls: 1) get access_token, 2) call generateIdToken with it.
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.url).toContain("/instance/service-accounts/default/token");
+    expect(calls[1]!.url).toBe(
+      "https://iam.fake/projects/-/serviceAccounts/target-sa%40proj.iam.gserviceaccount.com:generateIdToken",
+    );
+    expect(calls[1]!.method).toBe("POST");
+    expect(calls[1]!.auth).toBe("Bearer caller-at");
+    expect(JSON.parse(calls[1]!.body!)).toEqual({
+      audience: "https://example.com/iap",
+      includeEmail: false,
+    });
+  });
+
+  test("caches the caller's access_token across multiple impersonation calls", async () => {
+    let atHits = 0;
+    let idtHits = 0;
+    const fetcher: FetchLike = async (url) => {
+      const u = String(url);
+      if (u.endsWith("/token")) {
+        atHits++;
+        return new Response(JSON.stringify({ access_token: "at", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes(":generateIdToken")) {
+        idtHits++;
+        const audMatch = u; // just count
+        void audMatch;
+        return new Response(JSON.stringify({ token: `idt-${idtHits}` }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    };
+    const src = new MetadataServerTokenSource({
+      fetcher,
+      now: () => 0,
+      cacheTtlMs: 0, // force id_token refetch
+      impersonateServiceAccount: "target@p.iam",
+      iamCredentialsBaseUrl: "https://iam.fake",
+    });
+    await src.getToken("a");
+    await src.getToken("b");
+    expect(atHits).toBe(1); // access_token cached
+    expect(idtHits).toBe(2); // id_token refetched per call (TTL=0)
+  });
+
+  test("403 from iamcredentials propagates with a clear message", async () => {
+    const fetcher: FetchLike = async (url) => {
+      const u = String(url);
+      if (u.endsWith("/token")) {
+        return new Response(JSON.stringify({ access_token: "at", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("missing serviceAccountTokenCreator", {
+        status: 403,
+        headers: { "content-type": "text/plain" },
+      });
+    };
+    const src = new MetadataServerTokenSource({
+      fetcher,
+      now: () => 0,
+      impersonateServiceAccount: "target@p.iam",
+      iamCredentialsBaseUrl: "https://iam.fake",
+    });
+    await expect(src.getToken("aud")).rejects.toThrow(
+      /generateIdToken for target@p\.iam returned HTTP 403/,
+    );
+  });
+
+  test("when not impersonating, never touches iamcredentials", async () => {
+    let iamHit = 0;
+    const fetcher: FetchLike = async (url) => {
+      const u = String(url);
+      if (u.includes(":generateIdToken")) {
+        iamHit++;
+        return new Response("nope", { status: 500 });
+      }
+      // Direct metadata path uses /identity, not /token.
+      if (u.includes("/identity")) {
+        return new Response("direct-id-token", { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    };
+    const src = new MetadataServerTokenSource({ fetcher, now: () => 0 });
+    expect(await src.getToken("aud")).toBe("direct-id-token");
+    expect(iamHit).toBe(0);
+  });
+});
+
+describe("StaticTokenSource", () => {
+  test("returns the configured token", async () => {
+    const src = new StaticTokenSource("static-tok");
+    expect(await src.getToken("anything")).toBe("static-tok");
+  });
+});
+
+describe("EnvTokenSource", () => {
+  test("reads from the named env var", async () => {
+    const src = new EnvTokenSource("FAKE_IAP_TOKEN", { FAKE_IAP_TOKEN: "env-tok" });
+    expect(await src.getToken("aud")).toBe("env-tok");
+  });
+
+  test("rejects when env var is unset", async () => {
+    const src = new EnvTokenSource("MISSING", {});
+    await expect(src.getToken("aud")).rejects.toThrow(/not set or empty/);
+  });
+
+  test("re-reads on every call (rotation works)", async () => {
+    const env: NodeJS.ProcessEnv = { TOK: "first" };
+    const src = new EnvTokenSource("TOK", env);
+    expect(await src.getToken("aud")).toBe("first");
+    env.TOK = "second";
+    expect(await src.getToken("aud")).toBe("second");
+  });
+});

--- a/tests/middleware/client-pipeline.test.ts
+++ b/tests/middleware/client-pipeline.test.ts
@@ -65,9 +65,9 @@ describe("runClientPipeline", () => {
         bRan = true;
       },
     };
-    await expect(runClientPipeline([thrower("bad", "boom"), after], headers, baseCtx)).rejects.toThrow(
-      "boom",
-    );
+    await expect(
+      runClientPipeline([thrower("bad", "boom"), after], headers, baseCtx),
+    ).rejects.toThrow("boom");
     expect(bRan).toBe(false);
   });
 

--- a/tests/middleware/client-pipeline.test.ts
+++ b/tests/middleware/client-pipeline.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
+
+const baseCtx = {
+  request: new Request("http://proxy.local/api/v1/workflows"),
+  method: "GET",
+  pathname: "/api/v1/workflows",
+  upstreamUrl: "http://upstream.local/api/v1/workflows",
+};
+
+function setter(name: string, key: string, value: string): ClientMiddleware {
+  return {
+    name,
+    apply(headers) {
+      headers.set(key, value);
+    },
+  };
+}
+
+function thrower(name: string, message: string): ClientMiddleware {
+  return {
+    name,
+    apply() {
+      throw new Error(message);
+    },
+  };
+}
+
+describe("runClientPipeline", () => {
+  test("empty chain leaves headers untouched", async () => {
+    const headers = new Headers({ "x-original": "1" });
+    await runClientPipeline([], headers, baseCtx);
+    expect(headers.get("x-original")).toBe("1");
+    expect([...headers.keys()]).toEqual(["x-original"]);
+  });
+
+  test("each middleware can mutate headers", async () => {
+    const headers = new Headers();
+    await runClientPipeline(
+      [setter("a", "X-One", "1"), setter("b", "X-Two", "2")],
+      headers,
+      baseCtx,
+    );
+    expect(headers.get("X-One")).toBe("1");
+    expect(headers.get("X-Two")).toBe("2");
+  });
+
+  test("later middleware can override earlier middleware's headers", async () => {
+    const headers = new Headers();
+    await runClientPipeline(
+      [setter("a", "X-Key", "first"), setter("b", "X-Key", "second")],
+      headers,
+      baseCtx,
+    );
+    expect(headers.get("X-Key")).toBe("second");
+  });
+
+  test("a throwing middleware aborts the pipeline", async () => {
+    const headers = new Headers();
+    let bRan = false;
+    const after: ClientMiddleware = {
+      name: "after",
+      apply() {
+        bRan = true;
+      },
+    };
+    await expect(runClientPipeline([thrower("bad", "boom"), after], headers, baseCtx)).rejects.toThrow(
+      "boom",
+    );
+    expect(bRan).toBe(false);
+  });
+
+  test("async middleware is awaited", async () => {
+    const headers = new Headers();
+    const mw: ClientMiddleware = {
+      name: "async",
+      async apply(h) {
+        await new Promise((r) => setTimeout(r, 1));
+        h.set("X-Async", "ok");
+      },
+    };
+    await runClientPipeline([mw], headers, baseCtx);
+    expect(headers.get("X-Async")).toBe("ok");
+  });
+});

--- a/tests/middleware/client-registry.test.ts
+++ b/tests/middleware/client-registry.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  buildClientMiddlewares,
+  registerClientFactory,
+  resetClientRegistry,
+} from "@/middleware/client-registry.ts";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+
+interface FakeOptions {
+  fromEnv?: string;
+  fromCli?: string;
+  nested?: { a?: string; b?: string };
+}
+
+function fakeFactory(name: string): ClientMiddlewareFactory<FakeOptions> {
+  return {
+    name,
+    loadFromEnv: (env) => ({ fromEnv: env[`${name.toUpperCase()}_FROM_ENV`] }),
+    loadFromCLI: (opts) => {
+      const raw = opts[`${name}FromCli`];
+      return typeof raw === "string" ? { fromCli: raw } : {};
+    },
+    build: (opts) => {
+      const o = opts as FakeOptions;
+      return {
+        name,
+        apply: (h) => {
+          if (o.fromCli) h.set("X-From-Cli", o.fromCli);
+          if (o.fromEnv) h.set("X-From-Env", o.fromEnv);
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => resetClientRegistry());
+afterEach(() => resetClientRegistry());
+
+describe("buildClientMiddlewares", () => {
+  test("env-only options reach build()", () => {
+    registerClientFactory(fakeFactory("f1"));
+    const built = buildClientMiddlewares({
+      enabled: ["f1"],
+      env: { F1_FROM_ENV: "env-value" },
+      cliOpts: {},
+    });
+    expect(built).toHaveLength(1);
+    expect(built[0]?.name).toBe("f1");
+  });
+
+  test("CLI options override env options", () => {
+    let observed: unknown;
+    const f: ClientMiddlewareFactory<FakeOptions> = {
+      name: "obs",
+      loadFromEnv: () => ({ fromEnv: "env" }),
+      loadFromCLI: () => ({ fromEnv: "cli" }),
+      build: (o) => {
+        observed = o;
+        return { name: "obs", apply: () => {} };
+      },
+    };
+    registerClientFactory(f);
+    buildClientMiddlewares({ enabled: ["obs"] });
+    expect((observed as FakeOptions).fromEnv).toBe("cli");
+  });
+
+  test("unknown client middleware name throws with a friendly hint", () => {
+    registerClientFactory(fakeFactory("known"));
+    expect(() => buildClientMiddlewares({ enabled: ["nope"] })).toThrow(
+      /Unknown client middleware "nope"/,
+    );
+  });
+
+  test("nested options bucket: CLI partial override merges with env fields", () => {
+    let observed: unknown;
+    const f: ClientMiddlewareFactory<FakeOptions> = {
+      name: "nested",
+      loadFromEnv: () => ({ nested: { a: "env-a", b: "env-b" } }),
+      loadFromCLI: () => ({ nested: { a: "cli-a" } }),
+      build: (o) => {
+        observed = o;
+        return { name: "nested", apply: () => {} };
+      },
+    };
+    registerClientFactory(f);
+    buildClientMiddlewares({ enabled: ["nested"] });
+    expect((observed as { nested: { a: string; b: string } }).nested).toEqual({
+      a: "cli-a",
+      b: "env-b",
+    });
+  });
+
+  test("preserves middleware order", () => {
+    registerClientFactory(fakeFactory("a"));
+    registerClientFactory(fakeFactory("b"));
+    const built = buildClientMiddlewares({
+      enabled: ["b", "a"],
+      env: { A_FROM_ENV: "x", B_FROM_ENV: "y" },
+    });
+    expect(built.map((m) => m.name)).toEqual(["b", "a"]);
+  });
+});

--- a/tests/middleware/pipeline.test.ts
+++ b/tests/middleware/pipeline.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { runPipeline } from "@/middleware/pipeline.ts";
-import type { MiddlewareVerdict, PreWriteContext, PreWriteMiddleware } from "@/middleware/types.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
 
-const baseCtx: PreWriteContext = { workflow: null, mode: "proxy" };
+const baseCtx: ServerMiddlewareContext = { workflow: null, mode: "proxy" };
 
-function mw(name: string, verdict: MiddlewareVerdict): PreWriteMiddleware {
+function mw(name: string, verdict: MiddlewareVerdict): ServerMiddleware {
   return { name, evaluate: () => verdict };
 }
 
-function asyncMw(name: string, verdict: MiddlewareVerdict): PreWriteMiddleware {
+function asyncMw(name: string, verdict: MiddlewareVerdict): ServerMiddleware {
   return { name, evaluate: () => Promise.resolve(verdict) };
 }
 
-function throwingMw(name: string, message: string): PreWriteMiddleware {
+function throwingMw(name: string, message: string): ServerMiddleware {
   return {
     name,
     evaluate: () => {
@@ -47,7 +51,7 @@ describe("runPipeline", () => {
       violations: [{ rule: "x", severity: "error", message: "boom" }],
       denial: { status: 422, error: "workflow_lint_failed", message: "boom" },
     });
-    const after: PreWriteMiddleware = {
+    const after: ServerMiddleware = {
       name: "authz",
       evaluate: () => {
         bCalled = true;

--- a/tests/middleware/registry.test.ts
+++ b/tests/middleware/registry.test.ts
@@ -6,7 +6,7 @@ import {
   resetRegistry,
   resolveEnabledList,
 } from "@/middleware/registry.ts";
-import type { MiddlewareFactory } from "@/middleware/types.ts";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
 
 interface FakeOptions {
   fromEnv?: string;
@@ -14,7 +14,7 @@ interface FakeOptions {
   required?: string;
 }
 
-function fakeFactory(name: string): MiddlewareFactory<FakeOptions> {
+function fakeFactory(name: string): ServerMiddlewareFactory<FakeOptions> {
   return {
     name,
     loadFromEnv: (env) => ({ fromEnv: env[`${name.toUpperCase()}_FROM_ENV`] }),
@@ -56,8 +56,8 @@ describe("resolveEnabledList precedence", () => {
     expect(
       resolveEnabledList({
         cliValue: "lint,authz",
-        env: { N8N_MIDDLEWARES: "lint" },
-        envVar: "N8N_MIDDLEWARES",
+        env: { N8N_SERVER_MIDDLEWARES: "lint" },
+        envVar: "N8N_SERVER_MIDDLEWARES",
         fallback: ["lint"],
       }),
     ).toEqual(["lint", "authz"]);
@@ -66,16 +66,16 @@ describe("resolveEnabledList precedence", () => {
     expect(
       resolveEnabledList({
         cliValue: undefined,
-        env: { N8N_MIDDLEWARES: "authz" },
-        envVar: "N8N_MIDDLEWARES",
+        env: { N8N_SERVER_MIDDLEWARES: "authz" },
+        envVar: "N8N_SERVER_MIDDLEWARES",
         fallback: ["lint"],
       }),
     ).toEqual(["authz"]);
   });
   test("fallback when neither is set", () => {
-    expect(resolveEnabledList({ env: {}, envVar: "N8N_MIDDLEWARES", fallback: ["lint"] })).toEqual([
-      "lint",
-    ]);
+    expect(
+      resolveEnabledList({ env: {}, envVar: "N8N_SERVER_MIDDLEWARES", fallback: ["lint"] }),
+    ).toEqual(["lint"]);
   });
 });
 
@@ -93,7 +93,7 @@ describe("buildMiddlewares", () => {
 
   test("CLI options override env options", () => {
     let observed: unknown;
-    const f: MiddlewareFactory<FakeOptions> = {
+    const f: ServerMiddlewareFactory<FakeOptions> = {
       name: "obs",
       loadFromEnv: () => ({ fromEnv: "env" }),
       loadFromCLI: () => ({ fromEnv: "cli" }),
@@ -109,7 +109,9 @@ describe("buildMiddlewares", () => {
 
   test("unknown middleware name throws with a friendly hint", () => {
     registerFactory(fakeFactory("known"));
-    expect(() => buildMiddlewares({ enabled: ["nope"] })).toThrow(/Unknown middleware "nope"/);
+    expect(() => buildMiddlewares({ enabled: ["nope"] })).toThrow(
+      /Unknown server middleware "nope"/,
+    );
   });
 
   test("build() error propagates with middleware name in message", () => {
@@ -121,7 +123,7 @@ describe("buildMiddlewares", () => {
 
   test("nested options bucket: CLI partial override merges with env fields", () => {
     let observed: unknown;
-    const f: MiddlewareFactory<{ nested?: { a?: string; b?: string }; required?: string }> = {
+    const f: ServerMiddlewareFactory<{ nested?: { a?: string; b?: string }; required?: string }> = {
       name: "nested",
       loadFromEnv: () => ({ nested: { a: "env-a", b: "env-b" } }),
       loadFromCLI: () => ({ nested: { a: "cli-a" } }),

--- a/tests/proxy/proxy.authz.test.ts
+++ b/tests/proxy/proxy.authz.test.ts
@@ -280,10 +280,10 @@ describe("proxy + authz: chained with lint", () => {
   });
 });
 
-describe("proxy + authz: N8N_MIDDLEWARES env var", () => {
-  test("env var enables authz when --middleware is not passed", async () => {
-    const prev = process.env.N8N_MIDDLEWARES;
-    process.env.N8N_MIDDLEWARES = "authz";
+describe("proxy + authz: N8N_SERVER_MIDDLEWARES env var", () => {
+  test("env var enables authz when --server-middleware is not passed", async () => {
+    const prev = process.env.N8N_SERVER_MIDDLEWARES;
+    process.env.N8N_SERVER_MIDDLEWARES = "authz";
     try {
       groups.table.set("ryo@example.com", []);
       // No middlewares: [] config — would default to ["lint"] before the fix.
@@ -317,8 +317,8 @@ describe("proxy + authz: N8N_MIDDLEWARES env var", () => {
       expect(upstream.captured).toHaveLength(0);
       expect(groups.hits.length).toBeGreaterThan(0);
     } finally {
-      if (prev === undefined) delete process.env.N8N_MIDDLEWARES;
-      else process.env.N8N_MIDDLEWARES = prev;
+      if (prev === undefined) delete process.env.N8N_SERVER_MIDDLEWARES;
+      else process.env.N8N_SERVER_MIDDLEWARES = prev;
     }
   });
 });

--- a/tests/proxy/proxy.client-middleware.test.ts
+++ b/tests/proxy/proxy.client-middleware.test.ts
@@ -162,6 +162,46 @@ describe("proxy: client middleware injection", () => {
     expect(upstream.captured).toHaveLength(0);
   });
 
+  test("builtins: iap-auth + api-key-inject set both headers from a single config", async () => {
+    process.env.IAP_TEST_FAKE_TOKEN = "id-token-abc";
+    process.env.SHARED_N8N_KEY_FOR_E2E = "shared-key-xyz";
+    try {
+      // Register actual builtins for this test (not fakes).
+      const { registerClientBuiltins } = await import("@/middleware/client-wiring.ts");
+      registerClientBuiltins();
+      proxy = startProxy({
+        listen: "127.0.0.1:0",
+        upstream: `http://127.0.0.1:${upstream.port}`,
+        enforce: "off",
+        disableRules: [],
+        logFormat: "json",
+        allowDuplicates: true,
+        clientMiddlewares: ["iap-auth", "api-key-inject"],
+        clientMiddlewareCliOptions: {
+          iapAuthAudience: "https://example.com/iap",
+          iapAuthTokenSource: "env",
+          iapAuthTokenEnvVar: "IAP_TEST_FAKE_TOKEN",
+          apiKeyInjectKeyEnvVar: "SHARED_N8N_KEY_FOR_E2E",
+        },
+      });
+
+      // Client supplies its own Authorization (for IAP#1) — it must be
+      // replaced with the freshly minted IAP#2 token before forwarding.
+      const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+        method: "GET",
+        headers: { authorization: "Bearer client-token-for-iap-1" },
+      });
+      expect(res.status).toBe(200);
+      expect(upstream.captured).toHaveLength(1);
+      const cap = upstream.captured[0]!;
+      expect(cap.headers["authorization"]).toBe("Bearer id-token-abc");
+      expect(cap.headers["x-n8n-api-key"]).toBe("shared-key-xyz");
+    } finally {
+      delete process.env.IAP_TEST_FAKE_TOKEN;
+      delete process.env.SHARED_N8N_KEY_FOR_E2E;
+    }
+  });
+
   test("multiple middlewares run in order; later wins on header conflicts", async () => {
     const first: ClientMiddlewareFactory<unknown> = {
       name: "first",

--- a/tests/proxy/proxy.client-middleware.test.ts
+++ b/tests/proxy/proxy.client-middleware.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  registerClientFactory,
-  resetClientRegistry,
-} from "@/middleware/client-registry.ts";
+import { registerClientFactory, resetClientRegistry } from "@/middleware/client-registry.ts";
 import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
 import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
 

--- a/tests/proxy/proxy.client-middleware.test.ts
+++ b/tests/proxy/proxy.client-middleware.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  registerClientFactory,
+  resetClientRegistry,
+} from "@/middleware/client-registry.ts";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+interface Captured {
+  method: string;
+  pathname: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: Captured[];
+}
+
+function startMockUpstream(): MockUpstream {
+  const captured: Captured[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ method: req.method, pathname: url.pathname, headers, body });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { server, port: server.port!, captured };
+}
+
+/**
+ * Fake client middleware factory that injects two headers — one constant, one
+ * derived from the incoming request's pathname — so tests can prove the
+ * pipeline ran on the actual forwarded request.
+ */
+function makeFakeClientFactory(): ClientMiddlewareFactory<{ value?: string }> {
+  return {
+    name: "fake-inject",
+    loadFromEnv: (env) => ({ value: env.FAKE_INJECT_VALUE }),
+    loadFromCLI: (opts) =>
+      typeof opts.fakeInjectValue === "string" ? { value: opts.fakeInjectValue as string } : {},
+    build: (opts) => {
+      const o = opts as { value?: string };
+      return {
+        name: "fake-inject",
+        apply(headers, ctx) {
+          headers.set("X-Injected", o.value ?? "default-value");
+          headers.set("X-Saw-Path", ctx.pathname);
+        },
+      };
+    },
+  };
+}
+
+let upstream: MockUpstream;
+let proxy: ProxyHandle;
+
+beforeEach(() => {
+  resetClientRegistry();
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  await upstream.server.stop(true);
+  resetClientRegistry();
+});
+
+describe("proxy: client middleware injection", () => {
+  test("transparent GET sees injected headers", async () => {
+    registerClientFactory(makeFakeClientFactory());
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: ["fake-inject"],
+      clientMiddlewareCliOptions: { fakeInjectValue: "transparent" },
+    });
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      method: "GET",
+      headers: { "x-n8n-api-key": "test-key" },
+    });
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+    const cap = upstream.captured[0]!;
+    expect(cap.headers["x-injected"]).toBe("transparent");
+    expect(cap.headers["x-saw-path"]).toBe("/api/v1/workflows");
+    // Original auth headers are preserved alongside the injected ones.
+    expect(cap.headers["x-n8n-api-key"]).toBe("test-key");
+  });
+
+  test("workflow create (mutation) also sees injected headers", async () => {
+    registerClientFactory(makeFakeClientFactory());
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: ["fake-inject"],
+      clientMiddlewareCliOptions: { fakeInjectValue: "mutation" },
+    });
+
+    const body = JSON.stringify({
+      name: "wf",
+      nodes: [{ id: "1", name: "n", type: "noop", position: [0, 0], typeVersion: 1 }],
+      connections: {},
+    });
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]!.headers["x-injected"]).toBe("mutation");
+  });
+
+  test("a throwing middleware turns the upstream call into 502", async () => {
+    const failing: ClientMiddlewareFactory<unknown> = {
+      name: "boom",
+      loadFromEnv: () => ({}),
+      loadFromCLI: () => ({}),
+      build: () => ({
+        name: "boom",
+        apply() {
+          throw new Error("token mint failed");
+        },
+      }),
+    };
+    registerClientFactory(failing);
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: ["boom"],
+    });
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`);
+    expect(res.status).toBe(502);
+    // The upstream was never reached.
+    expect(upstream.captured).toHaveLength(0);
+  });
+
+  test("multiple middlewares run in order; later wins on header conflicts", async () => {
+    const first: ClientMiddlewareFactory<unknown> = {
+      name: "first",
+      loadFromEnv: () => ({}),
+      loadFromCLI: () => ({}),
+      build: () => ({
+        name: "first",
+        apply(h) {
+          h.set("X-Order", "first");
+          h.set("X-First-Only", "yes");
+        },
+      }),
+    };
+    const second: ClientMiddlewareFactory<unknown> = {
+      name: "second",
+      loadFromEnv: () => ({}),
+      loadFromCLI: () => ({}),
+      build: () => ({
+        name: "second",
+        apply(h) {
+          h.set("X-Order", "second");
+        },
+      }),
+    };
+    registerClientFactory(first);
+    registerClientFactory(second);
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: ["first", "second"],
+    });
+
+    await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]!.headers["x-order"]).toBe("second");
+    expect(upstream.captured[0]!.headers["x-first-only"]).toBe("yes");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a second middleware pipeline — `ClientMiddleware` — that runs on the **outgoing** side of the proxy, mirroring gRPC's Server/Client interceptor split. Pairs the new abstraction with two builtins that together solve the "proxy behind IAP forwards to a different n8n behind another IAP, using a shared n8n API key" deployment shape.

### Motivation

Existing `PreWriteMiddleware` (renamed here to `ServerMiddleware`) is a block/allow verdict over the workflow body and only runs on workflow mutations. It can't rewrite the outgoing upstream request, and it doesn't fire for transparent GETs / lists.

This PR introduces a parallel, simpler abstraction for outgoing concerns:
- **Server-side**: lint / authz / future policy checks → decide whether to proceed
- **Client-side (new)**: IAP token minting / API-key injection / trace propagation → rewrite outgoing headers

Two concerns, two responsibilities, two pipelines. Naming follows the well-established gRPC `ServerInterceptor` / `ClientInterceptor` pattern.

### Commits in order (review-friendly)

1. **`refactor(middleware): rename PreWriteMiddleware to ServerMiddleware`** — pure rename to free the "Server"/"Client" namespace before introducing the new abstraction. No behavior changes.

2. **`feat(proxy): introduce ClientMiddleware abstraction for outgoing requests`** — `ClientMiddleware` + `ClientMiddlewareContext` + `ClientMiddlewareFactory` types, a parallel registry / pipeline / wiring trio, and the `forwardRequest` hook that applies the chain before fetch on EVERY upstream call (mutation and transparent forward). New CLI flag `--client-middleware` and env `N8N_CLIENT_MIDDLEWARES`. A throwing client middleware turns the upstream call into 502.

3. **`feat(proxy): add iap-auth and api-key-inject client middlewares`** — two builtins:
   - `iap-auth`: mints a Google-signed id_token for the upstream's IAP audience. Three token sources (metadata server / env / static) plus optional **service-account impersonation** via `iamcredentials.googleapis.com:generateIdToken` for the cross-aud / cross-SA case. Always replaces incoming `Authorization` so IAP#1 vs IAP#2 audience mismatch never leaks through.
   - `api-key-inject`: sets `X-N8N-API-KEY` to a shared key. **The raw key is never accepted on the CLI** — only via env (direct) or via `--api-key-inject-key-env-var <NAME>` (indirect reference). Conflict policy: replace (default) or set-if-absent.

### Deployment example

```
n8n-cli proxy \
  --upstream https://n8n.example.com \
  --client-middleware iap-auth,api-key-inject \
  --iap-auth-audience <iap-oauth-client-id> \
  --iap-auth-impersonate-service-account <target-sa@proj.iam.gserviceaccount.com>

# env
N8N_API_KEY_INJECT_KEY=<shared-key>
```

Client sends a request with its own `Authorization` (for IAP#1, the proxy's own ingress). The proxy strips it, mints a fresh id_token (impersonating the target SA, aud = IAP#2's client_id), sets `X-N8N-API-KEY` from the env, and forwards.

### Notes

- Server-middleware CLI/env was renamed from `--middleware` / `N8N_MIDDLEWARES` to `--server-middleware` / `N8N_SERVER_MIDDLEWARES`. Pre-v1 breaking change.
- Token caches: id_token (per audience, 50 min default), caller access_token (single entry, honors `expires_in`). In-flight coalescing prevents thundering-herd on first miss.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 914 pass / 0 fail (49 new tests)
- [x] `bun run build` clean
- [ ] Manual sanity check by reviewer: spin up proxy with `--client-middleware iap-auth --iap-auth-token-source static --iap-auth-audience x --static-token x` (using internal API) — should boot and forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ci7zNcXKzP9B7swWhgcwd