### PR TITLE
feat(middleware): user identity verification pipeline (RFC)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+tests
+docs
+node_modules
+dist
+n8n-cli
+*.md
+!README.md
+.claude
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+
+# ---- build stage --------------------------------------------------------
+# Bun ships a `--compile` mode that produces a self-contained native binary,
+# so the runtime image only needs the resulting file. Two stages keep the
+# final image tiny (< 100MB) with no bun toolchain / node_modules baggage.
+#
+# Both stages MUST agree on libc. Bun-compiled binaries are dynamically
+# linked to the C library of the build image — mixing an Alpine (musl)
+# build with a Debian (glibc) runtime yields a binary the runtime's
+# loader can't find, and Cloud Run cold-starts crash-loop with
+# `exec /app/n8n-cli: no such file or directory`. Use the Debian bun
+# base to match the distroless/base-debian12 runtime below.
+
+FROM oven/bun:1.3.4-debian AS build
+
+WORKDIR /src
+
+# Install dependencies first for better layer caching.
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+# Pull in the rest of the source. `bun run build` runs `generate-schemas`
+# then `bun build --compile` (see package.json).
+COPY . .
+RUN bun run build
+
+# ---- runtime stage ------------------------------------------------------
+# distroless keeps the surface small; the compiled binary needs libstdc++
+# and glibc, hence the debian-slim variant of distroless (not static).
+
+FROM gcr.io/distroless/base-debian12:nonroot AS runtime
+
+WORKDIR /app
+
+COPY --from=build /src/n8n-cli /app/n8n-cli
+
+# Cloud Run passes PORT via env; the proxy honors --listen :$PORT via the
+# default value. Callers that need a specific port can override at deploy
+# time with `args` on the Cloud Run service.
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/app/n8n-cli"]
+CMD ["proxy"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -31,6 +31,13 @@ interface ProxyOptions {
   apiKeyInjectKeyEnvVar?: string;
   apiKeyInjectHeader?: string;
   apiKeyInjectConflictPolicy?: string;
+  // impersonator-token client-middleware options. Attaches the user's own
+  // Google id_token as a side header so the server can attribute the call
+  // to the human running the CLI (instead of the impersonated SA).
+  impersonatorTokenAudience?: string;
+  impersonatorTokenSource?: string;
+  impersonatorTokenEnvVar?: string;
+  impersonatorTokenOnError?: string;
   // Authz middleware options (flat namespace so commander stays happy).
   authzEnforce?: string;
   authzOnError?: string;
@@ -47,6 +54,16 @@ interface ProxyOptions {
   authzGroupsTimeoutMs?: string;
   authzWorkflowExtract?: string;
   authzWorkflowStripPrefix?: string;
+  // oauth-verify server middleware options. Verifies the incoming
+  // Authorization: Bearer against Google's tokeninfo endpoint.
+  oauthVerifyEnforce?: string;
+  oauthVerifyExpectedAudiences?: string;
+  oauthVerifyTrustedPrincipals?: string;
+  // impersonator-verify server middleware options. Verifies the side
+  // header carrying the human user's id_token attached by the client.
+  impersonatorVerifyEnforce?: string;
+  impersonatorVerifyRequirement?: string;
+  impersonatorVerifyExpectedAudiences?: string;
 }
 
 export function registerProxyCommand(program: Command): void {
@@ -151,6 +168,49 @@ export function registerProxyCommand(program: Command): void {
       "--authz-workflow-strip-prefix <prefix>",
       "Prefix to strip from each extracted ACL value",
     )
+    // oauth-verify — verifies incoming Authorization: Bearer via Google tokeninfo.
+    .option(
+      "--oauth-verify-enforce <level>",
+      "oauth-verify enforcement level: off, warn, deny (default: deny)",
+    )
+    .option(
+      "--oauth-verify-expected-audiences <list>",
+      "Comma-separated accepted `aud` claims (e.g. Cloud Run URL, IAP client_id)",
+    )
+    .option(
+      "--oauth-verify-trusted-principals <list>",
+      "Comma-separated bearer principals (emails / subjects) permitted to attach an X-Impersonator-Id-Token",
+    )
+    // impersonator-verify — verifies X-Impersonator-Id-Token (the human user's id_token).
+    .option(
+      "--impersonator-verify-enforce <level>",
+      "impersonator-verify enforcement level: off, warn, deny (default: deny)",
+    )
+    .option(
+      "--impersonator-verify-requirement <mode>",
+      "Behavior when the impersonator header is absent: optional, require (default: optional)",
+    )
+    .option(
+      "--impersonator-verify-expected-audiences <list>",
+      "Comma-separated accepted `aud` claims for the impersonator token (typically the gcloud ADC OAuth client id)",
+    )
+    // impersonator-token — attaches the user's id_token as a side header.
+    .option(
+      "--impersonator-token-audience <id>",
+      "aud claim for the minted user id_token (default: gcloud ADC OAuth client id)",
+    )
+    .option(
+      "--impersonator-token-source <kind>",
+      "Where the token comes from: adc (default), env, static",
+    )
+    .option(
+      "--impersonator-token-env-var <name>",
+      "Env var holding a pre-minted id_token (source=env)",
+    )
+    .option(
+      "--impersonator-token-on-error <mode>",
+      "Behavior on token-fetch failure: throw (default) or skip",
+    )
     .action((opts: ProxyOptions) => {
       const upstream = opts.upstream ?? process.env.N8N_API_URL;
       if (!upstream) {
@@ -237,6 +297,12 @@ function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
   copy("authzGroupsTimeoutMs");
   copy("authzWorkflowExtract");
   copy("authzWorkflowStripPrefix");
+  copy("oauthVerifyEnforce");
+  copy("oauthVerifyExpectedAudiences");
+  copy("oauthVerifyTrustedPrincipals");
+  copy("impersonatorVerifyEnforce");
+  copy("impersonatorVerifyRequirement");
+  copy("impersonatorVerifyExpectedAudiences");
   return out;
 }
 
@@ -261,6 +327,10 @@ function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unkn
   copy("apiKeyInjectKeyEnvVar");
   copy("apiKeyInjectHeader");
   copy("apiKeyInjectConflictPolicy");
+  copy("impersonatorTokenAudience");
+  copy("impersonatorTokenSource");
+  copy("impersonatorTokenEnvVar");
+  copy("impersonatorTokenOnError");
   return out;
 }
 

--- a/src/middleware/auth/google-tokeninfo.ts
+++ b/src/middleware/auth/google-tokeninfo.ts
@@ -1,0 +1,138 @@
+import type { IdTokenVerifier, VerifiedClaim } from "./types.ts";
+
+/**
+ * `IdTokenVerifier` implementation that delegates to Google's public
+ * `tokeninfo` endpoint. Suitable when callers present Google-signed
+ * id_tokens (Cloud Run IAM, IAP JWTs, Workspace OAuth, and any other
+ * flow that ends in a Google-issued token).
+ *
+ * Non-Google deployments should provide their own `IdTokenVerifier`
+ * implementation and inject it into the middleware constructors
+ * directly. This class is exported so it can serve as a reference
+ * implementation and as the factory default when Google is the issuer.
+ *
+ * Design notes:
+ *
+ * - The endpoint returns already-parsed claims including `email_verified`
+ *   (a normalized boolean-as-string). Local JWKS verification would leave
+ *   the caller to re-derive that from the payload — one more chance to
+ *   drift from the issuer's semantics.
+ * - Latency is a per-request round-trip, but the tokens themselves are
+ *   long-lived (~1h) so results are highly cacheable. We cache below
+ *   with a small in-memory map keyed by token string.
+ * - Only *positive* responses are cached; a negative outcome is either a
+ *   real verification failure (in which case a new call is cheap because
+ *   the token is bad anyway) or a transient network hiccup that
+ *   shouldn't be memoized.
+ * - The cache entry's expiry is capped by the token's own `exp` claim,
+ *   so a cached positive verdict cannot outlive the token itself.
+ *
+ * Failure model: `verify()` returns `null` for any reason (bad signature,
+ * network error, bad issuer, wrong audience, missing email). Callers do
+ * NOT differentiate between these — the correct action is always
+ * "reject the token".
+ */
+
+/** Raw shape of Google's `tokeninfo` response — see https://oauth2.googleapis.com/tokeninfo docs. */
+interface TokeninfoResponse {
+  email?: string;
+  email_verified?: string; // string "true" / "false"
+  aud?: string;
+  iss?: string;
+  exp?: string; // seconds since epoch, as string
+  sub?: string;
+}
+
+/** Accepted issuer values in Google id_tokens. */
+export const GOOGLE_ISSUERS: ReadonlySet<string> = new Set([
+  "https://accounts.google.com",
+  "accounts.google.com",
+]);
+
+/** Narrow fetch signature so tests can stub without touching global fetch. */
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface GoogleTokeninfoVerifierOptions {
+  /** Endpoint override — production leaves this unset. */
+  baseUrl?: string;
+  /** HTTP timeout per verification. Default 5 s. */
+  timeoutMs?: number;
+  /** Cache TTL cap for positive responses. Default 5 min. */
+  cacheTtlMs?: number;
+  fetcher?: FetchLike;
+  now?: () => number;
+}
+
+interface CacheEntry {
+  claim: VerifiedClaim;
+  expiresAt: number;
+}
+
+const DEFAULT_BASE_URL = "https://oauth2.googleapis.com/tokeninfo";
+
+export class GoogleTokeninfoVerifier implements IdTokenVerifier {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly cacheTtlMs: number;
+  private readonly fetcher: FetchLike;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(opts: GoogleTokeninfoVerifierOptions = {}) {
+    this.baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+    this.timeoutMs = opts.timeoutMs ?? 5_000;
+    this.cacheTtlMs = opts.cacheTtlMs ?? 5 * 60 * 1000;
+    this.fetcher = opts.fetcher ?? ((input, init) => fetch(input, init));
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  async verify(idToken: string): Promise<VerifiedClaim | null> {
+    if (!idToken) return null;
+    const cached = this.cache.get(idToken);
+    if (cached && cached.expiresAt > this.now()) {
+      return cached.claim;
+    }
+    const claim = await this.fetch(idToken);
+    if (claim) {
+      // Cap the cache entry at the token's own `exp` so a cached positive
+      // verdict never outlives the token. Falls back to configured TTL
+      // when `exp` is missing.
+      const configuredExpiry = this.now() + this.cacheTtlMs;
+      const tokenExpiryMs =
+        typeof claim.exp === "number" ? claim.exp * 1000 : Number.POSITIVE_INFINITY;
+      this.cache.set(idToken, {
+        claim,
+        expiresAt: Math.min(configuredExpiry, tokenExpiryMs),
+      });
+    }
+    return claim;
+  }
+
+  private async fetch(idToken: string): Promise<VerifiedClaim | null> {
+    const url = `${this.baseUrl}?id_token=${encodeURIComponent(idToken)}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetcher(url, { method: "GET", signal: controller.signal });
+      if (!res.ok) return null;
+      const json = (await res.json()) as TokeninfoResponse;
+      if (!json || typeof json !== "object") return null;
+      if (typeof json.iss !== "string" || !GOOGLE_ISSUERS.has(json.iss)) return null;
+      if (typeof json.aud !== "string" || json.aud.length === 0) return null;
+      const expNum =
+        typeof json.exp === "string" && /^\d+$/.test(json.exp) ? Number(json.exp) : undefined;
+      return {
+        email: json.email,
+        emailVerified: json.email_verified === "true",
+        aud: json.aud,
+        sub: typeof json.sub === "string" ? json.sub : undefined,
+        iss: json.iss,
+        exp: expNum,
+      };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/middleware/auth/types.ts
+++ b/src/middleware/auth/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Generic identity-token verification contract.
+ *
+ * The `oauth-verify` and `impersonator-verify` server middlewares are
+ * verifier-agnostic — they take any implementation of `IdTokenVerifier`
+ * and delegate the "is this a real signed token?" question to it. This
+ * keeps the middlewares themselves free of any assumption about who
+ * issued the token, what wire format it takes, or how signature
+ * verification happens.
+ *
+ * Concrete verifiers live under `src/middleware/auth/` next to this file:
+ *
+ *   - `GoogleTokeninfoVerifier` — hits Google's `tokeninfo` endpoint. The
+ *     obvious choice when the deployment authenticates callers with
+ *     Google-signed id_tokens (Cloud Run IAM tokens, Google Workspace
+ *     OAuth, IAP JWTs, etc.).
+ *
+ * Custom deployments plug their own verifier in programmatically via the
+ * middleware constructor (`options.verifier`) or through a bespoke
+ * factory. Nothing in the middleware code path is Google-specific.
+ */
+
+/** What a verified token claim exposes to the middlewares. */
+export interface VerifiedClaim {
+  /** Verified subject email. `oauth-verify` requires this to be present. */
+  email?: string;
+  /** True iff the verifier considers the email ownership proven. */
+  emailVerified: boolean;
+  /** Audience claim; the middleware pins this against a configured allowlist. */
+  aud: string;
+  /** Optional subject id — some verifiers expose it, most middlewares don't need it. */
+  sub?: string;
+  /** Optional issuer — verifiers that whitelist issuers already enforced this. */
+  iss?: string;
+  /** Optional expiry in seconds since epoch. Used by caching layers to cap TTL. */
+  exp?: number;
+}
+
+/**
+ * Pluggable verifier contract. An implementation is expected to:
+ *   - Cryptographically verify the token signature against its issuer
+ *   - Reject the token on any of {bad signature, wrong issuer, expired}
+ *   - Return normalised claims when the token verifies
+ *   - Return `null` for any failure (callers do not need to differentiate)
+ *
+ * Implementations MAY cache successful verifications. When they do, the
+ * cache MUST honour the token's own `exp` — a cache entry cannot outlive
+ * the token itself, otherwise expired tokens replay past their rated
+ * lifetime.
+ */
+export interface IdTokenVerifier {
+  verify(idToken: string): Promise<VerifiedClaim | null>;
+}
+
+/** Reads a Bearer token from an `Authorization` header value. Returns null when absent or malformed. */
+export function parseBearer(authorization: string | null | undefined): string | null {
+  if (!authorization) return null;
+  const m = /^Bearer\s+(\S+)$/i.exec(authorization.trim());
+  return m?.[1] ?? null;
+}

--- a/src/middleware/builtin/impersonator-token/adc-user-token-source.ts
+++ b/src/middleware/builtin/impersonator-token/adc-user-token-source.ts
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { UserTokenSource } from "./user-token-source.ts";
+
+/**
+ * Google-specific `UserTokenSource` that reads the Application Default
+ * Credentials file (`gcloud auth application-default login` output) and
+ * exchanges the user's refresh_token for a fresh id_token via Google's
+ * OAuth2 token endpoint.
+ *
+ * Why this lives separately from `user-token-source.ts`: this file
+ * couples to Google's OAuth token endpoint URL, ADC file layout, and
+ * refresh_token grant shape. Deployments that don't use Google can pick
+ * `StaticUserTokenSource` / `EnvUserTokenSource` and never touch this
+ * module. Custom sources implement the `UserTokenSource` interface
+ * directly.
+ *
+ * Not exported through the middleware's factory as a hard default;
+ * callers must select it explicitly via `tokenSourceKind: "adc"` on the
+ * factory or by injecting an instance into the middleware constructor.
+ */
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+interface CacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+/** Shape of `application_default_credentials.json`. */
+export interface AdcUserCredentials {
+  type?: string;
+  client_id?: string;
+  client_secret?: string;
+  refresh_token?: string;
+  quota_project_id?: string;
+}
+
+const DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const DEFAULT_CACHE_TTL_MS = 50 * 60 * 1000; // id_tokens live ~1h
+
+export interface AdcUserTokenSourceDeps {
+  fetcher?: FetchLike;
+  now?: () => number;
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+  /** Explicit override for the credentials file path (testing / non-default install). */
+  credentialsPath?: string;
+  /** Injected reader for tests — reads the JSON from disk. */
+  readCredentials?: () => Promise<AdcUserCredentials>;
+  /** Override for the OAuth token endpoint (testing). */
+  tokenEndpoint?: string;
+}
+
+function defaultAdcPath(): string {
+  const explicit = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (explicit) return explicit;
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA;
+    if (appdata) return join(appdata, "gcloud", "application_default_credentials.json");
+  }
+  return join(homedir(), ".config", "gcloud", "application_default_credentials.json");
+}
+
+/**
+ * Reads on-disk ADC and exchanges the refresh_token for id_tokens via
+ * Google's OAuth token endpoint. Caches per-audience with in-flight
+ * coalescing.
+ *
+ * Credential-read failures do NOT poison the source: if the initial
+ * read fails (e.g. file not yet created), the next call re-reads. This
+ * matters because CLI users often start the process before running
+ * `gcloud auth application-default login`.
+ */
+export class AdcUserTokenSource implements UserTokenSource {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inflight = new Map<string, Promise<string>>();
+  private readonly fetcher: FetchLike;
+  private readonly now: () => number;
+  private readonly cacheTtlMs: number;
+  private readonly timeoutMs: number;
+  private readonly credentialsPath: string;
+  private readonly tokenEndpoint: string;
+  private readonly readCredentialsImpl?: () => Promise<AdcUserCredentials>;
+  /** Cached credentials from the last successful disk read. */
+  private cachedCreds?: AdcUserCredentials;
+
+  constructor(deps: AdcUserTokenSourceDeps = {}) {
+    this.fetcher = deps.fetcher ?? ((input, init) => fetch(input, init));
+    this.now = deps.now ?? (() => Date.now());
+    this.cacheTtlMs = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.timeoutMs = deps.timeoutMs ?? 5_000;
+    this.credentialsPath = deps.credentialsPath ?? defaultAdcPath();
+    this.tokenEndpoint = deps.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
+    this.readCredentialsImpl = deps.readCredentials;
+  }
+
+  async getToken(audience: string): Promise<string> {
+    const cached = this.cache.get(audience);
+    if (cached && cached.expiresAt > this.now()) return cached.token;
+    const inflight = this.inflight.get(audience);
+    if (inflight) return inflight;
+    const p = this.fetchAndCache(audience).finally(() => this.inflight.delete(audience));
+    this.inflight.set(audience, p);
+    return p;
+  }
+
+  private async readCredentials(): Promise<AdcUserCredentials> {
+    if (this.cachedCreds) return this.cachedCreds;
+    const raw = this.readCredentialsImpl
+      ? await this.readCredentialsImpl()
+      : (JSON.parse(await readFile(this.credentialsPath, "utf8")) as AdcUserCredentials);
+    // Only cache after successful read — this way a first-time ENOENT
+    // doesn't poison future calls made after the user finally runs
+    // `gcloud auth application-default login`.
+    this.cachedCreds = raw;
+    return raw;
+  }
+
+  private async fetchAndCache(audience: string): Promise<string> {
+    const creds = await this.readCredentials();
+    if (!creds.refresh_token || !creds.client_id || !creds.client_secret) {
+      throw new Error(
+        "impersonator-token: ADC file is missing refresh_token/client_id/client_secret. " +
+          "Run `gcloud auth application-default login`.",
+      );
+    }
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: creds.refresh_token,
+      client_id: creds.client_id,
+      client_secret: creds.client_secret,
+      audience,
+    });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let res: Response;
+    try {
+      res = await this.fetcher(this.tokenEndpoint, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      const bodyText = await res.text().catch(() => "");
+      throw new Error(
+        `impersonator-token: refresh_token grant returned HTTP ${res.status}: ${bodyText.slice(0, 200)}`,
+      );
+    }
+    const parsed = (await res.json()) as { id_token?: string; expires_in?: number };
+    if (!parsed.id_token) {
+      throw new Error("impersonator-token: token endpoint returned no id_token");
+    }
+    const ttl =
+      typeof parsed.expires_in === "number" && parsed.expires_in > 60
+        ? (parsed.expires_in - 60) * 1000
+        : this.cacheTtlMs;
+    this.cache.set(audience, { token: parsed.id_token, expiresAt: this.now() + ttl });
+    return parsed.id_token;
+  }
+}

--- a/src/middleware/builtin/impersonator-token/factory.ts
+++ b/src/middleware/builtin/impersonator-token/factory.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { AdcUserTokenSource } from "./adc-user-token-source.ts";
+import { ImpersonatorTokenMiddleware } from "./middleware.ts";
+import {
+  EnvUserTokenSource,
+  StaticUserTokenSource,
+  type UserTokenSource,
+} from "./user-token-source.ts";
+
+/** Default header — must match `impersonator-verify`'s DEFAULT_IMPERSONATOR_HEADER. */
+const DEFAULT_HEADER_NAME = "X-Impersonator-Id-Token";
+
+const optionsSchema = z.object({
+  /**
+   * `aud` for the minted id_token. Required — every issuer has a
+   * different audience convention (an OAuth client id, a resource URI,
+   * an OIDC RP identifier). Set this to whatever value the server-side
+   * `impersonator-verify` expects.
+   */
+  audience: z.string().min(1, {
+    message:
+      "impersonator-token: `audience` is required. Set it to the aud claim your server expects on impersonator tokens.",
+  }),
+  tokenSourceKind: z
+    .union([z.literal("adc"), z.literal("env"), z.literal("static")])
+    .default("env"),
+  /** For tokenSourceKind=env. */
+  tokenEnvVar: z.string().optional(),
+  /** For tokenSourceKind=static — programmatic use only (tests / preminted). */
+  staticToken: z.string().optional(),
+  onError: z.union([z.literal("throw"), z.literal("skip")]).default("throw"),
+});
+
+type ImpersonatorTokenRawOptions = z.infer<typeof optionsSchema>;
+
+function buildTokenSource(opts: ImpersonatorTokenRawOptions): UserTokenSource {
+  switch (opts.tokenSourceKind) {
+    case "static": {
+      if (!opts.staticToken) {
+        throw new Error("impersonator-token: tokenSourceKind=static requires staticToken");
+      }
+      return new StaticUserTokenSource(opts.staticToken);
+    }
+    case "env": {
+      if (!opts.tokenEnvVar) {
+        throw new Error("impersonator-token: tokenSourceKind=env requires tokenEnvVar");
+      }
+      return new EnvUserTokenSource(opts.tokenEnvVar);
+    }
+    case "adc":
+      // gcloud Application Default Credentials — see adc-user-token-source.ts.
+      // Kept behind an explicit `adc` selector rather than made the default so
+      // that non-gcloud deployments don't get Google's OAuth token endpoint
+      // dialled at them silently.
+      return new AdcUserTokenSource();
+  }
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<ImpersonatorTokenRawOptions> {
+  const out: Partial<ImpersonatorTokenRawOptions> = {};
+  if (env.N8N_IMPERSONATOR_TOKEN_AUDIENCE) out.audience = env.N8N_IMPERSONATOR_TOKEN_AUDIENCE;
+  if (env.N8N_IMPERSONATOR_TOKEN_SOURCE) {
+    out.tokenSourceKind =
+      env.N8N_IMPERSONATOR_TOKEN_SOURCE as ImpersonatorTokenRawOptions["tokenSourceKind"];
+  }
+  if (env.N8N_IMPERSONATOR_TOKEN_ENV_VAR) out.tokenEnvVar = env.N8N_IMPERSONATOR_TOKEN_ENV_VAR;
+  if (env.N8N_IMPERSONATOR_TOKEN_ON_ERROR) {
+    out.onError = env.N8N_IMPERSONATOR_TOKEN_ON_ERROR as "throw" | "skip";
+  }
+  return out;
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<ImpersonatorTokenRawOptions> {
+  const out: Partial<ImpersonatorTokenRawOptions> = {};
+  const s = (k: string) => (typeof opts[k] === "string" ? (opts[k] as string) : undefined);
+  if (s("impersonatorTokenAudience")) out.audience = s("impersonatorTokenAudience");
+  if (s("impersonatorTokenSource")) {
+    out.tokenSourceKind = s(
+      "impersonatorTokenSource",
+    ) as ImpersonatorTokenRawOptions["tokenSourceKind"];
+  }
+  if (s("impersonatorTokenEnvVar")) out.tokenEnvVar = s("impersonatorTokenEnvVar");
+  if (s("impersonatorTokenOnError")) {
+    out.onError = s("impersonatorTokenOnError") as "throw" | "skip";
+  }
+  return out;
+}
+
+export const impersonatorTokenFactory: ClientMiddlewareFactory<ImpersonatorTokenRawOptions> = {
+  name: "impersonator-token",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    const tokenSource = buildTokenSource(parsed);
+    return new ImpersonatorTokenMiddleware({
+      audience: parsed.audience,
+      headerName: DEFAULT_HEADER_NAME,
+      tokenSource,
+      onError: parsed.onError,
+    });
+  },
+};
+
+export const impersonatorTokenOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/impersonator-token/middleware.ts
+++ b/src/middleware/builtin/impersonator-token/middleware.ts
@@ -1,0 +1,63 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
+import type { UserTokenSource } from "./user-token-source.ts";
+
+export interface ImpersonatorTokenOptions {
+  /**
+   * `aud` for the minted id_token. Almost always the gcloud ADC OAuth
+   * client_id (`764086051850-...`) because that's what user
+   * `application-default login` credentials produce via the
+   * refresh-token grant. Configurable so operators aren't hard-coded to
+   * one Google-managed constant.
+   */
+  audience: string;
+  /**
+   * Header to write the token to. Default is `X-Impersonator-Id-Token`
+   * to match the convention established by `mcp-gcloud-adc-proxy` and the
+   * receiving `impersonator-verify` server middleware.
+   */
+  headerName: string;
+  /**
+   * Where the user id_token comes from. Defaults to `AdcUserTokenSource`
+   * in the factory; tests inject a static source.
+   */
+  tokenSource: UserTokenSource;
+  /**
+   * On failure to obtain a user id_token, either abort the outgoing
+   * request (`throw`) or continue without the header (`skip`). `skip` is
+   * the safe default for endpoints that also serve machine callers —
+   * the SA-only path still works.
+   */
+  onError: "throw" | "skip";
+}
+
+/**
+ * Client middleware that attaches a user-owned id_token as
+ * `X-Impersonator-Id-Token` alongside the SA-owned Bearer set by
+ * `iap-auth`. A cooperating receiver (`impersonator-verify` on the server
+ * side, or any handler that reads a signed Google id_token side header)
+ * validates the token and rewrites its effective identity to the user,
+ * enabling per-person authorization even when the bearer must be an SA
+ * (aud constraint).
+ *
+ * Order note: register this AFTER `iap-auth` in the client middleware
+ * chain — `iap-auth` writes Authorization, this one writes a separate
+ * header, so order isn't semantically load-bearing, but keeping bearer
+ * first mirrors how the wire looks.
+ */
+export class ImpersonatorTokenMiddleware implements ClientMiddleware {
+  readonly name = "impersonator-token";
+
+  constructor(private readonly options: ImpersonatorTokenOptions) {}
+
+  async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
+    try {
+      const token = await this.options.tokenSource.getToken(this.options.audience);
+      if (!token) return;
+      headers.set(this.options.headerName, token);
+    } catch (err) {
+      if (this.options.onError === "throw") throw err;
+      // skip: leave the header off — server treats the request as
+      // SA-only. Callers that require the header should set onError=throw.
+    }
+  }
+}

--- a/src/middleware/builtin/impersonator-token/user-token-source.ts
+++ b/src/middleware/builtin/impersonator-token/user-token-source.ts
@@ -1,0 +1,39 @@
+/**
+ * Contract for producing a user-owned id_token that the client
+ * middleware attaches as the impersonator side-header. Implementations
+ * decide where the token comes from — a filesystem-backed OAuth
+ * refresh grant, an in-memory pre-minted token, an environment
+ * variable, whatever the deployment can produce a signed token from.
+ *
+ * The middleware itself doesn't care which implementation you use; only
+ * the header format (a bare id_token string) is shared.
+ */
+export interface UserTokenSource {
+  /** Returns a possibly-cached id_token whose `aud` claim equals `audience`. */
+  getToken(audience: string): Promise<string>;
+}
+
+/** Static token — used by tests and pre-minted-token setups. */
+export class StaticUserTokenSource implements UserTokenSource {
+  constructor(private readonly token: string) {}
+  getToken(_audience: string): Promise<string> {
+    return Promise.resolve(this.token);
+  }
+}
+
+/** Reads a pre-minted id_token from an env var. */
+export class EnvUserTokenSource implements UserTokenSource {
+  constructor(
+    private readonly varName: string,
+    private readonly env: NodeJS.ProcessEnv = process.env,
+  ) {}
+  getToken(_audience: string): Promise<string> {
+    const value = this.env[this.varName];
+    if (!value) {
+      return Promise.reject(
+        new Error(`impersonator-token: env var ${this.varName} is not set or empty`),
+      );
+    }
+    return Promise.resolve(value);
+  }
+}

--- a/src/middleware/builtin/impersonator-verify/factory.ts
+++ b/src/middleware/builtin/impersonator-verify/factory.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
+import { ImpersonatorVerifyMiddleware } from "./middleware.ts";
+import type {
+  ImpersonatorRequirement,
+  ImpersonatorVerifyEnforce,
+  ImpersonatorVerifyOptions,
+} from "./types.ts";
+
+const enforceSchema: z.ZodType<ImpersonatorVerifyEnforce> = z.union([
+  z.literal("off"),
+  z.literal("warn"),
+  z.literal("deny"),
+]);
+
+const requirementSchema: z.ZodType<ImpersonatorRequirement> = z.union([
+  z.literal("require"),
+  z.literal("optional"),
+]);
+
+const optionsSchema = z.object({
+  enforce: enforceSchema.default("deny"),
+  requirement: requirementSchema.default("optional"),
+  expectedAudiences: z.array(z.string().min(1)).default([]),
+});
+
+function splitList(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<ImpersonatorVerifyOptions> {
+  const out: Partial<ImpersonatorVerifyOptions> = {};
+  if (env.N8N_IMPERSONATOR_VERIFY_ENFORCE) {
+    out.enforce = env.N8N_IMPERSONATOR_VERIFY_ENFORCE as ImpersonatorVerifyEnforce;
+  }
+  if (env.N8N_IMPERSONATOR_VERIFY_REQUIREMENT) {
+    out.requirement = env.N8N_IMPERSONATOR_VERIFY_REQUIREMENT as ImpersonatorRequirement;
+  }
+  const aud = splitList(env.N8N_IMPERSONATOR_VERIFY_EXPECTED_AUDIENCES);
+  if (aud) out.expectedAudiences = aud;
+  return out;
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<ImpersonatorVerifyOptions> {
+  const out: Partial<ImpersonatorVerifyOptions> = {};
+  const s = (k: string) => (typeof opts[k] === "string" ? (opts[k] as string) : undefined);
+  const list = (k: string) => splitList(s(k));
+
+  if (s("impersonatorVerifyEnforce")) {
+    out.enforce = s("impersonatorVerifyEnforce") as ImpersonatorVerifyEnforce;
+  }
+  if (s("impersonatorVerifyRequirement")) {
+    out.requirement = s("impersonatorVerifyRequirement") as ImpersonatorRequirement;
+  }
+  const aud = list("impersonatorVerifyExpectedAudiences");
+  if (aud) out.expectedAudiences = aud;
+  return out;
+}
+
+export const impersonatorVerifyFactory: ServerMiddlewareFactory<ImpersonatorVerifyOptions> = {
+  name: "impersonator-verify",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged) as ImpersonatorVerifyOptions;
+    return new ImpersonatorVerifyMiddleware(parsed);
+  },
+};
+
+export const impersonatorVerifyOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/impersonator-verify/middleware.ts
+++ b/src/middleware/builtin/impersonator-verify/middleware.ts
@@ -1,0 +1,124 @@
+import { GoogleTokeninfoVerifier } from "@/middleware/auth/google-tokeninfo.ts";
+import type { IdTokenVerifier } from "@/middleware/auth/types.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
+import { DEFAULT_IMPERSONATOR_HEADER, type ImpersonatorVerifyOptions } from "./types.ts";
+
+/**
+ * Server middleware that verifies the impersonator id_token (default
+ * header: `X-Impersonator-Id-Token`) attached by a cooperating client on
+ * behalf of the human running the CLI.
+ *
+ * Rationale: many deployments authenticate the bearer as a machine
+ * principal (a service account, workload identity, agent token, etc.)
+ * because that's the only shape of credential the caller can produce
+ * with the required `aud`. In those cases the bearer's `email` claim is
+ * the machine's address — the real human's identity is lost. Clients
+ * that want the server to attribute the call to the actual person
+ * forward the user's own id_token in a side header; this middleware
+ * validates it.
+ *
+ * Trust contract:
+ *   1. `oauth-verify` MUST run before this middleware, so
+ *      `ctx.auth.bearer` is populated. Absence is treated as failure.
+ *   2. The bearer principal MUST be in `oauth-verify`'s
+ *      `trustedPrincipals` list. This prevents random human callers from
+ *      spoofing arbitrary user emails by attaching a header.
+ *   3. The impersonator token itself MUST verify against
+ *      `expectedAudiences` and carry a verified email.
+ *
+ * When all three hold, `ctx.auth.effective` and `ctx.identity` are
+ * rewritten to the impersonator's email. Downstream authz reads the new
+ * identity transparently.
+ */
+export class ImpersonatorVerifyMiddleware implements ServerMiddleware {
+  readonly name = "impersonator-verify";
+  private readonly verifier: IdTokenVerifier;
+  private readonly expectedAud: Set<string>;
+  private readonly headerName: string;
+
+  constructor(private readonly options: ImpersonatorVerifyOptions) {
+    this.verifier = options.verifier ?? new GoogleTokeninfoVerifier();
+    this.expectedAud = new Set(options.expectedAudiences);
+    this.headerName = options.headerName ?? DEFAULT_IMPERSONATOR_HEADER;
+  }
+
+  async evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> {
+    if (this.options.enforce === "off") return { block: false, violations: [] };
+    if (ctx.mode !== "proxy" || !ctx.request) {
+      return { block: false, violations: [] };
+    }
+
+    const raw = ctx.request.headers.get(this.headerName);
+    if (!raw) {
+      if (this.options.requirement === "require") {
+        return this.reject("missing impersonator token");
+      }
+      return { block: false, violations: [] };
+    }
+
+    // Bearer must be present *and* trusted before we honor an impersonator.
+    // Without oauth-verify running upstream we have no way to know if the
+    // bearer principal is trusted — the safe stance is refuse.
+    if (!ctx.auth?.bearer) {
+      return this.reject("impersonator forwarded but bearer not verified");
+    }
+    const trusted = (ctx as { __oauthVerifyBearerIsTrusted?: boolean })
+      .__oauthVerifyBearerIsTrusted;
+    if (!trusted) {
+      return this.reject("bearer principal is not trusted to forward an impersonator token");
+    }
+
+    if (this.expectedAud.size === 0) {
+      return this.reject("no expectedAudiences configured for impersonator");
+    }
+
+    const claim = await this.verifier.verify(raw);
+    if (!claim) return this.reject("verifier rejected the impersonator token");
+    if (!this.expectedAud.has(claim.aud)) {
+      // Do NOT echo the received aud back to the caller.
+      return this.reject("impersonator audience not accepted");
+    }
+    if (!claim.emailVerified || !claim.email) {
+      return this.reject("impersonator email not verified");
+    }
+
+    const impersonator = {
+      email: claim.email,
+      aud: claim.aud,
+      verified: true as const,
+    };
+    ctx.auth = {
+      ...(ctx.auth ?? {}),
+      impersonator,
+      effective: { email: claim.email, layer: "impersonator" as const },
+    };
+    ctx.identity = claim.email;
+    return { block: false, violations: [] };
+  }
+
+  private reject(reason: string): MiddlewareVerdict {
+    const violation = {
+      rule: "impersonator-verify-rejected",
+      severity: "error" as const,
+      message: `Impersonator verification failed: ${reason}`,
+    };
+    if (this.options.enforce === "warn") {
+      return { block: false, violations: [{ ...violation, severity: "warning" }] };
+    }
+    return {
+      block: true,
+      violations: [violation],
+      denial: {
+        status: 401,
+        error: "impersonator_verification_failed",
+        // Generic message to the caller; the specific reason is in the
+        // server-side violation record.
+        message: "Impersonator verification failed.",
+      },
+    };
+  }
+}

--- a/src/middleware/builtin/impersonator-verify/types.ts
+++ b/src/middleware/builtin/impersonator-verify/types.ts
@@ -1,0 +1,41 @@
+import type { IdTokenVerifier } from "@/middleware/auth/types.ts";
+
+/** Same enforce semantics as oauth-verify. */
+export type ImpersonatorVerifyEnforce = "off" | "warn" | "deny";
+
+/**
+ * Policy when the request lacks an impersonator token entirely (as opposed
+ * to carrying a malformed / mis-audienced one).
+ *
+ * - `require`  — reject; the endpoint only accepts requests that carry a
+ *                verified user-identity side channel.
+ * - `optional` — accept, leave `ctx.auth.effective` pointing at the bearer.
+ *                Use this for endpoints that also serve machine callers.
+ */
+export type ImpersonatorRequirement = "require" | "optional";
+
+/** Default header name that both the client middleware and this verifier use. */
+export const DEFAULT_IMPERSONATOR_HEADER = "X-Impersonator-Id-Token";
+
+export interface ImpersonatorVerifyOptions {
+  enforce: ImpersonatorVerifyEnforce;
+  requirement: ImpersonatorRequirement;
+  /**
+   * Header name carrying the impersonator id_token. Defaults to
+   * `X-Impersonator-Id-Token`; leave as default unless the client is
+   * emitting a non-standard header name.
+   */
+  headerName?: string;
+  /**
+   * Accepted `aud` claim values for the impersonator token. Populate with
+   * every audience your clients emit — for gcloud users this is the
+   * ADC OAuth client id; for other flows, whatever the issuing OAuth
+   * client's identifier is.
+   */
+  expectedAudiences: string[];
+  /**
+   * Token verifier. Injected for tests and non-Google deployments. When
+   * unset, the factory defaults to `GoogleTokeninfoVerifier`.
+   */
+  verifier?: IdTokenVerifier;
+}

--- a/src/middleware/builtin/lint/middleware.ts
+++ b/src/middleware/builtin/lint/middleware.ts
@@ -1,10 +1,6 @@
 import { hasErrorViolations, lintWorkflow } from "@/lint/engine.ts";
 import type { Violation } from "@/lint/rules/violation.ts";
-import {
-  type LintConfigLoadError,
-  prepareWriteLintContext,
-  type WriteLintContext,
-} from "@/lint/write-check.ts";
+import { prepareWriteLintContext, type WriteLintContext } from "@/lint/write-check.ts";
 import type {
   MiddlewareVerdict,
   ServerMiddleware,
@@ -34,8 +30,6 @@ export interface LintMiddlewareOptions {
    */
   startDir?: string;
 }
-
-const DENIAL_DOCS = "https://github.com/ubie-oss/n8n-cli#lint";
 
 /**
  * The lint middleware reuses the existing engine and write-check helpers;

--- a/src/middleware/builtin/oauth-verify/factory.ts
+++ b/src/middleware/builtin/oauth-verify/factory.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
+import { OAuthVerifyMiddleware } from "./middleware.ts";
+import type { OAuthVerifyEnforce, OAuthVerifyOptions } from "./types.ts";
+
+const enforceSchema: z.ZodType<OAuthVerifyEnforce> = z.union([
+  z.literal("off"),
+  z.literal("warn"),
+  z.literal("deny"),
+]);
+
+const optionsSchema = z.object({
+  enforce: enforceSchema.default("deny"),
+  expectedAudiences: z.array(z.string().min(1)).default([]),
+  trustedPrincipals: z.array(z.string().min(1)).default([]),
+});
+
+function splitList(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<OAuthVerifyOptions> {
+  const out: Partial<OAuthVerifyOptions> = {};
+  if (env.N8N_OAUTH_VERIFY_ENFORCE) {
+    out.enforce = env.N8N_OAUTH_VERIFY_ENFORCE as OAuthVerifyEnforce;
+  }
+  const aud = splitList(env.N8N_OAUTH_VERIFY_EXPECTED_AUDIENCES);
+  if (aud) out.expectedAudiences = aud;
+  const principals = splitList(env.N8N_OAUTH_VERIFY_TRUSTED_PRINCIPALS);
+  if (principals) out.trustedPrincipals = principals;
+  return out;
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<OAuthVerifyOptions> {
+  const out: Partial<OAuthVerifyOptions> = {};
+  const s = (k: string) => (typeof opts[k] === "string" ? (opts[k] as string) : undefined);
+  const list = (k: string) => splitList(s(k));
+
+  if (s("oauthVerifyEnforce")) out.enforce = s("oauthVerifyEnforce") as OAuthVerifyEnforce;
+  const aud = list("oauthVerifyExpectedAudiences");
+  if (aud) out.expectedAudiences = aud;
+  const principals = list("oauthVerifyTrustedPrincipals");
+  if (principals) out.trustedPrincipals = principals;
+  return out;
+}
+
+export const oauthVerifyFactory: ServerMiddlewareFactory<OAuthVerifyOptions> = {
+  name: "oauth-verify",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged) as OAuthVerifyOptions;
+    return new OAuthVerifyMiddleware(parsed);
+  },
+};
+
+export const oauthVerifyOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/oauth-verify/middleware.ts
+++ b/src/middleware/builtin/oauth-verify/middleware.ts
@@ -1,0 +1,113 @@
+import { GoogleTokeninfoVerifier } from "@/middleware/auth/google-tokeninfo.ts";
+import { type IdTokenVerifier, parseBearer } from "@/middleware/auth/types.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
+import type { OAuthVerifyOptions } from "./types.ts";
+
+/**
+ * Server middleware that verifies the `Authorization: Bearer` token as a
+ * signed id_token via a pluggable `IdTokenVerifier`.
+ *
+ * On success:
+ *   - `ctx.auth.bearer` is populated with the verified claim.
+ *   - `ctx.identity` is set to the verified email (mirrors the legacy
+ *     contract used by the existing `authz` middleware).
+ *   - `ctx.auth.effective` is set to the bearer's email; a later
+ *     `impersonator-verify` may overwrite it when a trusted principal
+ *     forwards a user token.
+ *
+ * On failure (missing token, wrong aud, unverified email, verifier
+ * rejection): behavior depends on `enforce` — `deny` blocks with 401,
+ * `warn` allows through with a warning violation, `off` passes silently.
+ *
+ * The verifier is completely decoupled from the middleware. The default
+ * (`GoogleTokeninfoVerifier`) fits deployments where callers present
+ * Google-signed id_tokens; other issuers plug in their own `IdTokenVerifier`
+ * via `options.verifier` and the pipeline logic here doesn't change.
+ *
+ * Modes: this middleware only runs meaningfully when there's a request
+ * (i.e. `mode === "proxy"`). Apply / single mode has no HTTP request, so
+ * we pass through — `--server-middleware` chains that include this one
+ * for both modes stay usable without special-casing.
+ */
+export class OAuthVerifyMiddleware implements ServerMiddleware {
+  readonly name = "oauth-verify";
+  private readonly verifier: IdTokenVerifier;
+  private readonly expectedAud: Set<string>;
+  private readonly trustedPrincipals: Set<string>;
+
+  constructor(private readonly options: OAuthVerifyOptions) {
+    this.verifier = options.verifier ?? new GoogleTokeninfoVerifier();
+    this.expectedAud = new Set(options.expectedAudiences);
+    this.trustedPrincipals = new Set(options.trustedPrincipals);
+  }
+
+  async evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> {
+    if (this.options.enforce === "off") return { block: false, violations: [] };
+    if (ctx.mode !== "proxy" || !ctx.request) {
+      // Apply / single mode has no HTTP request; nothing to verify.
+      return { block: false, violations: [] };
+    }
+
+    const authHeader = ctx.request.headers.get("authorization");
+    const token = parseBearer(authHeader);
+    if (!token) return this.reject("missing bearer");
+
+    if (this.expectedAud.size === 0) {
+      return this.reject("no expected audiences configured");
+    }
+
+    const claim = await this.verifier.verify(token);
+    if (!claim) return this.reject("verifier rejected the token");
+    if (!this.expectedAud.has(claim.aud)) {
+      // Do NOT echo the received aud back to the caller — that's an oracle.
+      return this.reject("audience not accepted");
+    }
+    if (!claim.emailVerified || !claim.email) {
+      return this.reject("email not verified");
+    }
+
+    // Populate auth context so downstream middlewares can rely on it.
+    // We stash trusted-principal membership on the request so
+    // `impersonator-verify` doesn't need to re-read this config.
+    const bearer = {
+      email: claim.email,
+      aud: claim.aud,
+      verified: true as const,
+    };
+    ctx.auth = {
+      ...(ctx.auth ?? {}),
+      bearer,
+      effective: { email: claim.email, layer: "bearer" as const },
+    };
+    ctx.identity = claim.email;
+    (ctx as { __oauthVerifyBearerIsTrusted?: boolean }).__oauthVerifyBearerIsTrusted =
+      this.trustedPrincipals.has(claim.email);
+    return { block: false, violations: [] };
+  }
+
+  private reject(reason: string): MiddlewareVerdict {
+    const violation = {
+      rule: "oauth-verify-rejected",
+      severity: "error" as const,
+      message: `Bearer verification failed: ${reason}`,
+    };
+    if (this.options.enforce === "warn") {
+      return { block: false, violations: [{ ...violation, severity: "warning" }] };
+    }
+    return {
+      block: true,
+      violations: [violation],
+      denial: {
+        status: 401,
+        error: "bearer_verification_failed",
+        // Generic message — the specific reason lives in server-side
+        // logs (via the violation) rather than leaking to the caller.
+        message: "Bearer verification failed.",
+      },
+    };
+  }
+}

--- a/src/middleware/builtin/oauth-verify/types.ts
+++ b/src/middleware/builtin/oauth-verify/types.ts
@@ -1,0 +1,44 @@
+import type { IdTokenVerifier } from "@/middleware/auth/types.ts";
+
+/**
+ * Behavior when the incoming Authorization: Bearer is absent, malformed, or
+ * fails verification.
+ *
+ * - `deny`  — return 401 and short-circuit the pipeline. Fail-closed.
+ * - `warn`  — record the failure but let the request proceed. Useful during
+ *             rollout when tokens are being introduced but not yet enforced.
+ * - `off`   — no verification at all. Included for symmetry with authz's
+ *             `enforce`; use `--server-middleware` to just not enable this
+ *             middleware if you want the same effect.
+ */
+export type OAuthVerifyEnforce = "off" | "warn" | "deny";
+
+export interface OAuthVerifyOptions {
+  enforce: OAuthVerifyEnforce;
+  /**
+   * Accepted `aud` claim values. Every deployment pins this to the token
+   * audiences that map to its own resource — e.g. a Cloud Run service URL,
+   * an IAP OAuth client id, a Kubernetes ServiceAccount JWT audience, etc.
+   * Empty list = middleware fails-closed because no token can pass.
+   */
+  expectedAudiences: string[];
+  /**
+   * Principals whose bearer identity is trusted enough to have an
+   * accompanying impersonator token honored. When a bearer's email is in
+   * this list, `impersonator-verify` will accept the side-channel
+   * identity assertion it carries.
+   *
+   * "Principal" here means whatever subject the verifier surfaces — an
+   * email, an SPIFFE id, an OIDC `sub`, etc. The comparison is a plain
+   * string match against the verified `email` claim, so populate this
+   * with the exact values your verifier emits.
+   */
+  trustedPrincipals: string[];
+  /**
+   * Token verifier. Injected for tests and for deployments that use a
+   * non-Google issuer. When left unset, the factory defaults to
+   * `GoogleTokeninfoVerifier` — swap that at the factory level (or bypass
+   * the factory entirely) to accept another issuer's tokens.
+   */
+  verifier?: IdTokenVerifier;
+}

--- a/src/middleware/client-wiring.ts
+++ b/src/middleware/client-wiring.ts
@@ -1,5 +1,6 @@
 import { apiKeyInjectFactory } from "./builtin/api-key-inject/factory.ts";
 import { iapAuthFactory } from "./builtin/iap-auth/factory.ts";
+import { impersonatorTokenFactory } from "./builtin/impersonator-token/factory.ts";
 import { knownClientMiddlewareNames, registerClientFactory } from "./client-registry.ts";
 
 /**
@@ -11,6 +12,7 @@ import { knownClientMiddlewareNames, registerClientFactory } from "./client-regi
 export function registerClientBuiltins(): void {
   registerClientFactory(iapAuthFactory);
   registerClientFactory(apiKeyInjectFactory);
+  registerClientFactory(impersonatorTokenFactory);
 }
 
 /**

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -4,6 +4,51 @@ import type { Violation } from "@/lint/rules/violation.ts";
 /** Where the pipeline is running. Middlewares can adapt to context. */
 export type PipelineMode = "proxy" | "apply" | "single";
 
+/**
+ * Cryptographically verified identity claim from a Bearer token or from an
+ * X-Impersonator-Id-Token side channel. Populated by auth-verifying
+ * middlewares (`oauth-verify`, `impersonator-verify`) and consumed by
+ * gating middlewares (`caller-authz`) or downstream logging.
+ *
+ * Rule: only middlewares that verify a token via Google JWKS / tokeninfo
+ * write these fields. Callers must not populate them from ambient headers,
+ * otherwise the "verified" contract silently breaks.
+ */
+export interface VerifiedTokenClaim {
+  /** Email claim from the id_token (Google `email` payload). */
+  email: string;
+  /** Audience claim (Google `aud` payload) that passed the aud check. */
+  aud: string;
+  /** True when the token itself declared `email_verified=true` and issuer matched. */
+  verified: true;
+}
+
+/**
+ * Structured auth state populated by verifying middlewares. Later middlewares
+ * (external-authz, external forwarding, audit logging) read `effective` to
+ * get the authoritative caller identity without caring which layer produced
+ * it. See `oauth-verify` / `impersonator-verify` for how fields are set.
+ */
+export interface AuthContext {
+  /** Bearer token in Authorization header, verified against expected aud. */
+  bearer?: VerifiedTokenClaim;
+  /**
+   * X-Impersonator-Id-Token (or configured equivalent), verified against
+   * the impersonator aud allowlist. Only trusted service accounts (per
+   * `oauth-verify`'s allowedServiceAccounts) may attach one.
+   */
+  impersonator?: VerifiedTokenClaim;
+  /**
+   * The authoritative identity for downstream authz. When an impersonator
+   * is present and trusted, this points at it; otherwise it mirrors the
+   * bearer. `layer` lets downstream code differentiate for audit purposes.
+   */
+  effective?: {
+    email: string;
+    layer: "bearer" | "impersonator";
+  };
+}
+
 /** Per-request input handed to each server middleware. */
 export interface ServerMiddlewareContext {
   /** Parsed workflow. May be null when JSON parsing failed upstream. */
@@ -16,8 +61,19 @@ export interface ServerMiddlewareContext {
   rawJSON?: string;
   /** Incoming HTTP request (proxy mode only). */
   request?: Request;
-  /** Identifier of the actor performing the write, if resolvable. */
+  /**
+   * Identifier of the actor performing the write, if resolvable. Kept for
+   * backwards compatibility with the existing `authz` middleware. Auth-
+   * verifying middlewares also mirror `auth.effective.email` here so simple
+   * consumers can read a single string.
+   */
   identity?: string;
+  /**
+   * Cryptographically verified identity, populated by auth middlewares.
+   * Consumers that need strong guarantees about *who* the caller is (as
+   * opposed to a hint) read from here.
+   */
+  auth?: AuthContext;
   /** Which call site is running the pipeline. */
   mode: PipelineMode;
 }

--- a/src/middleware/wiring.ts
+++ b/src/middleware/wiring.ts
@@ -1,5 +1,7 @@
 import { authzFactory } from "./builtin/authz/factory.ts";
+import { impersonatorVerifyFactory } from "./builtin/impersonator-verify/factory.ts";
 import { lintFactory } from "./builtin/lint/factory.ts";
+import { oauthVerifyFactory } from "./builtin/oauth-verify/factory.ts";
 import { knownMiddlewareNames, registerFactory } from "./registry.ts";
 
 /**
@@ -11,6 +13,8 @@ import { knownMiddlewareNames, registerFactory } from "./registry.ts";
 export function registerBuiltins(): void {
   registerFactory(lintFactory);
   registerFactory(authzFactory);
+  registerFactory(oauthVerifyFactory);
+  registerFactory(impersonatorVerifyFactory);
 }
 
 /**

--- a/tests/middleware/auth/google-tokeninfo.test.ts
+++ b/tests/middleware/auth/google-tokeninfo.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { type FetchLike, GoogleTokeninfoVerifier } from "@/middleware/auth/google-tokeninfo.ts";
+import { parseBearer } from "@/middleware/auth/types.ts";
+
+function fetchResponding(status: number, body: unknown): FetchLike {
+  return async () =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+}
+
+describe("parseBearer", () => {
+  test("returns the token when present", () => {
+    expect(parseBearer("Bearer abc")).toBe("abc");
+    expect(parseBearer("bearer  xyz")).toBe("xyz");
+  });
+  test("returns null when absent or malformed", () => {
+    expect(parseBearer(undefined)).toBeNull();
+    expect(parseBearer("")).toBeNull();
+    expect(parseBearer("Basic abc")).toBeNull();
+  });
+});
+
+describe("GoogleTokeninfoVerifier", () => {
+  test("returns a normalized claim on 200", async () => {
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: fetchResponding(200, {
+        iss: "https://accounts.google.com",
+        aud: "aud",
+        email: "u@x.dev",
+        email_verified: "true",
+      }),
+    });
+    const claim = await verifier.verify("tok");
+    expect(claim?.email).toBe("u@x.dev");
+    expect(claim?.aud).toBe("aud");
+    expect(claim?.emailVerified).toBe(true);
+  });
+
+  test("rejects non-Google issuers", async () => {
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: fetchResponding(200, {
+        iss: "https://evil.example.com",
+        aud: "aud",
+      }),
+    });
+    expect(await verifier.verify("tok")).toBeNull();
+  });
+
+  test("returns null on non-200", async () => {
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: fetchResponding(400, { error: "bad" }),
+    });
+    expect(await verifier.verify("tok")).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: () => Promise.reject(new Error("network down")),
+    });
+    expect(await verifier.verify("tok")).toBeNull();
+  });
+
+  test("returns null when tokenless", async () => {
+    const verifier = new GoogleTokeninfoVerifier({ fetcher: fetchResponding(200, {}) });
+    expect(await verifier.verify("")).toBeNull();
+  });
+
+  test("caches successful verifications only", async () => {
+    let calls = 0;
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: async () => {
+        calls++;
+        return new Response(
+          JSON.stringify({
+            iss: "https://accounts.google.com",
+            aud: "aud",
+            email: "u@x.dev",
+            email_verified: "true",
+            exp: String(Math.floor(Date.now() / 1000) + 3600), // 1h from now
+          }),
+          { status: 200 },
+        );
+      },
+      cacheTtlMs: 60_000,
+    });
+    await verifier.verify("tok");
+    await verifier.verify("tok");
+    expect(calls).toBe(1);
+  });
+
+  test("does not cache negative responses", async () => {
+    let calls = 0;
+    const verifier = new GoogleTokeninfoVerifier({
+      fetcher: async () => {
+        calls++;
+        return new Response("", { status: 400 });
+      },
+    });
+    await verifier.verify("tok");
+    await verifier.verify("tok");
+    expect(calls).toBe(2);
+  });
+
+  test("cache entry expiry is capped at the token's own exp claim", async () => {
+    // Token expiry is 100s from now; cache TTL is 5min. Cache MUST NOT
+    // serve the token past 100s — that's the security invariant.
+    let clock = 0;
+    let calls = 0;
+    const verifier = new GoogleTokeninfoVerifier({
+      now: () => clock,
+      cacheTtlMs: 5 * 60 * 1000,
+      fetcher: async () => {
+        calls++;
+        return new Response(
+          JSON.stringify({
+            iss: "https://accounts.google.com",
+            aud: "aud",
+            email: "u@x.dev",
+            email_verified: "true",
+            exp: "100", // 100s since epoch
+          }),
+          { status: 200 },
+        );
+      },
+    });
+    clock = 0;
+    expect(await verifier.verify("tok")).not.toBeNull();
+    expect(calls).toBe(1);
+    clock = 50_000; // 50s later — still within token exp
+    expect(await verifier.verify("tok")).not.toBeNull();
+    expect(calls).toBe(1);
+    clock = 101_000; // past token exp; cache MUST expire, forcing a refetch
+    expect(await verifier.verify("tok")).not.toBeNull();
+    expect(calls).toBe(2);
+  });
+});

--- a/tests/middleware/builtin/impersonator-token/middleware.test.ts
+++ b/tests/middleware/builtin/impersonator-token/middleware.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { AdcUserTokenSource } from "@/middleware/builtin/impersonator-token/adc-user-token-source.ts";
+import { impersonatorTokenFactory } from "@/middleware/builtin/impersonator-token/factory.ts";
+import { ImpersonatorTokenMiddleware } from "@/middleware/builtin/impersonator-token/middleware.ts";
+import {
+  StaticUserTokenSource,
+  type UserTokenSource,
+} from "@/middleware/builtin/impersonator-token/user-token-source.ts";
+
+const baseCtx = {
+  request: new Request("http://proxy.local/api/v1/workflows"),
+  method: "GET",
+  pathname: "/api/v1/workflows",
+  upstreamUrl: "http://upstream.local/api/v1/workflows",
+};
+
+describe("ImpersonatorTokenMiddleware", () => {
+  test("attaches the token to X-Impersonator-Id-Token by default", async () => {
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: new StaticUserTokenSource("user-tok"),
+      onError: "throw",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("x-impersonator-id-token")).toBe("user-tok");
+  });
+
+  test("respects custom headerName", async () => {
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-User-Id-Token",
+      tokenSource: new StaticUserTokenSource("t"),
+      onError: "throw",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("x-user-id-token")).toBe("t");
+  });
+
+  test("throws on token-source error when onError=throw", async () => {
+    const src: UserTokenSource = {
+      getToken: () => Promise.reject(new Error("source unavailable")),
+    };
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "H",
+      tokenSource: src,
+      onError: "throw",
+    });
+    await expect(mw.apply(new Headers(), baseCtx)).rejects.toThrow(/source unavailable/);
+  });
+
+  test("swallows error when onError=skip (SA-only fallback)", async () => {
+    const src: UserTokenSource = {
+      getToken: () => Promise.reject(new Error("source unavailable")),
+    };
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "H",
+      tokenSource: src,
+      onError: "skip",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("H")).toBeNull();
+  });
+
+  test("requests the token using configured audience", async () => {
+    let seenAud: string | undefined;
+    const src: UserTokenSource = {
+      getToken: (aud) => {
+        seenAud = aud;
+        return Promise.resolve("t");
+      },
+    };
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "https://custom-aud",
+      headerName: "H",
+      tokenSource: src,
+      onError: "throw",
+    });
+    await mw.apply(new Headers(), baseCtx);
+    expect(seenAud).toBe("https://custom-aud");
+  });
+});
+
+describe("AdcUserTokenSource", () => {
+  test("exchanges refresh_token for id_token via the OAuth token endpoint", async () => {
+    let capturedBody: string | undefined;
+    const src = new AdcUserTokenSource({
+      readCredentials: async () => ({
+        client_id: "cli",
+        client_secret: "secret",
+        refresh_token: "rt",
+      }),
+      fetcher: async (_url, init) => {
+        capturedBody = init?.body?.toString();
+        return new Response(JSON.stringify({ id_token: "user-id-tok", expires_in: 3600 }), {
+          status: 200,
+        });
+      },
+    });
+    const token = await src.getToken("aud-x");
+    expect(token).toBe("user-id-tok");
+    expect(capturedBody).toContain("grant_type=refresh_token");
+    expect(capturedBody).toContain("audience=aud-x");
+    expect(capturedBody).toContain("refresh_token=rt");
+  });
+
+  test("caches per audience", async () => {
+    let calls = 0;
+    const src = new AdcUserTokenSource({
+      readCredentials: async () => ({
+        client_id: "c",
+        client_secret: "s",
+        refresh_token: "r",
+      }),
+      fetcher: async () => {
+        calls++;
+        return new Response(JSON.stringify({ id_token: "t", expires_in: 3600 }), { status: 200 });
+      },
+    });
+    await src.getToken("a");
+    await src.getToken("a");
+    expect(calls).toBe(1);
+  });
+
+  test("throws when ADC file lacks the refresh_token", async () => {
+    const src = new AdcUserTokenSource({
+      readCredentials: async () => ({ client_id: "c", client_secret: "s" }),
+      fetcher: async () => new Response("{}", { status: 200 }),
+    });
+    await expect(src.getToken("aud")).rejects.toThrow(/refresh_token/);
+  });
+
+  test("surfaces non-200 token endpoint responses", async () => {
+    const src = new AdcUserTokenSource({
+      readCredentials: async () => ({
+        client_id: "c",
+        client_secret: "s",
+        refresh_token: "r",
+      }),
+      fetcher: async () => new Response("bad_grant", { status: 400 }),
+    });
+    await expect(src.getToken("aud")).rejects.toThrow(/HTTP 400/);
+  });
+
+  test("re-reads credentials after an initial read failure", async () => {
+    // Simulates the CLI-user scenario: first call fails because ADC
+    // wasn't set up yet, user runs `gcloud auth application-default
+    // login`, subsequent call must succeed without restart.
+    let attempt = 0;
+    const src = new AdcUserTokenSource({
+      readCredentials: async () => {
+        attempt++;
+        if (attempt === 1) throw new Error("ENOENT: application_default_credentials.json");
+        return { client_id: "c", client_secret: "s", refresh_token: "r" };
+      },
+      fetcher: async () =>
+        new Response(JSON.stringify({ id_token: "later-tok", expires_in: 3600 }), { status: 200 }),
+    });
+    await expect(src.getToken("aud")).rejects.toThrow(/ENOENT/);
+    // Second call must reach the fetcher — the failed first attempt
+    // must NOT be cached.
+    const token = await src.getToken("aud");
+    expect(token).toBe("later-tok");
+    expect(attempt).toBe(2);
+  });
+});
+
+describe("impersonatorTokenFactory", () => {
+  test("audience is required", () => {
+    expect(() => impersonatorTokenFactory.build({})).toThrow(/audience/);
+  });
+
+  test("static token source requires staticToken", () => {
+    expect(() =>
+      impersonatorTokenFactory.build({ audience: "aud", tokenSourceKind: "static" }),
+    ).toThrow(/staticToken/);
+  });
+
+  test("env token source requires tokenEnvVar", () => {
+    expect(() =>
+      impersonatorTokenFactory.build({ audience: "aud", tokenSourceKind: "env" }),
+    ).toThrow(/tokenEnvVar/);
+  });
+
+  test("default source is env (requires tokenEnvVar to actually build)", () => {
+    // Just verifying the default token-source selector doesn't silently
+    // pick a Google-specific transport.
+    expect(() => impersonatorTokenFactory.build({ audience: "aud" })).toThrow(/tokenEnvVar/);
+  });
+
+  test("adc token source is available when explicitly selected", () => {
+    const mw = impersonatorTokenFactory.build({ audience: "aud", tokenSourceKind: "adc" });
+    expect(mw.name).toBe("impersonator-token");
+  });
+
+  test("loads config from env", () => {
+    const partial = impersonatorTokenFactory.loadFromEnv({
+      N8N_IMPERSONATOR_TOKEN_AUDIENCE: "aud-env",
+      N8N_IMPERSONATOR_TOKEN_SOURCE: "env",
+      N8N_IMPERSONATOR_TOKEN_ENV_VAR: "MY_USER_TOKEN",
+      N8N_IMPERSONATOR_TOKEN_ON_ERROR: "skip",
+    });
+    expect(partial.audience).toBe("aud-env");
+    expect(partial.tokenSourceKind).toBe("env");
+    expect(partial.tokenEnvVar).toBe("MY_USER_TOKEN");
+    expect(partial.onError).toBe("skip");
+  });
+
+  test("loads config from CLI options", () => {
+    const partial = impersonatorTokenFactory.loadFromCLI({
+      impersonatorTokenAudience: "aud-cli",
+      impersonatorTokenOnError: "skip",
+    });
+    expect(partial.audience).toBe("aud-cli");
+    expect(partial.onError).toBe("skip");
+  });
+});

--- a/tests/middleware/builtin/impersonator-verify/middleware.test.ts
+++ b/tests/middleware/builtin/impersonator-verify/middleware.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import type { IdTokenVerifier, VerifiedClaim } from "@/middleware/auth/types.ts";
+import { impersonatorVerifyFactory } from "@/middleware/builtin/impersonator-verify/factory.ts";
+import { ImpersonatorVerifyMiddleware } from "@/middleware/builtin/impersonator-verify/middleware.ts";
+import type { ServerMiddlewareContext, VerifiedTokenClaim } from "@/middleware/types.ts";
+
+const OAUTH_CLIENT_AUD = "example-oauth-client.apps.example.com";
+
+function reqWithHeader(name: string, value: string | null): Request {
+  const headers = new Headers();
+  if (value) headers.set(name, value);
+  return new Request("https://proxy.local/api/v1/workflows", { headers });
+}
+
+function baseCtx(
+  req: Request,
+  opts?: { trustedBearer?: boolean; bearer?: VerifiedTokenClaim },
+): ServerMiddlewareContext {
+  const ctx: ServerMiddlewareContext = { workflow: null, request: req, mode: "proxy" };
+  if (opts?.bearer) {
+    ctx.auth = { bearer: opts.bearer, effective: { email: opts.bearer.email, layer: "bearer" } };
+    ctx.identity = opts.bearer.email;
+  }
+  if (opts?.trustedBearer !== undefined) {
+    (ctx as { __oauthVerifyBearerIsTrusted?: boolean }).__oauthVerifyBearerIsTrusted =
+      opts.trustedBearer;
+  }
+  return ctx;
+}
+
+function verifierYielding(claim: VerifiedClaim | null): IdTokenVerifier {
+  return { verify: async () => claim };
+}
+
+const validUserClaim: VerifiedClaim = {
+  iss: "https://accounts.google.com",
+  aud: OAUTH_CLIENT_AUD,
+  email: "user@example.com",
+  emailVerified: true,
+};
+
+const trustedBearerPrincipal: VerifiedTokenClaim = {
+  email: "trusted-caller@example.com",
+  aud: "https://proxy.local",
+  verified: true,
+};
+
+describe("ImpersonatorVerifyMiddleware", () => {
+  test("accepts a valid impersonator when bearer principal is trusted", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth?.impersonator?.email).toBe("user@example.com");
+    expect(ctx.auth?.effective).toEqual({ email: "user@example.com", layer: "impersonator" });
+    expect(ctx.identity).toBe("user@example.com");
+  });
+
+  test("rejects impersonator when bearer principal is untrusted", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"), {
+      trustedBearer: false,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.status).toBe(401);
+  });
+
+  test("rejects impersonator when bearer not verified upstream", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"));
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+  });
+
+  test("passes silently when no impersonator header (requirement=optional)", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", null), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth?.impersonator).toBeUndefined();
+    expect(ctx.auth?.effective?.layer).toBe("bearer");
+  });
+
+  test("blocks when no impersonator header + requirement=require", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "require",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", null), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+  });
+
+  test("rejects wrong-aud impersonator", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding({ ...validUserClaim, aud: "https://wrong" }),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+    // Aud must NOT leak to the caller.
+    expect(verdict.denial?.message).toBe("Impersonator verification failed.");
+  });
+
+  test("rejects unverified-email impersonator", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding({ ...validUserClaim, emailVerified: false }),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+  });
+
+  test("warn mode emits a violation but does not block", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "warn",
+      requirement: "optional",
+      headerName: "X-Impersonator-Id-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding({ ...validUserClaim, aud: "wrong" }),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Impersonator-Id-Token", "user-tok"), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(verdict.violations[0]?.severity).toBe("warning");
+  });
+
+  test("respects a custom header name", async () => {
+    const mw = new ImpersonatorVerifyMiddleware({
+      enforce: "deny",
+      requirement: "optional",
+      headerName: "X-Custom-User-Token",
+      expectedAudiences: [OAUTH_CLIENT_AUD],
+      verifier: verifierYielding(validUserClaim),
+    });
+    const ctx = baseCtx(reqWithHeader("X-Custom-User-Token", "user-tok"), {
+      trustedBearer: true,
+      bearer: trustedBearerPrincipal,
+    });
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth?.impersonator?.email).toBe("user@example.com");
+  });
+});
+
+describe("impersonatorVerifyFactory", () => {
+  test("loads from env with sensible defaults", () => {
+    const partial = impersonatorVerifyFactory.loadFromEnv({
+      N8N_IMPERSONATOR_VERIFY_ENFORCE: "warn",
+      N8N_IMPERSONATOR_VERIFY_REQUIREMENT: "require",
+      N8N_IMPERSONATOR_VERIFY_EXPECTED_AUDIENCES: "aud-a,aud-b",
+    });
+    expect(partial.enforce).toBe("warn");
+    expect(partial.requirement).toBe("require");
+    expect(partial.expectedAudiences).toEqual(["aud-a", "aud-b"]);
+  });
+});

--- a/tests/middleware/builtin/oauth-verify/middleware.test.ts
+++ b/tests/middleware/builtin/oauth-verify/middleware.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { GoogleTokeninfoVerifier } from "@/middleware/auth/google-tokeninfo.ts";
+import type { IdTokenVerifier, VerifiedClaim } from "@/middleware/auth/types.ts";
+import { oauthVerifyFactory } from "@/middleware/builtin/oauth-verify/factory.ts";
+import { OAuthVerifyMiddleware } from "@/middleware/builtin/oauth-verify/middleware.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
+
+function reqWith(auth: string | null): Request {
+  const headers = new Headers();
+  if (auth) headers.set("authorization", auth);
+  return new Request("https://proxy.local/api/v1/workflows", { headers });
+}
+
+function baseCtx(req: Request): ServerMiddlewareContext {
+  return { workflow: null, request: req, mode: "proxy" };
+}
+
+/** Stub verifier — the middleware doesn't care about the underlying token bytes. */
+function verifierYielding(claim: VerifiedClaim | null): IdTokenVerifier {
+  return { verify: async () => claim };
+}
+
+const validClaim: VerifiedClaim = {
+  iss: "https://accounts.google.com",
+  aud: "https://proxy.local",
+  email: "user@example.com",
+  emailVerified: true,
+};
+
+describe("OAuthVerifyMiddleware", () => {
+  test("accepts a valid bearer and populates auth context", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: ["https://proxy.local"],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx = baseCtx(reqWith("Bearer tok"));
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth?.bearer?.email).toBe("user@example.com");
+    expect(ctx.auth?.effective).toEqual({ email: "user@example.com", layer: "bearer" });
+    expect(ctx.identity).toBe("user@example.com");
+  });
+
+  test("rejects a missing bearer with 401 when enforce=deny", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: ["aud"],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx = baseCtx(reqWith(null));
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.status).toBe(401);
+  });
+
+  test("rejects wrong aud", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: ["something-else"],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx = baseCtx(reqWith("Bearer tok"));
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.error).toBe("bearer_verification_failed");
+    // Aud must NOT leak to the caller — check only the generic message.
+    expect(verdict.denial?.message).toBe("Bearer verification failed.");
+  });
+
+  test("rejects unverified email", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: ["https://proxy.local"],
+      trustedPrincipals: [],
+      verifier: verifierYielding({ ...validClaim, emailVerified: false }),
+    });
+    const verdict = await mw.evaluate(baseCtx(reqWith("Bearer tok")));
+    expect(verdict.block).toBe(true);
+  });
+
+  test("warn mode returns block=false but emits a warning violation", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "warn",
+      expectedAudiences: ["something-else"],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const verdict = await mw.evaluate(baseCtx(reqWith("Bearer tok")));
+    expect(verdict.block).toBe(false);
+    expect(verdict.violations[0]?.severity).toBe("warning");
+  });
+
+  test("off mode passes without touching context", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "off",
+      expectedAudiences: [],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx = baseCtx(reqWith(null));
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth).toBeUndefined();
+  });
+
+  test("marks trusted principals via internal context flag", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: ["https://proxy.local"],
+      trustedPrincipals: ["user@example.com"],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx = baseCtx(reqWith("Bearer tok"));
+    await mw.evaluate(ctx);
+    const trusted = (ctx as { __oauthVerifyBearerIsTrusted?: boolean })
+      .__oauthVerifyBearerIsTrusted;
+    expect(trusted).toBe(true);
+  });
+
+  test("no expected audiences configured → fails closed", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: [],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const verdict = await mw.evaluate(baseCtx(reqWith("Bearer tok")));
+    expect(verdict.block).toBe(true);
+  });
+
+  test("apply/single mode passes through without touching auth", async () => {
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "deny",
+      expectedAudiences: [],
+      trustedPrincipals: [],
+      verifier: verifierYielding(validClaim),
+    });
+    const ctx: ServerMiddlewareContext = { workflow: null, mode: "apply" };
+    const verdict = await mw.evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(ctx.auth).toBeUndefined();
+  });
+
+  test("default verifier is Google when none injected", () => {
+    // Sanity check the factory-default wiring: constructing with no
+    // verifier should not throw and should produce a working middleware.
+    const mw = new OAuthVerifyMiddleware({
+      enforce: "off",
+      expectedAudiences: [],
+      trustedPrincipals: [],
+    });
+    expect(mw.name).toBe("oauth-verify");
+    // The internal verifier field is private; check the class exists.
+    expect(new GoogleTokeninfoVerifier()).toBeDefined();
+  });
+});
+
+describe("oauthVerifyFactory", () => {
+  test("loads config from env", () => {
+    const partial = oauthVerifyFactory.loadFromEnv({
+      N8N_OAUTH_VERIFY_ENFORCE: "warn",
+      N8N_OAUTH_VERIFY_EXPECTED_AUDIENCES: "a, b , c ",
+      N8N_OAUTH_VERIFY_TRUSTED_PRINCIPALS: "sa@example.com",
+    });
+    expect(partial.enforce).toBe("warn");
+    expect(partial.expectedAudiences).toEqual(["a", "b", "c"]);
+    expect(partial.trustedPrincipals).toEqual(["sa@example.com"]);
+  });
+
+  test("loads config from CLI", () => {
+    const partial = oauthVerifyFactory.loadFromCLI({
+      oauthVerifyEnforce: "warn",
+      oauthVerifyExpectedAudiences: "aud1,aud2",
+    });
+    expect(partial.enforce).toBe("warn");
+    expect(partial.expectedAudiences).toEqual(["aud1", "aud2"]);
+  });
+
+  test("build() constructs a live middleware", () => {
+    const mw = oauthVerifyFactory.build({ expectedAudiences: ["aud"] });
+    expect(mw.name).toBe("oauth-verify");
+  });
+});


### PR DESCRIPTION
## Summary

Adds five middlewares that let a Cloud Run / IAP-fronted deployment attribute proxy calls to the actual human running the CLI — cryptographically, without trusting client-side claims.

### New middlewares

**Server-side (ingress):**

- `oauth-verify` — verifies `Authorization: Bearer` via Google `tokeninfo`; pins iss / aud allowlist / `email_verified`
- `impersonator-verify` — verifies a side header (`X-Impersonator-Id-Token`) as the human user's own Google id_token; only honored when the primary bearer is a pre-registered trusted SA (spoof prevention)
- `caller-authz` — generic external-authz gate resolving the effective identity to a group list via a configurable HTTP endpoint

**Client-side (egress):**

- `impersonator-token` — mints the current user's Google id_token via ADC refresh-token grant and attaches it as `X-Impersonator-Id-Token`

### Also included

- Shared `TokeninfoVerifier` under `src/middleware/auth/`
- `Dockerfile` (distroless, multi-stage build)
- Full CLI-flag + `N8N_*` env-var surface, consistent with PR #47

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun test` — 971 pass / 0 fail (baseline 914 + 57 new)
- [x] `bun run lint` — exit 0
- [x] `bun run build` — produces working binary

## Status

Draft / RFC — posted to solicit review before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
