### PR TITLE
fix(proxy): drop Content-Encoding from forwarded upstream responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -12,6 +12,9 @@
  * client is expected to supply them and the upstream needs them to
  * authenticate. Client middlewares (see `ClientMiddleware`) can rewrite or
  * replace these after the strip step but before fetch.
+ *
+ * On the way back, `Content-Encoding` (and the now-stale `Content-Length`) are
+ * dropped from the upstream response — see `normalizeResponseEncoding`.
  */
 import { runClientPipeline } from "@/middleware/client-pipeline.ts";
 import type { ClientMiddleware } from "@/middleware/types.ts";
@@ -45,6 +48,41 @@ function buildUpstreamHeaders(req: Request): Headers {
     headers.delete(h);
   }
   return headers;
+}
+
+/**
+ * Rebuilds an upstream response so its headers describe the body we actually
+ * hand downstream.
+ *
+ * `fetch` negotiates and transparently *decodes* the response body (the
+ * outgoing request carries an `Accept-Encoding` the runtime adds on its own),
+ * but the `Response` it returns still advertises the upstream's
+ * `Content-Encoding` and the compressed `Content-Length`. Forwarding those
+ * verbatim hands the client a plain body labelled `content-encoding: br`,
+ * which any client that honours the header fails to decode — n8n-cli's own
+ * API client dies with `BrotliDecompressionError`. curl only escapes this
+ * because it doesn't ask for compression by default.
+ *
+ * So: when the upstream declares a real content coding, strip both headers and
+ * let the runtime recompute the length. Responses without an encoding (or with
+ * `identity`) pass through untouched, keeping the original object — and its
+ * mutable headers, which `handleWorkflowMutation` relies on to attach lint
+ * counters.
+ */
+function normalizeResponseEncoding(response: Response): Response {
+  const encoding = response.headers.get("content-encoding");
+  if (!encoding || encoding.trim().toLowerCase() === "identity") return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  // Stale: it measures the compressed bytes, not the decoded body we forward.
+  headers.delete("content-length");
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 export interface ForwardOptions {
@@ -107,7 +145,7 @@ export async function forwardRequest(
   try {
     const response = await fetch(upstreamUrl, init);
     const elapsedMs = Math.round(performance.now() - start);
-    return { response, elapsedMs };
+    return { response: normalizeResponseEncoding(response), elapsedMs };
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/tests/proxy/proxy.response-encoding.test.ts
+++ b/tests/proxy/proxy.response-encoding.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+/**
+ * Regression tests for forwarding compressed upstream responses.
+ *
+ * `fetch` decodes the upstream body on its own but leaves `Content-Encoding`
+ * and the compressed `Content-Length` on the Response. Passing those through
+ * hands the client a plain body labelled `content-encoding: gzip`, which any
+ * client that honours the header fails to decode.
+ */
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+}
+
+/** Upstream that answers with a gzip-encoded JSON body, as n8n's LB does. */
+function startCompressingUpstream(payload: unknown): MockUpstream {
+  const raw = Buffer.from(JSON.stringify(payload));
+  const gzipped = Bun.gzipSync(raw);
+  const server = Bun.serve({
+    port: 0,
+    fetch: () =>
+      new Response(gzipped, {
+        status: 200,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "content-encoding": "gzip",
+          // The compressed length — exactly what makes a verbatim forward wrong.
+          "content-length": String(gzipped.byteLength),
+          "x-upstream-marker": "kept",
+        },
+      }),
+  });
+  return { server, port: server.port! };
+}
+
+/** Upstream that answers uncompressed, to prove the pass-through path is untouched. */
+function startPlainUpstream(payload: unknown): MockUpstream {
+  const body = JSON.stringify(payload);
+  const server = Bun.serve({
+    port: 0,
+    fetch: () =>
+      new Response(body, {
+        status: 200,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "content-length": String(Buffer.byteLength(body)),
+          "x-upstream-marker": "kept",
+        },
+      }),
+  });
+  return { server, port: server.port! };
+}
+
+let upstream: MockUpstream | undefined;
+let proxy: ProxyHandle | undefined;
+
+afterEach(async () => {
+  await proxy?.stop();
+  await upstream?.server.stop(true);
+  proxy = undefined;
+  upstream = undefined;
+});
+
+function startProxyAgainst(port: number): ProxyHandle {
+  return startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${port}`,
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+  });
+}
+
+describe("proxy: upstream response encoding", () => {
+  test("a compressed upstream response reaches the client decodable", async () => {
+    const payload = { data: [{ id: "abc123", name: "workflow" }], nextCursor: null };
+    upstream = startCompressingUpstream(payload);
+    proxy = startProxyAgainst(upstream.port);
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      headers: { "accept-encoding": "gzip" },
+    });
+
+    expect(res.status).toBe(200);
+    // The body must be readable — before the fix this threw a decompression error.
+    expect(await res.json()).toEqual(payload);
+    // And the misleading headers must be gone rather than describing a body we no longer send.
+    expect(res.headers.get("content-encoding")).toBeNull();
+    // Unrelated upstream headers survive the rebuild.
+    expect(res.headers.get("x-upstream-marker")).toBe("kept");
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+  });
+
+  test("an uncompressed upstream response is forwarded untouched", async () => {
+    const payload = { data: [], nextCursor: null };
+    upstream = startPlainUpstream(payload);
+    proxy = startProxyAgainst(upstream.port);
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(payload);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("x-upstream-marker")).toBe("kept");
+  });
+});


### PR DESCRIPTION
## Problem

`forwardRequest` returns the upstream `Response` object verbatim. `fetch` transparently *decodes* the body (the runtime adds its own `Accept-Encoding` to the outgoing request), but the Response still advertises the upstream's `Content-Encoding` and the compressed `Content-Length`. The proxy therefore answers with a **plain body labelled `content-encoding: br`** and a length measuring bytes it never sent.

Observed against a deployed proxy fronting an n8n instance whose load balancer compresses responses:

```
$ curl -H 'Accept-Encoding: br' <proxy>/api/v1/workflows?limit=1 -D -
content-type: application/json; charset=utf-8
content-encoding: br          <- header says brotli
content-length: 4854          <- compressed length
{"data":[{"updatedAt":"...    <- body is plain JSON
```

Any client that honours the header fails to decode. n8n-cli's own API client dies on the first call:

```
$ N8N_API_URL=http://127.0.0.1:8099 n8n-cli workflow list --limit 2
Decompression error: BrotliDecompressionError
Error: network error: BrotliDecompressionError fetching "http://127.0.0.1:8099/api/v1/workflows?limit=2"
```

So the CLI cannot talk to a deployed proxy at all — reads included. This hid behind manual testing because curl doesn't request compression unless asked, so every hand-run `curl` check passed.

## Fix

Rebuild the response without `Content-Encoding` and `Content-Length` when the upstream declares a real content coding. The body is already decoded, so letting the runtime recompute the length is correct.

Responses with no encoding (or `identity`) keep the original object rather than a copy — `handleWorkflowMutation` mutates `response.headers` to attach `x-n8n-lint-violations` / `x-n8n-duplicate-warning`, and that path stays untouched.

## Tests

`tests/proxy/proxy.response-encoding.test.ts`:

- a gzip-encoded upstream response (with the compressed `Content-Length`) reaches the client decodable, with `content-encoding` gone and unrelated upstream headers preserved
- an uncompressed upstream response is forwarded untouched

Verified the first test fails with `ZlibError` when the fix is reverted.

Full suite: 1023 pass, 1 fail — `tests/lint/rules/no-plaintext-secrets.test.ts` ("detects literal in a password-masked param (crypto.secret)") also fails on `origin/main` at f3f879d, confirmed in a clean worktree. Unrelated to this change. `tsc --noEmit` clean; `biome check` clean on both touched files.