### PR TITLE
feat(client): let the CLI authenticate against a gateway in front of n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,12 +956,44 @@ n8n-cli version
 | Variable | Description |
 |----------|-------------|
 | `N8N_API_URL` | n8n instance API URL (required) |
-| `N8N_API_KEY` | n8n API key (required) |
+| `N8N_API_KEY` | n8n API key (required, unless an egress chain supplies credentials — see below) |
 | `N8N_API_TIMEOUT` | Request timeout in milliseconds |
 | `N8N_DEFAULT_PROJECT` | Default project ID for apply |
+| `N8N_CLIENT_MIDDLEWARES` | Comma-separated egress middlewares applied to every API call (see below) |
 | `APPLY_FILTER_BY_TAGS` | Comma-separated tags to filter apply targets |
 | `CHECKS_FILTER_BY_TAGS` | Comma-separated tags to filter lint/fmt targets (AND condition) |
 | `PROXY_FILTER_BY_TAGS` | Comma-separated tags to scope proxy middleware enforcement (AND condition) |
+
+### Talking to an authenticating gateway
+
+When n8n sits behind a gateway that authenticates callers per request — for example
+the [`proxy`](#proxy) subcommand deployed in front of it, or an identity-aware proxy —
+point `N8N_API_URL` at the gateway and enable the egress middlewares it expects.
+They run on every API call the CLI makes, so ordinary commands (`apply`, `import`,
+`workflow ...`) work unchanged:
+
+```bash
+export N8N_API_URL="https://gateway.example.com"
+export N8N_CLIENT_MIDDLEWARES="iap-auth,impersonator-token"
+
+# Gate credential: mint an id_token as a service account, using local ADC as the
+# caller. `aud` defaults to N8N_API_URL, which is what a Cloud Run gateway expects.
+export N8N_IAP_AUTH_TOKEN_SOURCE="adc-impersonate"
+export N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT="gate-caller@example.iam.gserviceaccount.com"
+
+# Human identity side-header, so the gateway can attribute the call to a person.
+# `aud` defaults to the OAuth client that issued the ADC credentials.
+export N8N_IMPERSONATOR_TOKEN_SOURCE="adc"
+```
+
+`N8N_API_KEY` is not required in this setup: a gateway that terminates
+authentication holds the n8n key and injects it upstream (`api-key-inject`), so
+the caller never needs one. Tokens are minted on demand and cached in-process, so
+no external refresh step is involved.
+
+Available egress middlewares: `iap-auth` (Bearer id_token; sources `metadata`,
+`adc-impersonate`, `env`, `static`), `impersonator-token`
+(`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`.
 
 ### CLAUDE.md Integration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,3 +1,5 @@
+import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
 import { NetworkError, parseAPIError } from "./errors.ts";
 
 /** Client is the n8n API client */
@@ -5,8 +7,26 @@ export class Client {
   private readonly baseURL: string;
   private readonly apiKey: string;
   private readonly timeoutMs: number;
+  private readonly clientMiddlewares: ClientMiddleware[];
 
-  constructor(baseURL: string, apiKey: string, timeoutMs = 30_000) {
+  constructor(
+    baseURL: string,
+    apiKey: string,
+    timeoutMs = 30_000,
+    /**
+     * Outgoing middlewares applied to every API call, in order. Empty by
+     * default, so a client talking straight to n8n behaves exactly as before.
+     *
+     * This is the seam that lets the CLI reach an authenticating gateway in
+     * front of n8n: such a gateway needs a per-request credential (a
+     * short-lived id_token, a user identity side-header), and without a hook
+     * here the CLI can only ever send `X-N8N-API-KEY` — so it is rejected at
+     * the edge before any n8n request happens. The middlewares are the same
+     * ones the proxy subcommand uses on its own egress, so there is one
+     * implementation and one config vocabulary for both directions.
+     */
+    clientMiddlewares: ClientMiddleware[] = [],
+  ) {
     // Ensure baseURL doesn't have trailing slash
     let url = baseURL.replace(/\/+$/, "");
 
@@ -18,6 +38,7 @@ export class Client {
     this.baseURL = url;
     this.apiKey = apiKey;
     this.timeoutMs = timeoutMs;
+    this.clientMiddlewares = clientMiddlewares;
   }
 
   /** doRequest performs an HTTP request with authentication */
@@ -27,13 +48,30 @@ export class Client {
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 
     try {
+      const headers = new Headers({
+        "X-N8N-API-KEY": this.apiKey,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        // Ask for an identity encoding on purpose. A proxy in front of n8n
+        // typically re-emits the upstream's Content-Encoding over a body its
+        // own HTTP client already decoded, and the mismatch surfaces here as a
+        // decompression failure we cannot recover from. Uncompressed transfers
+        // cost bandwidth a CLI can afford; a read path that dies on large
+        // responses is not.
+        "Accept-Encoding": "identity",
+      });
+
+      if (this.clientMiddlewares.length > 0) {
+        await runClientPipeline(this.clientMiddlewares, headers, {
+          method,
+          pathname: new URL(url).pathname,
+          upstreamUrl: url,
+        });
+      }
+
       const init: RequestInit = {
         method,
-        headers: {
-          "X-N8N-API-KEY": this.apiKey,
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
+        headers,
         signal: controller.signal,
       };
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { parseTagFilter } from "@/common/tags.ts";
 import { parseMiddlewareList } from "@/middleware/registry.ts";
 import { parseEnforceLevel } from "@/proxy/config.ts";
+import { parseRoutes } from "@/proxy/rest/router.ts";
 import { startProxy } from "@/proxy/server.ts";
 
 interface ProxyOptions {
@@ -17,6 +18,7 @@ interface ProxyOptions {
   serverMiddleware?: string;
   clientMiddleware?: string;
   tags?: string;
+  routes?: string;
   // iap-auth client-middleware options.
   iapAuthAudience?: string;
   iapAuthTokenSource?: string;
@@ -54,6 +56,11 @@ interface ProxyOptions {
   authzGroupsTimeoutMs?: string;
   authzWorkflowExtract?: string;
   authzWorkflowStripPrefix?: string;
+  authzAclSource?: string;
+  authzAclCacheTtlMs?: string;
+  authzOnMissingAcl?: string;
+  authzBootstrapGroups?: string;
+  authzActions?: string;
   // oauth-verify server middleware options. Verifies the incoming
   // Authorization: Bearer against Google's tokeninfo endpoint.
   oauthVerifyEnforce?: string;
@@ -143,6 +150,12 @@ export function registerProxyCommand(program: Command): void {
       "--tags <tags>",
       "Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: PROXY_FILTER_BY_TAGS). Non-matching saves are forwarded transparently.",
     )
+    .option(
+      "--routes <table>",
+      "Endpoints to treat as policy-relevant, one per line or comma-separated: " +
+        '"METHOD /path/:id -> action [body=workflow]" (env: N8N_PROXY_ROUTES). ' +
+        "Defaults to workflow create/update/tags/delete/activate.",
+    )
     // Authz options — only meaningful when "authz" is in the server-middleware chain.
     .option("--authz-enforce <level>", "Authz enforcement level: off, warn, error")
     .option("--authz-on-error <mode>", "Behavior when groups API fails: deny, allow")
@@ -167,6 +180,26 @@ export function registerProxyCommand(program: Command): void {
     .option(
       "--authz-workflow-strip-prefix <prefix>",
       "Prefix to strip from each extracted ACL value",
+    )
+    .option(
+      "--authz-acl-source <kind>",
+      "Where to read the ACL from: request (body, legacy) or upstream (stored workflow — required for tag-based ACLs and the only non-forgeable option)",
+    )
+    .option(
+      "--authz-acl-cache-ttl-ms <ms>",
+      "Cache lifetime for stored-ACL lookups (default: 10000)",
+    )
+    .option(
+      "--authz-on-missing-acl <mode>",
+      "What to do when the target declares no ACL (every create included): deny (default) or allow",
+    )
+    .option(
+      "--authz-bootstrap-groups <groups>",
+      "Comma-separated groups allowed to act when the target has no ACL; overrides --authz-on-missing-acl",
+    )
+    .option(
+      "--authz-actions <actions>",
+      "Comma-separated route actions this middleware authorizes (default: all it sees)",
     )
     // oauth-verify — verifies incoming Authorization: Bearer via Google tokeninfo.
     .option(
@@ -228,8 +261,10 @@ export function registerProxyCommand(program: Command): void {
       const middlewares = parseMiddlewareList(opts.serverMiddleware);
       const clientMiddlewares = parseMiddlewareList(opts.clientMiddleware);
       const filterByTags = parseTagFilter(opts.tags ?? process.env.PROXY_FILTER_BY_TAGS);
+      const routes = parseRoutes(opts.routes ?? process.env.N8N_PROXY_ROUTES);
 
       const handle = startProxy({
+        routes,
         listen: opts.listen,
         upstream,
         lintConfigPath: opts.lintConfig,

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -34,13 +34,13 @@ export interface GlobalContext {
 /**
  * Builds the egress middleware chain for the API client from
  * `N8N_CLIENT_MIDDLEWARES`. Empty by default, which keeps the direct-to-n8n
- * path byte-identical to before.
+ * path byte-identical to before — nothing is registered, nothing runs.
  *
- * `iap-auth` inherits the API URL as its audience unless the operator set one:
- * for a Cloud Run gateway the expected `aud` *is* the service URL, and making
- * people repeat it in a second variable only invites the two to drift.
+ * Deliberately knows no middleware by name: each factory reads its own
+ * configuration off the environment, so authentication stays an opt-in
+ * extension rather than something the core request path carries.
  */
-function buildEgressChain(config: Config): ClientMiddleware[] {
+function buildEgressChain(): ClientMiddleware[] {
   const enabled = resolveEnabledList({
     env: process.env,
     envVar: "N8N_CLIENT_MIDDLEWARES",
@@ -49,20 +49,11 @@ function buildEgressChain(config: Config): ClientMiddleware[] {
   if (enabled.length === 0) return [];
 
   registerClientBuiltins();
-  const cliOpts: Record<string, unknown> = {};
-  if (!process.env.N8N_IAP_AUTH_AUDIENCE) {
-    cliOpts.iapAuthAudience = config.apiURL;
-  }
-  return buildClientMiddlewares({ enabled, env: process.env, cliOpts });
+  return buildClientMiddlewares({ enabled, env: process.env });
 }
 
 function createContext(config: Config): GlobalContext {
-  const client = new Client(
-    config.apiURL,
-    config.apiKey,
-    config.timeoutMs,
-    buildEgressChain(config),
-  );
+  const client = new Client(config.apiURL, config.apiKey, config.timeoutMs, buildEgressChain());
   return {
     config,
     client,

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -12,6 +12,13 @@ import {
   loadFromEnv,
   validate,
 } from "../config/config.ts";
+import { buildClientMiddlewares } from "../middleware/client-registry.ts";
+import {
+  DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
+  registerClientBuiltins,
+} from "../middleware/client-wiring.ts";
+import { resolveEnabledList } from "../middleware/registry.ts";
+import type { ClientMiddleware } from "../middleware/types.ts";
 import { runVersion } from "./commands/version.ts";
 
 export interface GlobalContext {
@@ -24,8 +31,38 @@ export interface GlobalContext {
   dataTableService: DataTableService;
 }
 
+/**
+ * Builds the egress middleware chain for the API client from
+ * `N8N_CLIENT_MIDDLEWARES`. Empty by default, which keeps the direct-to-n8n
+ * path byte-identical to before.
+ *
+ * `iap-auth` inherits the API URL as its audience unless the operator set one:
+ * for a Cloud Run gateway the expected `aud` *is* the service URL, and making
+ * people repeat it in a second variable only invites the two to drift.
+ */
+function buildEgressChain(config: Config): ClientMiddleware[] {
+  const enabled = resolveEnabledList({
+    env: process.env,
+    envVar: "N8N_CLIENT_MIDDLEWARES",
+    fallback: DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
+  });
+  if (enabled.length === 0) return [];
+
+  registerClientBuiltins();
+  const cliOpts: Record<string, unknown> = {};
+  if (!process.env.N8N_IAP_AUTH_AUDIENCE) {
+    cliOpts.iapAuthAudience = config.apiURL;
+  }
+  return buildClientMiddlewares({ enabled, env: process.env, cliOpts });
+}
+
 function createContext(config: Config): GlobalContext {
-  const client = new Client(config.apiURL, config.apiKey, config.timeoutMs);
+  const client = new Client(
+    config.apiURL,
+    config.apiKey,
+    config.timeoutMs,
+    buildEgressChain(config),
+  );
   return {
     config,
     client,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -55,8 +55,16 @@ export function loadFromEnv(config: Config): Config {
   return config;
 }
 
-/** Validates the configuration. Throws ConfigError if invalid. */
-export function validate(config: Config): void {
+/**
+ * Validates the configuration. Throws ConfigError if invalid.
+ *
+ * The API key requirement is waived when an egress middleware chain is
+ * configured (`N8N_CLIENT_MIDDLEWARES`): a gateway that terminates
+ * authentication holds the n8n key itself and injects it upstream, so the
+ * caller has none. Demanding one anyway would push operators to park a
+ * placeholder — or worse, the real shared key — in every developer's shell.
+ */
+export function validate(config: Config, env: NodeJS.ProcessEnv = process.env): void {
   if (!config.apiURL) {
     throw new ConfigError(
       "api-url",
@@ -64,11 +72,13 @@ export function validate(config: Config): void {
       "Set N8N_API_URL environment variable or use --api-url flag",
     );
   }
-  if (!config.apiKey) {
+  const hasEgressChain = (env.N8N_CLIENT_MIDDLEWARES ?? "").trim().length > 0;
+  if (!config.apiKey && !hasEgressChain) {
     throw new ConfigError(
       "api-key",
       "API key is required",
-      "Set N8N_API_KEY environment variable or use --api-key flag",
+      "Set N8N_API_KEY environment variable or use --api-key flag " +
+        "(not needed when N8N_CLIENT_MIDDLEWARES supplies credentials)",
     );
   }
 }

--- a/src/middleware/builtin/authz/factory.ts
+++ b/src/middleware/builtin/authz/factory.ts
@@ -21,8 +21,20 @@ const identitySchema = z.object({
 // them avoids silently assuming a particular tag convention or API schema.
 // Same for `stripPrefix` — it's a string transform that depends on the
 // organization's tag naming scheme.
+const groupsAuthSchema = z.object({
+  kind: z
+    .union([z.literal("none"), z.literal("bearer-env"), z.literal("gcp-id-token")])
+    .default("none"),
+  tokenEnvVar: z.string().optional(),
+  audience: z.string().optional(),
+  tokenSource: z.union([z.literal("metadata"), z.literal("adc-impersonate")]).optional(),
+  impersonateServiceAccount: z.string().optional(),
+});
+
 const groupsSchema = z.object({
   url: z.string({ message: "authz: groups.url is required" }).url(),
+  /** Outgoing auth. Omitted means header-only, i.e. the previous behaviour. */
+  auth: groupsAuthSchema.optional(),
   method: z.string().default("POST"),
   headers: z.record(z.string(), z.string()).default({}),
   body: z.string().optional(),
@@ -58,7 +70,22 @@ const optionsSchema = z.object({
   identity: identitySchema.default({ source: "none", decode: "raw" }),
   groups: groupsSchema,
   workflow: workflowSchema,
+  // Default "request" keeps existing deployments behaving as before; "upstream"
+  // is what makes the ACL non-forgeable (and what an ACL kept in tags needs).
+  aclSource: z.union([z.literal("request"), z.literal("upstream")]).default("request"),
+  aclCacheTtlMs: z.number().int().min(0).default(10_000),
+  onMissingAcl: z.union([z.literal("deny"), z.literal("allow")]).default("deny"),
+  bootstrapGroups: z.array(z.string()).default([]),
+  actions: z.array(z.string()).default([]),
 });
+
+/** Comma-separated list → trimmed, non-empty entries. */
+function splitList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 /**
  * Pulls Authz config off the env. Splits the config into namespaced bags
@@ -92,6 +119,18 @@ function fromEnv(env: NodeJS.ProcessEnv): Partial<AuthzOptions> {
       // than swallowing here — users get one clear error at build time.
     }
   }
+  const groupsAuth: Record<string, string> = {};
+  if (env.N8N_AUTHZ_GROUPS_AUTH_KIND) groupsAuth.kind = env.N8N_AUTHZ_GROUPS_AUTH_KIND;
+  if (env.N8N_AUTHZ_GROUPS_AUTH_TOKEN_ENV_VAR)
+    groupsAuth.tokenEnvVar = env.N8N_AUTHZ_GROUPS_AUTH_TOKEN_ENV_VAR;
+  if (env.N8N_AUTHZ_GROUPS_AUTH_AUDIENCE) groupsAuth.audience = env.N8N_AUTHZ_GROUPS_AUTH_AUDIENCE;
+  if (env.N8N_AUTHZ_GROUPS_AUTH_TOKEN_SOURCE)
+    groupsAuth.tokenSource = env.N8N_AUTHZ_GROUPS_AUTH_TOKEN_SOURCE;
+  if (env.N8N_AUTHZ_GROUPS_AUTH_IMPERSONATE_SERVICE_ACCOUNT)
+    groupsAuth.impersonateServiceAccount = env.N8N_AUTHZ_GROUPS_AUTH_IMPERSONATE_SERVICE_ACCOUNT;
+  if (Object.keys(groupsAuth).length > 0) {
+    groups.auth = groupsAuth as unknown as GroupsRequestSpec["auth"];
+  }
   if (env.N8N_AUTHZ_GROUPS_BODY) groups.body = env.N8N_AUTHZ_GROUPS_BODY;
   if (env.N8N_AUTHZ_GROUPS_EXTRACT) groups.extract = env.N8N_AUTHZ_GROUPS_EXTRACT;
   if (env.N8N_AUTHZ_GROUPS_CACHE_TTL_MS)
@@ -99,6 +138,19 @@ function fromEnv(env: NodeJS.ProcessEnv): Partial<AuthzOptions> {
   if (env.N8N_AUTHZ_GROUPS_TIMEOUT_MS)
     groups.timeoutMs = Number.parseInt(env.N8N_AUTHZ_GROUPS_TIMEOUT_MS, 10);
   if (Object.keys(groups).length > 0) opts.groups = groups as GroupsRequestSpec;
+
+  if (env.N8N_AUTHZ_ACL_SOURCE) {
+    opts.aclSource = env.N8N_AUTHZ_ACL_SOURCE as AuthzOptions["aclSource"];
+  }
+  if (env.N8N_AUTHZ_ACL_CACHE_TTL_MS) {
+    opts.aclCacheTtlMs = Number.parseInt(env.N8N_AUTHZ_ACL_CACHE_TTL_MS, 10);
+  }
+  if (env.N8N_AUTHZ_ON_MISSING_ACL) {
+    opts.onMissingAcl = env.N8N_AUTHZ_ON_MISSING_ACL as AuthzOptions["onMissingAcl"];
+  }
+  if (env.N8N_AUTHZ_BOOTSTRAP_GROUPS)
+    opts.bootstrapGroups = splitList(env.N8N_AUTHZ_BOOTSTRAP_GROUPS);
+  if (env.N8N_AUTHZ_ACTIONS) opts.actions = splitList(env.N8N_AUTHZ_ACTIONS);
 
   const workflow: Partial<WorkflowACLSpec> = {};
   if (env.N8N_AUTHZ_WORKFLOW_EXTRACT) workflow.extract = env.N8N_AUTHZ_WORKFLOW_EXTRACT;
@@ -159,6 +211,16 @@ function fromCLI(opts: Record<string, unknown>): Partial<AuthzOptions> {
     workflow.stripPrefix = opts.authzWorkflowStripPrefix as string;
   }
   if (Object.keys(workflow).length > 0) out.workflow = workflow as WorkflowACLSpec;
+
+  if (s("authzAclSource")) out.aclSource = s("authzAclSource") as AuthzOptions["aclSource"];
+  const aclTtl = n("authzAclCacheTtlMs");
+  if (aclTtl !== undefined) out.aclCacheTtlMs = aclTtl;
+  if (s("authzOnMissingAcl")) {
+    out.onMissingAcl = s("authzOnMissingAcl") as AuthzOptions["onMissingAcl"];
+  }
+  if (s("authzBootstrapGroups"))
+    out.bootstrapGroups = splitList(s("authzBootstrapGroups") as string);
+  if (s("authzActions")) out.actions = splitList(s("authzActions") as string);
 
   return out;
 }

--- a/src/middleware/builtin/authz/groups-auth.ts
+++ b/src/middleware/builtin/authz/groups-auth.ts
@@ -1,0 +1,68 @@
+import { AdcImpersonateTokenSource } from "@/middleware/builtin/iap-auth/adc-impersonate-source.ts";
+import {
+  EnvTokenSource,
+  MetadataServerTokenSource,
+  type TokenSource,
+} from "@/middleware/builtin/iap-auth/token-source.ts";
+import type { GroupsAuthSpec } from "./types.ts";
+
+/**
+ * Turns a `GroupsAuthSpec` into a function that stamps credentials onto the
+ * outgoing groups request.
+ *
+ * The token sources are the ones `iap-auth` already uses, so a groups API
+ * behind an identity-aware proxy needs no new machinery — and both directions
+ * share one vocabulary for "where do id_tokens come from".
+ */
+export type GroupsAuthenticator = (headers: Record<string, string>) => Promise<void>;
+
+export function buildGroupsAuthenticator(
+  spec: GroupsAuthSpec | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): GroupsAuthenticator | undefined {
+  if (!spec || spec.kind === "none") return undefined;
+
+  if (spec.kind === "bearer-env") {
+    if (!spec.tokenEnvVar) {
+      throw new Error("authz: groups.auth.kind=bearer-env requires groups.auth.tokenEnvVar");
+    }
+    const varName = spec.tokenEnvVar;
+    return async (headers) => {
+      const token = env[varName];
+      if (!token) {
+        throw new Error(`authz: groups auth env var ${varName} is not set or empty`);
+      }
+      headers.authorization = `Bearer ${token}`;
+    };
+  }
+
+  // gcp-id-token
+  if (!spec.audience) {
+    throw new Error(
+      "authz: groups.auth.kind=gcp-id-token requires groups.auth.audience " +
+        "(the aud the groups endpoint's gateway expects)",
+    );
+  }
+  const audience = spec.audience;
+  const source: TokenSource =
+    spec.tokenSource === "adc-impersonate"
+      ? buildAdcSource(spec)
+      : new MetadataServerTokenSource({
+          impersonateServiceAccount: spec.impersonateServiceAccount,
+        });
+  return async (headers) => {
+    headers.authorization = `Bearer ${await source.getToken(audience)}`;
+  };
+}
+
+function buildAdcSource(spec: GroupsAuthSpec): TokenSource {
+  if (!spec.impersonateServiceAccount) {
+    throw new Error(
+      "authz: groups.auth.tokenSource=adc-impersonate requires groups.auth.impersonateServiceAccount",
+    );
+  }
+  return new AdcImpersonateTokenSource(spec.impersonateServiceAccount);
+}
+
+/** Re-exported so tests can inject a trivial source without touching the network. */
+export { EnvTokenSource };

--- a/src/middleware/builtin/authz/groups-resolver.ts
+++ b/src/middleware/builtin/authz/groups-resolver.ts
@@ -1,5 +1,6 @@
 import { type CompiledJSONPath, compileJSONPath } from "@/middleware/jsonpath.ts";
 import { expandRecord, expandTemplate } from "@/middleware/template.ts";
+import { buildGroupsAuthenticator, type GroupsAuthenticator } from "./groups-auth.ts";
 import type { GroupsRequestSpec } from "./types.ts";
 
 /**
@@ -12,6 +13,8 @@ export interface GroupsResolverDeps {
   fetch?: FetchLike;
   env?: NodeJS.ProcessEnv;
   now?: () => number;
+  /** Overrides the authenticator built from `spec.auth` (tests). */
+  authenticate?: GroupsAuthenticator;
 }
 
 interface CacheEntry {
@@ -36,6 +39,7 @@ export class GroupsResolver {
   private readonly fetchImpl: FetchLike;
   private readonly env: NodeJS.ProcessEnv;
   private readonly now: () => number;
+  private readonly authenticate?: GroupsAuthenticator;
 
   constructor(
     private readonly spec: GroupsRequestSpec,
@@ -45,6 +49,9 @@ export class GroupsResolver {
     this.fetchImpl = deps.fetch ?? ((input, init) => fetch(input, init));
     this.env = deps.env ?? process.env;
     this.now = deps.now ?? (() => Date.now());
+    // Built once: a misconfigured auth spec should fail at startup, not on the
+    // first authorization decision.
+    this.authenticate = deps.authenticate ?? buildGroupsAuthenticator(spec.auth, this.env);
   }
 
   async resolve(identity: string): Promise<string[]> {
@@ -58,6 +65,8 @@ export class GroupsResolver {
     const headers = expandRecord(this.spec.headers, bindings);
     const body =
       this.spec.body !== undefined ? expandTemplate(this.spec.body, bindings) : undefined;
+
+    if (this.authenticate) await this.authenticate(headers);
 
     const init: RequestInit = { method: this.spec.method, headers };
     if (body !== undefined && this.spec.method !== "GET" && this.spec.method !== "HEAD") {

--- a/src/middleware/builtin/authz/middleware.ts
+++ b/src/middleware/builtin/authz/middleware.ts
@@ -26,6 +26,12 @@ export class AuthzMiddleware implements ServerMiddleware {
   readonly name = "authz";
   private readonly resolver: GroupsResolver;
   private readonly acl: WorkflowACLExtractor;
+  /**
+   * Stored-ACL cache. Deliberately short-lived (`aclCacheTtlMs`): a cached ACL
+   * is a cached permission, so this only exists to keep a multi-workflow apply
+   * from re-reading the same workflow once per request.
+   */
+  private readonly aclCache = new Map<string, { acl: string[]; expiresAt: number }>();
 
   constructor(
     private readonly options: AuthzOptions,
@@ -40,11 +46,16 @@ export class AuthzMiddleware implements ServerMiddleware {
       return { block: false, violations: [] };
     }
 
+    // Action scoping: when the operator named actions, stay out of the way on
+    // every other route so something else (or nothing) governs those.
+    const scoped = this.options.actions ?? [];
+    if (scoped.length > 0 && ctx.action && !scoped.includes(ctx.action)) {
+      return { block: false, violations: [] };
+    }
+
     const identity =
       ctx.identity ??
       resolveIdentity(this.options.identity, { request: ctx.request, env: process.env });
-
-    const allowed = this.acl.extract(ctx.workflow);
 
     if (!identity) {
       return this.dispatchDenial(
@@ -52,11 +63,42 @@ export class AuthzMiddleware implements ServerMiddleware {
         "Actor identity could not be resolved (header/env not present or claim missing)",
       );
     }
+
+    let allowed: string[];
+    try {
+      allowed = await this.resolveAcl(ctx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.options.onError === "allow") {
+        return {
+          block: false,
+          violations: [
+            {
+              rule: "authz-acl-warning",
+              severity: "warning",
+              message: `ACL lookup failed (fail-open): ${message}`,
+            },
+          ],
+        };
+      }
+      return this.dispatchDenial("authz-acl-error", `ACL lookup failed: ${message}`);
+    }
+
+    // Nothing to check against: every `create` lands here, and so does a
+    // workflow nobody has labelled yet. `bootstrapGroups` decides by membership
+    // when set; otherwise the blanket answer applies.
     if (allowed.length === 0) {
-      return this.dispatchDenial(
-        "authz-no-acl",
-        "Workflow does not declare any allowed groups — refusing to allow edits via the gate",
-      );
+      const bootstrap = this.options.bootstrapGroups ?? [];
+      if (bootstrap.length === 0) {
+        if ((this.options.onMissingAcl ?? "deny") === "allow") {
+          return { block: false, violations: [] };
+        }
+        return this.dispatchDenial(
+          "authz-no-acl",
+          "Workflow does not declare any allowed groups — refusing to allow edits via the gate",
+        );
+      }
+      allowed = bootstrap;
     }
 
     let groups: string[];
@@ -89,6 +131,39 @@ export class AuthzMiddleware implements ServerMiddleware {
       "authz-denied",
       `Identity "${identity}" is not in any of the workflow's allowed groups (${allowed.join(", ")})`,
     );
+  }
+
+  /**
+   * Reads the ACL the decision is made against.
+   *
+   * With `aclSource: "upstream"` this is the *stored* workflow, never the
+   * payload: an ACL the caller can rewrite in the same request grants nothing.
+   * It is also the only source that works for an ACL kept in n8n tags, since
+   * tags are assigned through a separate endpoint and never appear in a
+   * workflow write body.
+   *
+   * A `create` has no stored state; it returns empty and the caller's
+   * missing-ACL policy takes over.
+   */
+  private async resolveAcl(ctx: ServerMiddlewareContext): Promise<string[]> {
+    if ((this.options.aclSource ?? "request") === "request") {
+      return this.acl.extract(ctx.workflow);
+    }
+    const id = ctx.workflowId;
+    if (!id) return [];
+    if (!ctx.fetchStoredWorkflow) {
+      throw new Error(
+        "aclSource=upstream needs a stored-workflow reader, which this host did not provide",
+      );
+    }
+    const ttl = this.options.aclCacheTtlMs ?? 10_000;
+    const cached = this.aclCache.get(id);
+    if (cached && cached.expiresAt > Date.now()) return cached.acl;
+
+    const stored = await ctx.fetchStoredWorkflow(id);
+    const acl = this.acl.extract(stored);
+    if (ttl > 0) this.aclCache.set(id, { acl, expiresAt: Date.now() + ttl });
+    return acl;
   }
 
   private dispatchDenial(rule: string, message: string): MiddlewareVerdict {

--- a/src/middleware/builtin/authz/types.ts
+++ b/src/middleware/builtin/authz/types.ts
@@ -1,6 +1,26 @@
 import type { IdentitySpec } from "@/middleware/identity.ts";
 
 /**
+ * How to authenticate the outgoing groups request.
+ *
+ * A groups API worth trusting is rarely open: it sits behind an identity-aware
+ * proxy, or wants a bearer token. Static headers cannot express that when the
+ * credential is a short-lived id_token, so the source is pluggable. `none`
+ * keeps the header-only behaviour.
+ */
+export interface GroupsAuthSpec {
+  kind: "none" | "bearer-env" | "gcp-id-token";
+  /** bearer-env: env var holding the token. */
+  tokenEnvVar?: string;
+  /** gcp-id-token: `aud` of the minted token. */
+  audience?: string;
+  /** gcp-id-token: where the token comes from. */
+  tokenSource?: "metadata" | "adc-impersonate";
+  /** gcp-id-token: service account to mint as (required by adc-impersonate). */
+  impersonateServiceAccount?: string;
+}
+
+/**
  * Configuration for fetching the actor's group memberships from an HTTP
  * service. Every field is user-supplied so the middleware has no built-in
  * knowledge of any specific groups API.
@@ -8,6 +28,8 @@ import type { IdentitySpec } from "@/middleware/identity.ts";
 export interface GroupsRequestSpec {
   url: string;
   method: string;
+  /** Outgoing authentication. Defaults to `{ kind: "none" }`. */
+  auth?: GroupsAuthSpec;
   /**
    * Header map. Values support `${env:VAR}` for secret injection.
    */
@@ -59,10 +81,48 @@ export type AuthzEnforce = "off" | "warn" | "error";
  */
 export type AuthzOnError = "deny" | "allow";
 
+/**
+ * Where the ACL is read from.
+ *
+ * `upstream` is the meaningful setting: it reads the *stored* workflow, so a
+ * caller cannot grant themselves access by putting their own group in the body
+ * of the very request being authorized. It is also the only workable setting
+ * for an ACL kept in n8n tags — tags are assigned through a separate endpoint,
+ * so they are simply absent from a workflow write payload.
+ *
+ * `request` keeps the original behaviour for deployments whose ACL genuinely
+ * travels in the body and who only want a guardrail against accidents.
+ */
+export type AclSource = "request" | "upstream";
+
+/** What to do when the target has no ACL to check against. */
+export type OnMissingAcl = "deny" | "allow";
+
 export interface AuthzOptions {
   enforce: AuthzEnforce;
   onError: AuthzOnError;
   identity: IdentitySpec;
   groups: GroupsRequestSpec;
   workflow: WorkflowACLSpec;
+  /** Defaults to `request` so existing configurations behave as before. */
+  aclSource?: AclSource;
+  /** Cache lifetime for stored-workflow lookups. Short by design: a stale ACL is a stale permission. */
+  aclCacheTtlMs?: number;
+  /**
+   * Applied when the target declares no ACL — including every `create`, which
+   * has no stored state yet. `deny` refuses; `allow` lets it through.
+   */
+  onMissingAcl?: OnMissingAcl;
+  /**
+   * Groups permitted to act when the target has no ACL. Non-empty overrides
+   * `onMissingAcl`: membership decides instead of a blanket answer, which is
+   * what makes "anyone on the team may create, but only owners may edit"
+   * expressible.
+   */
+  bootstrapGroups?: string[];
+  /**
+   * Actions this middleware authorizes. Empty means every action reaching it.
+   * Names come from the proxy's route table.
+   */
+  actions?: string[];
 }

--- a/src/middleware/builtin/iap-auth/adc-impersonate-source.ts
+++ b/src/middleware/builtin/iap-auth/adc-impersonate-source.ts
@@ -1,0 +1,204 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { FetchLike, TokenSource } from "./token-source.ts";
+
+/**
+ * `TokenSource` that mints an id_token **as a target service account**, using
+ * the local Application Default Credentials as the caller.
+ *
+ * Why this exists: `MetadataServerTokenSource` covers workloads (Cloud Run,
+ * GCE, GKE) because it reads the caller's access_token off the metadata
+ * server. A developer laptop has no metadata server, so a CLI running there
+ * cannot mint the id_token its gateway expects — leaving the operator to run
+ * `gcloud auth print-identity-token --impersonate-service-account=...` by hand
+ * every hour and paste the result into an env var. This source closes that gap:
+ * read ADC from disk, exchange the refresh_token for an access_token, then ask
+ * the IAM Credentials API to mint an id_token as the target SA.
+ *
+ * Requires `roles/iam.serviceAccountTokenCreator` on the target SA for the ADC
+ * principal — the same grant `gcloud --impersonate-service-account` needs.
+ *
+ * Only user credentials (`authorized_user`, i.e. the output of
+ * `gcloud auth application-default login`) are supported as the caller.
+ * Service-account key files are rejected with an explicit error rather than
+ * silently doing something surprising: a workload that has a key file can use
+ * the metadata source, and keyless is the direction we want anyway.
+ */
+
+const DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const DEFAULT_IAM_CREDENTIALS_BASE = "https://iamcredentials.googleapis.com/v1";
+/** GCP id_tokens live ~1h; 50 min leaves headroom for skew and in-flight calls. */
+const DEFAULT_CACHE_TTL_MS = 50 * 60 * 1000;
+
+interface AdcUserCredentials {
+  type?: string;
+  client_id?: string;
+  client_secret?: string;
+  refresh_token?: string;
+}
+
+interface CacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+export interface AdcImpersonateTokenSourceDeps {
+  fetcher?: FetchLike;
+  now?: () => number;
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+  /** Explicit ADC path (testing / non-default install). */
+  credentialsPath?: string;
+  /** Injected credentials reader for tests. */
+  readCredentials?: () => Promise<AdcUserCredentials>;
+  tokenEndpoint?: string;
+  iamCredentialsBaseUrl?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function defaultAdcPath(env: NodeJS.ProcessEnv): string {
+  const explicit = env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (explicit) return explicit;
+  if (process.platform === "win32") {
+    const appdata = env.APPDATA;
+    if (appdata) return join(appdata, "gcloud", "application_default_credentials.json");
+  }
+  return join(homedir(), ".config", "gcloud", "application_default_credentials.json");
+}
+
+export class AdcImpersonateTokenSource implements TokenSource {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inflight = new Map<string, Promise<string>>();
+  private readonly fetcher: FetchLike;
+  private readonly now: () => number;
+  private readonly cacheTtlMs: number;
+  private readonly timeoutMs: number;
+  private readonly credentialsPath: string;
+  private readonly tokenEndpoint: string;
+  private readonly iamCredentialsBaseUrl: string;
+  private readonly readCredentialsImpl?: () => Promise<AdcUserCredentials>;
+  private cachedCreds?: AdcUserCredentials;
+
+  constructor(
+    private readonly targetServiceAccount: string,
+    deps: AdcImpersonateTokenSourceDeps = {},
+  ) {
+    const env = deps.env ?? process.env;
+    this.fetcher = deps.fetcher ?? ((url, init) => fetch(url, init));
+    this.now = deps.now ?? (() => Date.now());
+    this.cacheTtlMs = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.timeoutMs = deps.timeoutMs ?? 10_000;
+    this.credentialsPath = deps.credentialsPath ?? defaultAdcPath(env);
+    this.tokenEndpoint = deps.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
+    this.iamCredentialsBaseUrl = deps.iamCredentialsBaseUrl ?? DEFAULT_IAM_CREDENTIALS_BASE;
+    this.readCredentialsImpl = deps.readCredentials;
+  }
+
+  async getToken(audience: string): Promise<string> {
+    const cached = this.cache.get(audience);
+    if (cached && cached.expiresAt > this.now()) return cached.token;
+    const pending = this.inflight.get(audience);
+    if (pending) return pending;
+    const p = this.mint(audience).finally(() => this.inflight.delete(audience));
+    this.inflight.set(audience, p);
+    return p;
+  }
+
+  private async readCredentials(): Promise<AdcUserCredentials> {
+    if (this.cachedCreds) return this.cachedCreds;
+    let raw: AdcUserCredentials;
+    try {
+      raw = this.readCredentialsImpl
+        ? await this.readCredentialsImpl()
+        : (JSON.parse(await readFile(this.credentialsPath, "utf8")) as AdcUserCredentials);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `iap-auth: could not read Application Default Credentials (${this.credentialsPath}): ${message}. ` +
+          "Run `gcloud auth application-default login`.",
+      );
+    }
+    if (raw.type && raw.type !== "authorized_user") {
+      throw new Error(
+        `iap-auth: tokenSourceKind=adc-impersonate expects user credentials (type "authorized_user"), got "${raw.type}". ` +
+          "Use tokenSourceKind=metadata for workload identities.",
+      );
+    }
+    if (!raw.refresh_token || !raw.client_id || !raw.client_secret) {
+      throw new Error(
+        "iap-auth: ADC file is missing refresh_token/client_id/client_secret. " +
+          "Run `gcloud auth application-default login`.",
+      );
+    }
+    // Only cache a usable file, so a first-time ENOENT doesn't poison later calls.
+    this.cachedCreds = raw;
+    return raw;
+  }
+
+  /** Exchanges the ADC refresh_token for an access_token (the caller credential). */
+  private async fetchCallerAccessToken(): Promise<string> {
+    const creds = await this.readCredentials();
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: creds.refresh_token as string,
+      client_id: creds.client_id as string,
+      client_secret: creds.client_secret as string,
+    });
+    const res = await this.callWithTimeout(this.tokenEndpoint, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `iap-auth: ADC refresh_token grant returned HTTP ${res.status}: ${text.slice(0, 200)}`,
+      );
+    }
+    const parsed = (await res.json()) as { access_token?: string };
+    if (!parsed.access_token) {
+      throw new Error("iap-auth: ADC token endpoint returned no access_token");
+    }
+    return parsed.access_token;
+  }
+
+  private async mint(audience: string): Promise<string> {
+    const accessToken = await this.fetchCallerAccessToken();
+    const url = `${this.iamCredentialsBaseUrl}/projects/-/serviceAccounts/${encodeURIComponent(
+      this.targetServiceAccount,
+    )}:generateIdToken`;
+    const res = await this.callWithTimeout(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      // includeEmail so the receiver can pin the principal (oauth-verify's
+      // trusted-principals check reads the email claim).
+      body: JSON.stringify({ audience, includeEmail: true }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `iap-auth: iamcredentials.generateIdToken for ${this.targetServiceAccount} returned HTTP ${res.status}: ${text.slice(0, 200)}. ` +
+          "Check that you hold roles/iam.serviceAccountTokenCreator on that service account.",
+      );
+    }
+    const parsed = (await res.json()) as { token?: string };
+    if (!parsed.token) {
+      throw new Error(
+        `iap-auth: iamcredentials.generateIdToken for ${this.targetServiceAccount} returned no token`,
+      );
+    }
+    this.cache.set(audience, { token: parsed.token, expiresAt: this.now() + this.cacheTtlMs });
+    return parsed.token;
+  }
+
+  private async callWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetcher(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/middleware/builtin/iap-auth/factory.ts
+++ b/src/middleware/builtin/iap-auth/factory.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { AdcImpersonateTokenSource } from "./adc-impersonate-source.ts";
 import { IapAuthMiddleware } from "./middleware.ts";
 import {
   EnvTokenSource,
@@ -19,11 +20,18 @@ const optionsSchema = z.object({
     .min(1, { message: "iap-auth: audience must not be empty" }),
   /**
    * Where to get the id_token from. Defaults to "metadata" (GCE metadata
-   * server) — the production path. "env" reads a pre-minted token from an
-   * env var for local development. "static" is reserved for tests.
+   * server) — the production path for workloads. "adc-impersonate" mints the
+   * token as `impersonateServiceAccount` using local Application Default
+   * Credentials, which is what a developer laptop (no metadata server) needs.
+   * "env" reads a pre-minted token from an env var. "static" is for tests.
    */
   tokenSourceKind: z
-    .union([z.literal("metadata"), z.literal("env"), z.literal("static")])
+    .union([
+      z.literal("metadata"),
+      z.literal("adc-impersonate"),
+      z.literal("env"),
+      z.literal("static"),
+    ])
     .default("metadata"),
   /** Env var name when tokenSourceKind=env. */
   tokenEnvVar: z.string().optional(),
@@ -70,6 +78,21 @@ function buildTokenSource(opts: IapAuthRawOptions): TokenSource {
         throw new Error("iap-auth: tokenSourceKind=env requires tokenEnvVar");
       }
       return new EnvTokenSource(opts.tokenEnvVar);
+    }
+    case "adc-impersonate": {
+      if (!opts.impersonateServiceAccount) {
+        throw new Error(
+          "iap-auth: tokenSourceKind=adc-impersonate requires impersonateServiceAccount " +
+            "(the service account whose identity the gateway expects)",
+        );
+      }
+      return new AdcImpersonateTokenSource(opts.impersonateServiceAccount, {
+        cacheTtlMs: opts.cacheTtlMs,
+        // ADC + IAM Credentials are remote calls, unlike the local metadata
+        // server, so the metadata-tuned default timeout is too tight here.
+        timeoutMs: Math.max(opts.timeoutMs, 10_000),
+        iamCredentialsBaseUrl: opts.iamCredentialsBaseUrl,
+      });
     }
     case "metadata":
       return new MetadataServerTokenSource({

--- a/src/middleware/builtin/iap-auth/factory.ts
+++ b/src/middleware/builtin/iap-auth/factory.ts
@@ -107,7 +107,14 @@ function buildTokenSource(opts: IapAuthRawOptions): TokenSource {
 
 function fromEnv(env: NodeJS.ProcessEnv): Partial<IapAuthRawOptions> {
   const out: Partial<IapAuthRawOptions> = {};
-  if (env.N8N_IAP_AUTH_AUDIENCE) out.audience = env.N8N_IAP_AUTH_AUDIENCE;
+  // Falling back to the API URL keeps the common case to one variable: when the
+  // gateway is a Cloud Run service, the `aud` it expects *is* its URL, and two
+  // variables holding the same value only drift apart. The fallback lives here
+  // rather than in the CLI wiring so nothing outside this middleware needs to
+  // know that `iap-auth` has an audience at all.
+  if (env.N8N_IAP_AUTH_AUDIENCE || env.N8N_API_URL) {
+    out.audience = env.N8N_IAP_AUTH_AUDIENCE ?? env.N8N_API_URL;
+  }
   if (env.N8N_IAP_AUTH_TOKEN_SOURCE) {
     out.tokenSourceKind = env.N8N_IAP_AUTH_TOKEN_SOURCE as IapAuthRawOptions["tokenSourceKind"];
   }

--- a/src/middleware/builtin/impersonator-token/adc-user-token-source.ts
+++ b/src/middleware/builtin/impersonator-token/adc-user-token-source.ts
@@ -96,6 +96,23 @@ export class AdcUserTokenSource implements UserTokenSource {
     this.readCredentialsImpl = deps.readCredentials;
   }
 
+  /**
+   * The ADC file names its own OAuth client, and that client is the only `aud`
+   * Google will mint a token for through this grant (a foreign-project
+   * audience fails with `invalid_audience`). So when the operator leaves the
+   * audience unset, read it off the credentials instead of guessing a
+   * well-known constant.
+   */
+  async defaultAudience(): Promise<string | undefined> {
+    try {
+      const creds = await this.readCredentials();
+      return creds.client_id;
+    } catch {
+      // Let getToken() surface the real credential error with its own message.
+      return undefined;
+    }
+  }
+
   async getToken(audience: string): Promise<string> {
     const cached = this.cache.get(audience);
     if (cached && cached.expiresAt > this.now()) return cached.token;

--- a/src/middleware/builtin/impersonator-token/factory.ts
+++ b/src/middleware/builtin/impersonator-token/factory.ts
@@ -13,15 +13,14 @@ const DEFAULT_HEADER_NAME = "X-Impersonator-Id-Token";
 
 const optionsSchema = z.object({
   /**
-   * `aud` for the minted id_token. Required — every issuer has a
-   * different audience convention (an OAuth client id, a resource URI,
-   * an OIDC RP identifier). Set this to whatever value the server-side
-   * `impersonator-verify` expects.
+   * `aud` for the minted id_token. Optional: when omitted the selected token
+   * source names its own audience (`tokenSourceKind=adc` reads `client_id` out
+   * of the credentials file, which is the only aud that grant can produce).
+   * Set it explicitly only when the server expects something else — every
+   * issuer has its own convention (an OAuth client id, a resource URI, an
+   * OIDC RP identifier).
    */
-  audience: z.string().min(1, {
-    message:
-      "impersonator-token: `audience` is required. Set it to the aud claim your server expects on impersonator tokens.",
-  }),
+  audience: z.string().default(""),
   tokenSourceKind: z
     .union([z.literal("adc"), z.literal("env"), z.literal("static")])
     .default("env"),

--- a/src/middleware/builtin/impersonator-token/middleware.ts
+++ b/src/middleware/builtin/impersonator-token/middleware.ts
@@ -3,11 +3,14 @@ import type { UserTokenSource } from "./user-token-source.ts";
 
 export interface ImpersonatorTokenOptions {
   /**
-   * `aud` for the minted id_token. Almost always the gcloud ADC OAuth
-   * client_id (`764086051850-...`) because that's what user
-   * `application-default login` credentials produce via the
-   * refresh-token grant. Configurable so operators aren't hard-coded to
-   * one Google-managed constant.
+   * `aud` for the minted id_token — the OAuth client that issued the
+   * credentials, since the refresh-token grant will not mint a token for a
+   * client in another project.
+   *
+   * Leave empty to let the token source name its own audience (see
+   * `UserTokenSource.defaultAudience`). That is the safer default: a
+   * hard-coded constant that doesn't match the credentials actually in use
+   * fails at the far end, where the error says only "verification failed".
    */
   audience: string;
   /**
@@ -51,7 +54,7 @@ export class ImpersonatorTokenMiddleware implements ClientMiddleware {
 
   async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
     try {
-      const token = await this.options.tokenSource.getToken(this.options.audience);
+      const token = await this.options.tokenSource.getToken(await this.resolveAudience());
       if (!token) return;
       headers.set(this.options.headerName, token);
     } catch (err) {
@@ -59,5 +62,16 @@ export class ImpersonatorTokenMiddleware implements ClientMiddleware {
       // skip: leave the header off — server treats the request as
       // SA-only. Callers that require the header should set onError=throw.
     }
+  }
+
+  /** Configured audience, else whatever the token source derives from its credentials. */
+  private async resolveAudience(): Promise<string> {
+    if (this.options.audience) return this.options.audience;
+    const derived = await this.options.tokenSource.defaultAudience?.();
+    if (derived) return derived;
+    throw new Error(
+      "impersonator-token: no audience configured and the token source could not derive one. " +
+        "Set N8N_IMPERSONATOR_TOKEN_AUDIENCE (or --impersonator-token-audience).",
+    );
   }
 }

--- a/src/middleware/builtin/impersonator-token/user-token-source.ts
+++ b/src/middleware/builtin/impersonator-token/user-token-source.ts
@@ -11,6 +11,20 @@
 export interface UserTokenSource {
   /** Returns a possibly-cached id_token whose `aud` claim equals `audience`. */
   getToken(audience: string): Promise<string>;
+  /**
+   * Audience to use when the operator didn't configure one, if the source can
+   * derive it from its own credentials.
+   *
+   * This matters because the `aud` of a token minted through the refresh-token
+   * grant is not a free choice: Google only issues one for a client in the
+   * same project as the credentials. Making the source name its own audience
+   * removes a whole failure class where a configured constant silently doesn't
+   * match the credentials in use (the request is then rejected downstream, or
+   * the grant fails outright with `invalid_audience`).
+   *
+   * Return undefined when the source has no opinion.
+   */
+  defaultAudience?(): Promise<string | undefined>;
 }
 
 /** Static token — used by tests and pre-minted-token setups. */

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -176,8 +176,12 @@ export interface ServerMiddlewareFactory<O> {
  * (already hop-by-hop stripped) Headers instance for the upstream fetch.
  */
 export interface ClientMiddlewareContext {
-  /** The original incoming Request from the proxy client. */
-  request: Request;
+  /**
+   * The incoming Request being relayed, in proxy mode. Absent when the caller
+   * originates the request itself (the CLI's own API client) — there is no
+   * inbound request to expose in that case.
+   */
+  request?: Request;
   /** HTTP method that will be sent upstream. */
   method: string;
   /** Pathname (and query) of the upstream URL — useful for scope decisions. */

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -76,6 +76,21 @@ export interface ServerMiddlewareContext {
   auth?: AuthContext;
   /** Which call site is running the pipeline. */
   mode: PipelineMode;
+  /**
+   * What the caller is trying to do, from the proxy's route table ("create",
+   * "update", "tags", "delete", "activate", or an operator-defined name).
+   * Undefined in apply mode, where the only operation is a definition write.
+   */
+  action?: string;
+  /** Target workflow id, when the operation names one (everything but create). */
+  workflowId?: string;
+  /**
+   * Reads the *stored* state of a workflow from upstream. Middlewares that must
+   * not trust the request body — an ACL the caller could rewrite in the same
+   * call is no ACL — use this instead. Absent when the host cannot reach
+   * upstream on the middleware's behalf.
+   */
+  fetchStoredWorkflow?: (id: string) => Promise<Workflow | null>;
 }
 
 /**

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -1,3 +1,5 @@
+import type { RouteSpec } from "./rest/router.ts";
+
 /** Enforce levels: off = log only, warn = forward + log violations, error = block on errors */
 export type EnforceLevel = "off" | "warn" | "error";
 
@@ -50,6 +52,12 @@ export interface ProxyConfig {
    * intercepted save" (legacy behavior).
    */
   filterByTags?: string[];
+  /**
+   * Endpoints treated as policy-relevant. Defaults to `DEFAULT_ROUTES`.
+   * Configurable because the surface worth gating is deployment specific —
+   * see `parseRoutes` for the text format.
+   */
+  routes?: RouteSpec[];
   /**
    * Ordered list of client middleware names to apply to every outgoing
    * upstream request (mutation and transparent-forward paths alike).

--- a/src/proxy/rest/router.ts
+++ b/src/proxy/rest/router.ts
@@ -1,24 +1,124 @@
-/** Recognized n8n public-API endpoints that mutate workflow definitions. */
-export type WorkflowMutation =
-  | { kind: "create" } // POST /api/v1/workflows
-  | { kind: "update"; id: string }; // PUT /api/v1/workflows/:id
+/**
+ * The set of upstream endpoints the proxy treats as policy-relevant.
+ *
+ * Anything not matched here is forwarded transparently, so this table decides
+ * what middleware can see at all. It is configurable (`--routes` /
+ * `N8N_PROXY_ROUTES`) because the surface worth gating is deployment specific:
+ * a self-hosted n8n variant, a future API version, or an operator who also
+ * wants credential writes under policy shouldn't need a new release.
+ */
+
+export interface RouteSpec {
+  method: string;
+  /** Path with `:id` standing for exactly one path segment. */
+  pattern: string;
+  /** Action name handed to middleware as `ctx.action`. */
+  action: string;
+  /**
+   * Whether the request body is a workflow definition. Tag assignment, delete
+   * and activate carry something else (or nothing), so body-reading middleware
+   * (lint) must stay out of their way.
+   */
+  bodyIsWorkflow: boolean;
+}
+
+export interface WorkflowMutation {
+  action: string;
+  /** Workflow id from the path, when the route carries one. */
+  id?: string;
+  bodyIsWorkflow: boolean;
+}
 
 /**
- * Identifies if a request targets a workflow mutation endpoint on the public
- * n8n API. Returns null for any other request (which should be transparently
- * forwarded).
+ * Default table: the endpoints that change a workflow, or change who may
+ * reach it. `create`/`update` carry a workflow body; the rest do not.
  */
-export function matchWorkflowMutation(method: string, pathname: string): WorkflowMutation | null {
+export const DEFAULT_ROUTES: RouteSpec[] = [
+  { method: "POST", pattern: "/api/v1/workflows", action: "create", bodyIsWorkflow: true },
+  { method: "PUT", pattern: "/api/v1/workflows/:id", action: "update", bodyIsWorkflow: true },
+  // Tag assignment is its own endpoint upstream and n8n ignores tags on the
+  // workflow body, so an ACL kept in tags can only be defended here.
+  { method: "PUT", pattern: "/api/v1/workflows/:id/tags", action: "tags", bodyIsWorkflow: false },
+  { method: "DELETE", pattern: "/api/v1/workflows/:id", action: "delete", bodyIsWorkflow: false },
+  {
+    method: "POST",
+    pattern: "/api/v1/workflows/:id/activate",
+    action: "activate",
+    bodyIsWorkflow: false,
+  },
+  {
+    method: "POST",
+    pattern: "/api/v1/workflows/:id/deactivate",
+    action: "activate",
+    bodyIsWorkflow: false,
+  },
+];
+
+/**
+ * Parses a route table from text. One route per line (or comma-separated):
+ *
+ *   METHOD /path/:id -> action [body=workflow]
+ *
+ * `#` starts a comment. Malformed lines throw instead of being skipped — a
+ * typo that silently dropped a route would silently drop enforcement.
+ */
+export function parseRoutes(raw: string | undefined): RouteSpec[] | undefined {
+  if (!raw || raw.trim() === "") return undefined;
+  const lines = raw
+    .split(/[\n,]/)
+    .map((l) => l.trim())
+    .filter((l) => l !== "" && !l.startsWith("#"));
+  if (lines.length === 0) return undefined;
+
+  return lines.map((line) => {
+    const m = line.match(/^(\S+)\s+(\S+)\s*->\s*(\S+)(?:\s+body=(\S+))?$/);
+    if (!m) {
+      throw new Error(
+        `Invalid proxy route "${line}". Expected: METHOD /path/:id -> action [body=workflow]`,
+      );
+    }
+    return {
+      method: (m[1] as string).toUpperCase(),
+      pattern: m[2] as string,
+      action: m[3] as string,
+      bodyIsWorkflow: m[4] === "workflow",
+    };
+  });
+}
+
+function matchPattern(pattern: string, pathname: string): { id?: string } | null {
+  const pParts = pattern.split("/");
+  const aParts = pathname.split("/");
+  if (pParts.length !== aParts.length) return null;
+  let id: string | undefined;
+  for (let i = 0; i < pParts.length; i++) {
+    const p = pParts[i] as string;
+    const a = aParts[i] as string;
+    if (p === ":id") {
+      if (a === "") return null;
+      id = decodeURIComponent(a);
+      continue;
+    }
+    if (p !== a) return null;
+  }
+  return { id };
+}
+
+/**
+ * Identifies whether a request targets a policy-relevant endpoint. Returns
+ * null for everything else, which the caller forwards transparently.
+ */
+export function matchWorkflowMutation(
+  method: string,
+  pathname: string,
+  routes: RouteSpec[] = DEFAULT_ROUTES,
+): WorkflowMutation | null {
   const normalized = pathname.replace(/\/+$/, "");
-
-  if (method === "POST" && normalized === "/api/v1/workflows") {
-    return { kind: "create" };
+  for (const route of routes) {
+    if (route.method !== method.toUpperCase()) continue;
+    const hit = matchPattern(route.pattern, normalized);
+    if (!hit) continue;
+    return { action: route.action, id: hit.id, bodyIsWorkflow: route.bodyIsWorkflow };
   }
-
-  if (method === "PUT") {
-    const m = normalized.match(/^\/api\/v1\/workflows\/([^/]+)$/);
-    if (m) return { kind: "update", id: decodeURIComponent(m[1] as string) };
-  }
-
   return null;
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -186,7 +186,7 @@ async function handle(req: Request, deps: HandlerDeps): Promise<Response> {
     return handleProbe(req.method, pathname, deps);
   }
 
-  const mutation = matchWorkflowMutation(req.method, pathname);
+  const mutation = matchWorkflowMutation(req.method, pathname, deps.config.routes);
   if (mutation) {
     return handleWorkflowMutation(req, mutation, pathname, deps);
   }
@@ -256,29 +256,38 @@ async function handleWorkflowMutation(
   const rawJSON = await req.text();
   const apiKey = req.headers.get("x-n8n-api-key");
 
-  // Malformed JSON: return 400 from the proxy itself rather than layering on
-  // an upstream 400. n8n would also reject it; one clear error beats two.
+  // Only some routes carry a workflow definition. Tag assignment, delete and
+  // activate carry something else (or nothing), so parsing their body as a
+  // workflow — and rejecting it when that fails — would break endpoints this
+  // proxy is only gating, not inspecting.
   let workflow: Workflow | null = null;
-  try {
-    workflow = JSON.parse(rawJSON) as Workflow;
-  } catch (parseErr) {
-    const message = parseErr instanceof Error ? parseErr.message : String(parseErr);
-    deps.logger.log({
-      action: "block",
-      method: req.method,
-      path: pathname,
-      status: 400,
-      message: `invalid JSON: ${message}`,
-    });
-    return buildBadJSONResponse(message);
+  if (mutation.bodyIsWorkflow) {
+    // Malformed JSON: return 400 from the proxy itself rather than layering on
+    // an upstream 400. n8n would also reject it; one clear error beats two.
+    try {
+      workflow = JSON.parse(rawJSON) as Workflow;
+    } catch (parseErr) {
+      const message = parseErr instanceof Error ? parseErr.message : String(parseErr);
+      deps.logger.log({
+        action: "block",
+        method: req.method,
+        path: pathname,
+        status: 400,
+        message: `invalid JSON: ${message}`,
+      });
+      return buildBadJSONResponse(message);
+    }
   }
 
   // Scope filter: when --tags / PROXY_FILTER_BY_TAGS is set, only workflows
   // carrying every named tag get middleware + duplicate processing. Other
   // saves are forwarded transparently so the proxy can be deployed in front
   // of an instance whose workflows are only partially under policy.
+  //
+  // Routes without a workflow body can't be filtered this way — the tags live
+  // upstream, not in the request — so they always go through the pipeline.
   const filterTags = deps.config.filterByTags ?? [];
-  if (filterTags.length > 0 && !hasAllTags(workflow?.tags, filterTags)) {
+  if (mutation.bodyIsWorkflow && filterTags.length > 0 && !hasAllTags(workflow?.tags, filterTags)) {
     return handleSkippedMutation(req, rawJSON, pathname, workflow, filterTags, deps);
   }
 
@@ -288,9 +297,13 @@ async function handleWorkflowMutation(
   // identity or which header it lives on.
   const verdict = await runPipeline(deps.middlewares, {
     workflow,
-    rawJSON,
+    // Middleware that reads a body only makes sense where one exists.
+    rawJSON: mutation.bodyIsWorkflow ? rawJSON : undefined,
     request: req,
     mode: "proxy",
+    action: mutation.action,
+    workflowId: mutation.id,
+    fetchStoredWorkflow: (id) => fetchStoredWorkflow(id, apiKey, deps),
   });
 
   const workflowName = workflow?.name;
@@ -314,7 +327,7 @@ async function handleWorkflowMutation(
 
   // Duplicate detection (creates only — updates target a specific id).
   let duplicateMatches: Awaited<ReturnType<DuplicateChecker["findByName"]>> = [];
-  if (mutation.kind === "create" && deps.duplicates && workflow?.name) {
+  if (mutation.action === "create" && deps.duplicates && workflow?.name) {
     try {
       duplicateMatches = await deps.duplicates.findByName(workflow.name, apiKey);
     } catch {
@@ -373,6 +386,43 @@ async function handleWorkflowMutation(
   } catch (err) {
     return reportError(err, req, pathname, deps);
   }
+}
+
+/**
+ * Reads the stored state of a workflow from upstream, for middleware that must
+ * not trust the request body (an ACL the caller can rewrite in the same call
+ * grants nothing).
+ *
+ * Runs under the caller's own API key when they sent one, so this never
+ * escalates privileges — same reasoning as the duplicate-name lookup. The
+ * client middleware chain applies, so IAP/API-key injection works here too.
+ *
+ * Returns null when upstream says the workflow doesn't exist; throws on
+ * anything else so the caller can apply its own fail-open/closed policy rather
+ * than mistaking an outage for "no ACL".
+ */
+async function fetchStoredWorkflow(
+  id: string,
+  apiKey: string | null,
+  deps: HandlerDeps,
+): Promise<Workflow | null> {
+  const url = `${deps.upstream}/api/v1/workflows/${encodeURIComponent(id)}`;
+  const headers = new Headers({ accept: "application/json" });
+  if (apiKey) headers.set("x-n8n-api-key", apiKey);
+  const { response } = await forwardRequest(
+    new Request(url, { method: "GET", headers }),
+    deps.upstream,
+    undefined,
+    {
+      timeoutMs: deps.config.upstreamTimeoutMs,
+      clientMiddlewares: deps.clientMiddlewares,
+    },
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`upstream returned HTTP ${response.status} for workflow ${id}`);
+  }
+  return (await response.json()) as Workflow;
 }
 
 function reportError(err: unknown, req: Request, pathname: string, deps: HandlerDeps): Response {

--- a/tests/api/client-egress.test.ts
+++ b/tests/api/client-egress.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@/api/client.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
+
+/**
+ * The API client's egress seam.
+ *
+ * Without it the CLI can only ever send `X-N8N-API-KEY`, so it cannot reach a
+ * gateway that authenticates callers per request — the request is rejected at
+ * the edge before n8n is involved at all.
+ */
+
+interface Captured {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+let captured: Captured[];
+let server: ReturnType<typeof Bun.serve>;
+let base: string;
+
+beforeEach(() => {
+  captured = [];
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ method: req.method, url: req.url, headers });
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterEach(async () => {
+  await server.stop(true);
+});
+
+/** Middleware that stands in for iap-auth / impersonator-token. */
+function fakeAuth(): ClientMiddleware {
+  return {
+    name: "fake-auth",
+    apply(headers, ctx) {
+      headers.set("Authorization", `Bearer token-for-${ctx.method}`);
+      headers.set("X-Impersonator-Id-Token", "user-token");
+      headers.set("X-Saw-Path", ctx.pathname);
+    },
+  };
+}
+
+describe("Client egress middlewares", () => {
+  test("no chain configured leaves the request exactly as before", async () => {
+    const client = new Client(base, "key-123");
+    await client.get("/workflows");
+
+    expect(captured).toHaveLength(1);
+    const req = captured[0]!;
+    expect(req.headers["x-n8n-api-key"]).toBe("key-123");
+    expect(req.headers.authorization).toBeUndefined();
+  });
+
+  test("configured middlewares can attach credentials to every call", async () => {
+    const client = new Client(base, "key-123", 30_000, [fakeAuth()]);
+    await client.get("/workflows");
+    await client.post("/workflows", { name: "wf" });
+
+    expect(captured).toHaveLength(2);
+    for (const req of captured) {
+      expect(req.headers.authorization).toBe(`Bearer token-for-${req.method}`);
+      expect(req.headers["x-impersonator-id-token"]).toBe("user-token");
+      // The API key still rides along; a gateway may replace it upstream.
+      expect(req.headers["x-n8n-api-key"]).toBe("key-123");
+    }
+    // Context reflects the actual outgoing request, not a placeholder.
+    expect(captured[0]!.headers["x-saw-path"]).toBe("/api/v1/workflows");
+  });
+
+  test("a middleware that throws aborts the call instead of sending it unauthenticated", async () => {
+    const boom: ClientMiddleware = {
+      name: "boom",
+      apply() {
+        throw new Error("mint failed");
+      },
+    };
+    const client = new Client(base, "key-123", 30_000, [boom]);
+
+    await expect(client.get("/workflows")).rejects.toThrow(/mint failed/);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("requests ask for an identity encoding so a re-labelling proxy cannot break reads", async () => {
+    const client = new Client(base, "key-123");
+    await client.get("/workflows");
+
+    expect(captured[0]!.headers["accept-encoding"]).toBe("identity");
+  });
+});

--- a/tests/middleware/builtin/authz/authz-upstream-acl.test.ts
+++ b/tests/middleware/builtin/authz/authz-upstream-acl.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test";
+import type { Workflow } from "@/api/types.ts";
+import { buildGroupsAuthenticator } from "@/middleware/builtin/authz/groups-auth.ts";
+import { AuthzMiddleware } from "@/middleware/builtin/authz/middleware.ts";
+import type { AuthzOptions } from "@/middleware/builtin/authz/types.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
+
+/**
+ * Authorization against the *stored* ACL, plus the missing-ACL policies.
+ *
+ * The distinction matters because an ACL read out of the request body is not an
+ * ACL: the caller writes that body. It matters practically too — n8n assigns
+ * tags through a separate endpoint, so a workflow write payload never carries
+ * them, and a tag-based ACL read from the body is always empty.
+ */
+
+const OPTIONS: AuthzOptions = {
+  enforce: "error",
+  onError: "deny",
+  identity: { source: "none", decode: "raw" },
+  groups: {
+    url: "https://groups.test/lookup",
+    method: "POST",
+    headers: {},
+    extract: "$.groups[*]",
+    cacheTtlMs: 0,
+    timeoutMs: 1000,
+  },
+  workflow: { extract: "$.tags[*].name", stripPrefix: "acl:" },
+  aclSource: "upstream",
+};
+
+function withTags(...tags: string[]): Workflow {
+  return {
+    id: "wf1",
+    name: "wf",
+    nodes: [],
+    connections: {},
+    tags: tags.map((name) => ({ name })),
+  } as unknown as Workflow;
+}
+
+function middleware(opts: Partial<AuthzOptions>, groups: string[]) {
+  return new AuthzMiddleware(
+    { ...OPTIONS, ...opts },
+    {
+      fetch: async () => new Response(JSON.stringify({ groups }), { status: 200 }),
+    },
+  );
+}
+
+function ctx(over: Partial<ServerMiddlewareContext> = {}): ServerMiddlewareContext {
+  return {
+    workflow: null,
+    mode: "proxy",
+    identity: "dev@example.com",
+    action: "update",
+    workflowId: "wf1",
+    ...over,
+  };
+}
+
+describe("authz: ACL from stored state", () => {
+  test("allows when the stored ACL intersects the caller's groups", async () => {
+    const mw = middleware({}, ["team-a", "everyone"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ fetchStoredWorkflow: async () => withTags("managed", "acl:team-a") }),
+    );
+
+    expect(verdict.block).toBe(false);
+  });
+
+  test("denies when it does not", async () => {
+    const mw = middleware({}, ["team-b"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ fetchStoredWorkflow: async () => withTags("acl:team-a") }),
+    );
+
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.status).toBe(403);
+    expect(verdict.violations[0]?.rule).toBe("authz-denied");
+  });
+
+  test("a self-granting body cannot buy access — only stored tags count", async () => {
+    const mw = middleware({}, ["team-b"]);
+
+    const verdict = await mw.evaluate(
+      ctx({
+        // Caller claims their own group in the payload...
+        workflow: withTags("acl:team-b"),
+        // ...but the stored workflow says otherwise.
+        fetchStoredWorkflow: async () => withTags("acl:team-a"),
+      }),
+    );
+
+    expect(verdict.block).toBe(true);
+  });
+
+  test("reads the stored workflow once per id, not once per check", async () => {
+    let reads = 0;
+    const mw = middleware({ aclCacheTtlMs: 60_000 }, ["team-a"]);
+    const fetchStoredWorkflow = async () => {
+      reads++;
+      return withTags("acl:team-a");
+    };
+
+    await mw.evaluate(ctx({ fetchStoredWorkflow }));
+    await mw.evaluate(ctx({ fetchStoredWorkflow }));
+
+    expect(reads).toBe(1);
+  });
+
+  test("an unreachable upstream denies rather than reading as 'no ACL'", async () => {
+    const mw = middleware({}, ["team-a"]);
+
+    const verdict = await mw.evaluate(
+      ctx({
+        fetchStoredWorkflow: async () => {
+          throw new Error("upstream returned HTTP 500 for workflow wf1");
+        },
+      }),
+    );
+
+    expect(verdict.block).toBe(true);
+    expect(verdict.violations[0]?.rule).toBe("authz-acl-error");
+  });
+
+  test("onError=allow turns an unreachable upstream into a warning", async () => {
+    const mw = middleware({ onError: "allow" }, ["team-a"]);
+
+    const verdict = await mw.evaluate(
+      ctx({
+        fetchStoredWorkflow: async () => {
+          throw new Error("boom");
+        },
+      }),
+    );
+
+    expect(verdict.block).toBe(false);
+    expect(verdict.violations[0]?.severity).toBe("warning");
+  });
+
+  test("a host that cannot read upstream state is a configuration error, not an allow", async () => {
+    const mw = middleware({}, ["team-a"]);
+
+    const verdict = await mw.evaluate(ctx({ fetchStoredWorkflow: undefined }));
+
+    expect(verdict.block).toBe(true);
+    expect(verdict.violations[0]?.message).toMatch(/stored-workflow reader/);
+  });
+});
+
+describe("authz: targets with no ACL", () => {
+  test("create is denied by default — there is nothing to authorize against", async () => {
+    const mw = middleware({}, ["team-a"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ action: "create", workflowId: undefined, fetchStoredWorkflow: async () => null }),
+    );
+
+    expect(verdict.block).toBe(true);
+    expect(verdict.violations[0]?.rule).toBe("authz-no-acl");
+  });
+
+  test("bootstrapGroups decides creates by membership", async () => {
+    const mw = middleware({ bootstrapGroups: ["engineers"] }, ["engineers"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ action: "create", workflowId: undefined, fetchStoredWorkflow: async () => null }),
+    );
+
+    expect(verdict.block).toBe(false);
+  });
+
+  test("bootstrapGroups still refuses a non-member", async () => {
+    const mw = middleware({ bootstrapGroups: ["engineers"] }, ["marketing"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ action: "create", workflowId: undefined, fetchStoredWorkflow: async () => null }),
+    );
+
+    expect(verdict.block).toBe(true);
+  });
+
+  test("onMissingAcl=allow lets unlabelled targets through", async () => {
+    const mw = middleware({ onMissingAcl: "allow" }, ["team-a"]);
+
+    const verdict = await mw.evaluate(
+      ctx({ fetchStoredWorkflow: async () => withTags("managed") }),
+    );
+
+    expect(verdict.block).toBe(false);
+  });
+});
+
+describe("authz: action scoping", () => {
+  test("only authorizes the listed actions", async () => {
+    const mw = middleware({ actions: ["delete"] }, ["team-b"]);
+
+    // "update" is out of scope, so it passes untouched even though the
+    // caller's groups don't match the stored ACL.
+    const update = await mw.evaluate(
+      ctx({ action: "update", fetchStoredWorkflow: async () => withTags("acl:team-a") }),
+    );
+    expect(update.block).toBe(false);
+
+    const del = await mw.evaluate(
+      ctx({ action: "delete", fetchStoredWorkflow: async () => withTags("acl:team-a") }),
+    );
+    expect(del.block).toBe(true);
+  });
+});
+
+describe("authz: groups request authentication", () => {
+  test("bearer-env attaches the token from the environment", async () => {
+    const auth = buildGroupsAuthenticator({ kind: "bearer-env", tokenEnvVar: "TOK" }, {
+      TOK: "secret-token",
+    } as NodeJS.ProcessEnv);
+    const headers: Record<string, string> = {};
+
+    await auth?.(headers);
+
+    expect(headers.authorization).toBe("Bearer secret-token");
+  });
+
+  test("bearer-env says which variable is empty instead of silently sending nothing", async () => {
+    const auth = buildGroupsAuthenticator(
+      { kind: "bearer-env", tokenEnvVar: "TOK" },
+      {} as NodeJS.ProcessEnv,
+    );
+
+    await expect(auth?.({})).rejects.toThrow(/TOK/);
+  });
+
+  test("kind=none keeps the header-only behaviour", () => {
+    expect(buildGroupsAuthenticator({ kind: "none" })).toBeUndefined();
+    expect(buildGroupsAuthenticator(undefined)).toBeUndefined();
+  });
+
+  test("gcp-id-token requires an audience", () => {
+    expect(() => buildGroupsAuthenticator({ kind: "gcp-id-token" })).toThrow(/audience/);
+  });
+
+  test("gcp-id-token with adc-impersonate requires the target service account", () => {
+    expect(() =>
+      buildGroupsAuthenticator({
+        kind: "gcp-id-token",
+        audience: "aud",
+        tokenSource: "adc-impersonate",
+      }),
+    ).toThrow(/impersonateServiceAccount/);
+  });
+});

--- a/tests/middleware/builtin/iap-auth/adc-impersonate-source.test.ts
+++ b/tests/middleware/builtin/iap-auth/adc-impersonate-source.test.ts
@@ -126,6 +126,23 @@ describe("iapAuthFactory: adc-impersonate", () => {
     ).not.toThrow();
   });
 
+  test("audience falls back to the API URL, so one variable covers the common case", () => {
+    const opts = iapAuthFactory.loadFromEnv({
+      N8N_API_URL: "https://gateway.example.run.app",
+    } as NodeJS.ProcessEnv);
+
+    expect(opts.audience).toBe("https://gateway.example.run.app");
+  });
+
+  test("an explicit audience still wins over the fallback", () => {
+    const opts = iapAuthFactory.loadFromEnv({
+      N8N_API_URL: "https://gateway.example.run.app",
+      N8N_IAP_AUTH_AUDIENCE: "explicit-client-id",
+    } as NodeJS.ProcessEnv);
+
+    expect(opts.audience).toBe("explicit-client-id");
+  });
+
   test("is selectable from the environment", () => {
     const opts = iapAuthFactory.loadFromEnv({
       N8N_IAP_AUTH_TOKEN_SOURCE: "adc-impersonate",

--- a/tests/middleware/builtin/iap-auth/adc-impersonate-source.test.ts
+++ b/tests/middleware/builtin/iap-auth/adc-impersonate-source.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { AdcImpersonateTokenSource } from "@/middleware/builtin/iap-auth/adc-impersonate-source.ts";
+import { iapAuthFactory } from "@/middleware/builtin/iap-auth/factory.ts";
+
+/**
+ * Minting a gateway id_token from a developer laptop: there is no metadata
+ * server there, so the caller credential comes from ADC and the id_token is
+ * minted as the target service account through the IAM Credentials API.
+ */
+
+const CREDS = {
+  type: "authorized_user",
+  client_id: "client-abc.apps.googleusercontent.com",
+  client_secret: "secret",
+  refresh_token: "refresh",
+};
+
+const TARGET = "gate@example.iam.gserviceaccount.com";
+
+interface Call {
+  url: string;
+  body: string;
+  auth?: string;
+}
+
+function makeSource(
+  opts: {
+    creds?: Record<string, unknown>;
+    idTokenStatus?: number;
+    idTokenBody?: unknown;
+    now?: () => number;
+  } = {},
+) {
+  const calls: Call[] = [];
+  const source = new AdcImpersonateTokenSource(TARGET, {
+    readCredentials: async () => (opts.creds ?? CREDS) as never,
+    tokenEndpoint: "https://token.test/token",
+    iamCredentialsBaseUrl: "https://iam.test/v1",
+    now: opts.now,
+    fetcher: async (url, init) => {
+      calls.push({
+        url,
+        body: String(init?.body ?? ""),
+        auth: new Headers(init?.headers).get("authorization") ?? undefined,
+      });
+      if (url === "https://token.test/token") {
+        return new Response(JSON.stringify({ access_token: "caller-access-token" }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify(opts.idTokenBody ?? { token: "minted-id-token" }), {
+        status: opts.idTokenStatus ?? 200,
+      });
+    },
+  });
+  return { source, calls };
+}
+
+describe("AdcImpersonateTokenSource", () => {
+  test("exchanges ADC for an access token, then mints an id_token as the target SA", async () => {
+    const { source, calls } = makeSource();
+
+    const token = await source.getToken("https://gateway.example.run.app");
+
+    expect(token).toBe("minted-id-token");
+    expect(calls).toHaveLength(2);
+    // 1) refresh_token grant WITHOUT an audience — we want an access_token here.
+    expect(calls[0]!.url).toBe("https://token.test/token");
+    expect(calls[0]!.body).toContain("grant_type=refresh_token");
+    expect(calls[0]!.body).not.toContain("audience=");
+    // 2) generateIdToken on the target SA, authorised by that access_token.
+    expect(calls[1]!.url).toBe(
+      `https://iam.test/v1/projects/-/serviceAccounts/${encodeURIComponent(TARGET)}:generateIdToken`,
+    );
+    expect(calls[1]!.auth).toBe("Bearer caller-access-token");
+    expect(JSON.parse(calls[1]!.body)).toEqual({
+      audience: "https://gateway.example.run.app",
+      includeEmail: true,
+    });
+  });
+
+  test("caches per audience so a multi-call command mints once", async () => {
+    const { source, calls } = makeSource({ now: () => 1_000 });
+
+    await source.getToken("aud-a");
+    await source.getToken("aud-a");
+    await source.getToken("aud-b");
+
+    // 2 calls for the first audience, 2 more for the second — not 6.
+    expect(calls).toHaveLength(4);
+  });
+
+  test("service-account key files are rejected with a pointer to the right source", async () => {
+    const { source } = makeSource({ creds: { type: "service_account" } });
+
+    await expect(source.getToken("aud")).rejects.toThrow(/authorized_user.*metadata/s);
+  });
+
+  test("an incomplete ADC file says how to fix it", async () => {
+    const { source } = makeSource({ creds: { type: "authorized_user" } });
+
+    await expect(source.getToken("aud")).rejects.toThrow(/application-default login/);
+  });
+
+  test("a denied impersonation names the role the caller is missing", async () => {
+    const { source } = makeSource({ idTokenStatus: 403, idTokenBody: { error: "forbidden" } });
+
+    await expect(source.getToken("aud")).rejects.toThrow(/serviceAccountTokenCreator/);
+  });
+});
+
+describe("iapAuthFactory: adc-impersonate", () => {
+  test("requires the target service account", () => {
+    expect(() =>
+      iapAuthFactory.build({ audience: "aud", tokenSourceKind: "adc-impersonate" }),
+    ).toThrow(/impersonateServiceAccount/);
+  });
+
+  test("builds when the target is given", () => {
+    expect(() =>
+      iapAuthFactory.build({
+        audience: "aud",
+        tokenSourceKind: "adc-impersonate",
+        impersonateServiceAccount: TARGET,
+      }),
+    ).not.toThrow();
+  });
+
+  test("is selectable from the environment", () => {
+    const opts = iapAuthFactory.loadFromEnv({
+      N8N_IAP_AUTH_TOKEN_SOURCE: "adc-impersonate",
+      N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT: TARGET,
+    } as NodeJS.ProcessEnv);
+
+    expect(opts.tokenSourceKind).toBe("adc-impersonate");
+    expect(opts.impersonateServiceAccount).toBe(TARGET);
+  });
+});

--- a/tests/middleware/builtin/impersonator-token/middleware.test.ts
+++ b/tests/middleware/builtin/impersonator-token/middleware.test.ts
@@ -171,8 +171,22 @@ describe("AdcUserTokenSource", () => {
 });
 
 describe("impersonatorTokenFactory", () => {
-  test("audience is required", () => {
-    expect(() => impersonatorTokenFactory.build({})).toThrow(/audience/);
+  test("audience is optional at build time — the token source may name it", () => {
+    // `tokenSourceKind=adc` reads client_id out of the credentials file, and
+    // that is the only aud the refresh-token grant can mint for anyway, so
+    // requiring the operator to restate it just invites a mismatch.
+    expect(() => impersonatorTokenFactory.build({ tokenSourceKind: "adc" })).not.toThrow();
+  });
+
+  test("a source that cannot name an audience fails at apply time with a fixable message", async () => {
+    const mw = impersonatorTokenFactory.build({
+      tokenSourceKind: "static",
+      staticToken: "tok",
+      onError: "throw",
+    });
+    await expect(
+      mw.apply(new Headers(), { method: "GET", pathname: "/", upstreamUrl: "https://x/" }),
+    ).rejects.toThrow(/N8N_IMPERSONATOR_TOKEN_AUDIENCE/);
   });
 
   test("static token source requires staticToken", () => {

--- a/tests/proxy/proxy.test.ts
+++ b/tests/proxy/proxy.test.ts
@@ -113,27 +113,50 @@ function proxyURL(p: string): string {
 
 describe("proxy: route matcher", () => {
   test("POST /api/v1/workflows is recognized as create", () => {
-    expect(matchWorkflowMutation("POST", "/api/v1/workflows")).toEqual({ kind: "create" });
+    expect(matchWorkflowMutation("POST", "/api/v1/workflows")).toEqual({
+      action: "create",
+      id: undefined,
+      bodyIsWorkflow: true,
+    });
   });
 
   test("PUT /api/v1/workflows/:id is recognized as update", () => {
     expect(matchWorkflowMutation("PUT", "/api/v1/workflows/abc123")).toEqual({
-      kind: "update",
+      action: "update",
       id: "abc123",
+      bodyIsWorkflow: true,
     });
   });
 
-  test("Other endpoints are not matched", () => {
+  test("endpoints that change access or state are matched, without a workflow body", () => {
+    expect(matchWorkflowMutation("PUT", "/api/v1/workflows/abc/tags")).toEqual({
+      action: "tags",
+      id: "abc",
+      bodyIsWorkflow: false,
+    });
+    expect(matchWorkflowMutation("DELETE", "/api/v1/workflows/abc")).toEqual({
+      action: "delete",
+      id: "abc",
+      bodyIsWorkflow: false,
+    });
+    expect(matchWorkflowMutation("POST", "/api/v1/workflows/abc/activate")).toEqual({
+      action: "activate",
+      id: "abc",
+      bodyIsWorkflow: false,
+    });
+  });
+
+  test("reads and unrelated endpoints are not matched", () => {
     expect(matchWorkflowMutation("GET", "/api/v1/workflows")).toBeNull();
-    expect(matchWorkflowMutation("DELETE", "/api/v1/workflows/abc")).toBeNull();
+    expect(matchWorkflowMutation("GET", "/api/v1/workflows/abc")).toBeNull();
     expect(matchWorkflowMutation("POST", "/api/v1/credentials")).toBeNull();
-    expect(matchWorkflowMutation("POST", "/api/v1/workflows/abc/activate")).toBeNull();
   });
 
   test("URL-encoded ids are decoded", () => {
     expect(matchWorkflowMutation("PUT", "/api/v1/workflows/wf%20a")).toEqual({
-      kind: "update",
+      action: "update",
       id: "wf a",
+      bodyIsWorkflow: true,
     });
   });
 });


### PR DESCRIPTION
## Problem

`Client.doRequest` sends a fixed set of headers — `X-N8N-API-KEY`, `Content-Type`, `Accept`. There is no seam to attach anything else, so pointing `N8N_API_URL` at a gateway that authenticates callers per request fails at the edge:

```
$ N8N_API_URL=<gateway> N8N_API_KEY=dummy n8n-cli workflow list --limit 2
Error: Unexpected error (status 403)
```

The credential never reaches the gateway, and n8n is never involved. That leaves two bad options: bypass the gateway, or run a local relay process whose only job is to add two headers. Both defeat the purpose of deploying the gateway.

## Changes

- **`Client` takes an egress middleware chain**, wired from `N8N_CLIENT_MIDDLEWARES`. These are the same `ClientMiddleware`s the `proxy` subcommand already runs on its own egress, so there is one implementation and one config vocabulary for both directions. Empty by default — the direct-to-n8n path is byte-identical to before.
- **New `iap-auth` token source `adc-impersonate`**: mints the id_token as a target service account using local Application Default Credentials (ADC refresh-token grant → `iamcredentials.generateIdToken`). The `metadata` source only covers workloads; a developer machine previously had no way to produce that token except pasting `gcloud auth print-identity-token --impersonate-service-account=...` into an env var every hour.
- **Audience derivation instead of a required constant.** `impersonator-token`'s audience is now optional: the ADC source names its own, because the refresh-token grant only issues tokens for the client that owns the credentials — asking for a different project's client fails outright with `invalid_audience`. A configured constant that doesn't match the credentials in use fails at the far end with nothing but "verification failed", which is a miserable thing to debug. `iap-auth` likewise defaults its audience to the API URL, which is what a Cloud Run gateway expects.
- **`N8N_API_KEY` is optional when an egress chain is configured.** A gateway that terminates authentication holds the n8n key and injects it upstream, so the caller has none; demanding one anyway pushes operators to park a placeholder — or the real shared key — in every developer's shell.
- **`Accept-Encoding: identity` on API requests.** A proxy commonly re-emits the upstream's `Content-Encoding` over a body its own HTTP client already decoded, and that mismatch arrives here as an unrecoverable decompression failure. Uncompressed transfers cost bandwidth a CLI can afford; a read path that dies on large responses is not affordable.

Resulting setup — no relay process, no manual token step:

```bash
export N8N_API_URL="https://gateway.example.com"
export N8N_CLIENT_MIDDLEWARES="iap-auth,impersonator-token"
export N8N_IAP_AUTH_TOKEN_SOURCE="adc-impersonate"
export N8N_IAP_AUTH_IMPERSONATE_SERVICE_ACCOUNT="gate-caller@example.iam.gserviceaccount.com"
export N8N_IMPERSONATOR_TOKEN_SOURCE="adc"
```

## Verification

Every check below ran the built CLI against a deployed gateway fronting a real n8n — no `curl`, no relay process, no hand-minted tokens, and no `N8N_API_KEY`:

| Command | Result |
|---|---|
| `workflow list --limit 3` | 3 workflows returned |
| `workflow get <id>` | returned, fields intact |
| `apply --ids=<id> --dry-run` | `1 unchanged` |
| `workflow create -f <lint-violating>.json --no-lint` | refused by the gateway: `Workflow violates 2 linter rules and was not forwarded to n8n` |
| `workflow create -f <clean>.json` | created |
| `workflow update <id> -f <edited>.json` | updated; `workflow get` shows the edit |
| `workflow delete <id> --force` | deleted; a 100-row list confirms no residue |

Notably the read path succeeded against a gateway whose own build predates the `Content-Encoding` fix in #50 — the `identity` request header sidesteps it, so clients are not blocked on the gateway being rebuilt.

Unit tests: `tests/api/client-egress.test.ts` (chain applied to every call, absent chain leaves requests untouched, a throwing middleware aborts rather than sending unauthenticated, identity encoding requested) and `tests/middleware/builtin/iap-auth/adc-impersonate-source.test.ts` (grant → mint sequence and payloads, per-audience caching, and the error messages for a key file, an incomplete ADC file, and a denied impersonation).

Suite: 1036 pass, 1 fail — `tests/lint/rules/no-plaintext-secrets.test.ts` also fails on `origin/main` at ea0b6d4, confirmed in a clean worktree. Unrelated. `tsc --noEmit` clean; `biome check` clean on every touched file.