### PR TITLE
feat(proxy): verify impersonator tokens against the issuer's JWKS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/middleware/auth/jwks.ts
+++ b/src/middleware/auth/jwks.ts
@@ -1,0 +1,424 @@
+import type { IdTokenVerifier, VerifiedClaim } from "./types.ts";
+
+/**
+ * `IdTokenVerifier` that validates a JWT against the signing keys its
+ * issuer publishes as a JWK Set — the standard OIDC verification shape.
+ *
+ * Where `GoogleTokeninfoVerifier` asks a Google-hosted endpoint "is this
+ * token good?", this verifier answers the question locally: fetch the
+ * issuer's public keys once, then check the signature itself. That makes
+ * it work for any issuer that publishes a JWKS, which in practice means
+ * any OIDC provider, any cloud workload identity, and any platform that
+ * can sign a JWT with a key it publishes:
+ *
+ *   - a service account signing an assertion about a human it
+ *     authenticated (keys at the provider's JWKS endpoint for that
+ *     account),
+ *   - a CI system's OIDC token (`token.actions.githubusercontent.com`
+ *     and friends),
+ *   - Kubernetes projected ServiceAccount tokens / SPIFFE JWT-SVIDs,
+ *   - a corporate IdP (Okta, Auth0, Keycloak, Entra ID).
+ *
+ * Trust model: an entry in `issuers` is a statement by the operator that
+ * "this issuer may assert identities to us". Nothing else grants that.
+ * A token whose `iss` is not listed is rejected without any network call,
+ * which also makes this verifier cheap to place first in a chain — it
+ * declines foreign tokens instantly rather than spending a round trip.
+ *
+ * What "verified" means here: the listed issuer signed this assertion.
+ * Whether the issuer is entitled to speak for the identity inside is the
+ * operator's decision, expressed by listing it. Deployments that want the
+ * issuer to *also* self-attest verification (the OIDC `email_verified`
+ * convention) keep `emailVerifiedClaim` set; deployments whose issuer has
+ * no such claim (CI tokens carrying a username, say) clear it and pick
+ * the identity claim explicitly.
+ *
+ * Failure model matches the rest of `IdTokenVerifier`: any problem
+ * returns `null`. Callers reject; they never need the reason.
+ */
+
+/** Narrow fetch signature so tests can stub without touching global fetch. */
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+/** One issuer the deployment is willing to accept assertions from. */
+export interface JwksIssuer {
+  /** Exact `iss` claim value. */
+  issuer: string;
+  /** URL where that issuer publishes its JWK Set. */
+  jwksUri: string;
+}
+
+export interface JwksVerifierOptions {
+  /**
+   * Issuers this verifier accepts. An empty list makes every token fail,
+   * which is the correct fail-closed reading of "no issuer configured".
+   */
+  issuers: JwksIssuer[];
+  /**
+   * Claim carrying the identity the caller is asserting. Default `email`
+   * to match OIDC. Set to e.g. `sub` or `actor` for issuers that do not
+   * mint email claims.
+   */
+  identityClaim?: string;
+  /**
+   * Boolean claim that must be `true` for the token to pass, mirroring
+   * OIDC's `email_verified`. Set to an empty string to skip the check —
+   * required for issuers that do not emit it.
+   */
+  emailVerifiedClaim?: string;
+  /** Tolerance applied to `exp` / `nbf` / `iat`, in seconds. Default 60. */
+  clockSkewSec?: number;
+  /** How long a fetched key set may be reused. Default 10 min. */
+  jwksCacheTtlMs?: number;
+  /**
+   * Floor between JWKS refetches triggered by an unknown `kid`. Bounds
+   * how hard a token with a bogus `kid` can hammer the issuer. Default 30 s.
+   */
+  jwksMinRefetchMs?: number;
+  /** HTTP timeout per JWKS fetch. Default 5 s. */
+  timeoutMs?: number;
+  fetcher?: FetchLike;
+  now?: () => number;
+}
+
+/** Subset of a JWK we care about, post-validation. */
+interface ParsedJwk {
+  kid?: string;
+  alg?: string;
+  kty: string;
+  // RSA
+  n?: string;
+  e?: string;
+  // EC
+  crv?: string;
+  x?: string;
+  y?: string;
+}
+
+interface KeySetEntry {
+  keys: ParsedJwk[];
+  fetchedAt: number;
+}
+
+interface JwtParts {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signingInput: Uint8Array<ArrayBuffer>;
+  signature: Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * Signature algorithms we verify. Restricting the set is deliberate:
+ * accepting whatever the token's own header names is how `alg=none` and
+ * RSA/HMAC confusion attacks get in. Both entries are asymmetric, so a
+ * token can only be produced by the holder of the issuer's private key.
+ */
+const ALGORITHMS = {
+  RS256: { kty: "RSA" },
+  ES256: { kty: "EC" },
+} as const satisfies Record<string, { kty: string }>;
+
+type SupportedAlg = keyof typeof ALGORITHMS;
+
+function isSupportedAlg(alg: string): alg is SupportedAlg {
+  return Object.hasOwn(ALGORITHMS, alg);
+}
+
+export class JwksVerifier implements IdTokenVerifier {
+  private readonly issuers: Map<string, string>;
+  private readonly identityClaim: string;
+  private readonly emailVerifiedClaim: string;
+  private readonly clockSkewSec: number;
+  private readonly jwksCacheTtlMs: number;
+  private readonly jwksMinRefetchMs: number;
+  private readonly timeoutMs: number;
+  private readonly fetcher: FetchLike;
+  private readonly now: () => number;
+  private readonly keySets = new Map<string, KeySetEntry>();
+  /** In-flight fetches, so concurrent verifies share one round trip. */
+  private readonly inflight = new Map<string, Promise<KeySetEntry | null>>();
+
+  constructor(opts: JwksVerifierOptions) {
+    this.issuers = new Map(opts.issuers.map((i) => [i.issuer, i.jwksUri]));
+    this.identityClaim = opts.identityClaim ?? "email";
+    this.emailVerifiedClaim = opts.emailVerifiedClaim ?? "email_verified";
+    this.clockSkewSec = opts.clockSkewSec ?? 60;
+    this.jwksCacheTtlMs = opts.jwksCacheTtlMs ?? 10 * 60 * 1000;
+    this.jwksMinRefetchMs = opts.jwksMinRefetchMs ?? 30_000;
+    this.timeoutMs = opts.timeoutMs ?? 5_000;
+    this.fetcher = opts.fetcher ?? ((input, init) => fetch(input, init));
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  async verify(idToken: string): Promise<VerifiedClaim | null> {
+    const parts = parseJwt(idToken);
+    if (!parts) return null;
+
+    // Reject foreign issuers before touching the network. This is what
+    // lets a chain put this verifier first without paying for it.
+    const iss = parts.payload.iss;
+    if (typeof iss !== "string") return null;
+    const jwksUri = this.issuers.get(iss);
+    if (!jwksUri) return null;
+
+    const alg = parts.header.alg;
+    if (typeof alg !== "string" || !isSupportedAlg(alg)) return null;
+
+    const kid = typeof parts.header.kid === "string" ? parts.header.kid : undefined;
+    const key = await this.resolveKey(jwksUri, kid, ALGORITHMS[alg].kty);
+    if (!key) return null;
+
+    const ok = await verifySignature(key, alg, parts);
+    if (!ok) return null;
+
+    return this.buildClaim(parts.payload, iss);
+  }
+
+  /** Validate the time window and pull the claims the middlewares read. */
+  private buildClaim(payload: Record<string, unknown>, iss: string): VerifiedClaim | null {
+    const nowSec = Math.floor(this.now() / 1000);
+
+    // `exp` is mandatory. A signed assertion with no expiry is a
+    // permanent credential, which is never what an identity assertion
+    // should be.
+    const exp = payload.exp;
+    if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
+    if (nowSec > exp + this.clockSkewSec) return null;
+
+    const nbf = payload.nbf;
+    if (typeof nbf === "number" && nowSec + this.clockSkewSec < nbf) return null;
+
+    const iat = payload.iat;
+    if (typeof iat === "number" && nowSec + this.clockSkewSec < iat) return null;
+
+    // `VerifiedClaim` carries a single audience because that is what the
+    // middlewares pin against. A multi-valued `aud` would force us to
+    // pick one arbitrarily, so we decline it rather than guess.
+    const aud = normalizeAudience(payload.aud);
+    if (!aud) return null;
+
+    if (this.emailVerifiedClaim && payload[this.emailVerifiedClaim] !== true) {
+      return null;
+    }
+
+    const identity = payload[this.identityClaim];
+    if (typeof identity !== "string" || identity.length === 0) return null;
+
+    return {
+      email: identity,
+      // The allowlisted issuer signed this. See the class doc for what
+      // that does and does not mean.
+      emailVerified: true,
+      aud,
+      sub: typeof payload.sub === "string" ? payload.sub : undefined,
+      iss,
+      exp,
+    };
+  }
+
+  /**
+   * Find the signing key, refetching once when the `kid` is unknown so a
+   * key rotation heals without waiting out the cache TTL.
+   */
+  private async resolveKey(
+    jwksUri: string,
+    kid: string | undefined,
+    kty: string,
+  ): Promise<ParsedJwk | null> {
+    const cached = this.keySets.get(jwksUri);
+    const fresh = cached && this.now() - cached.fetchedAt < this.jwksCacheTtlMs;
+    if (fresh) {
+      const hit = selectKey(cached.keys, kid, kty);
+      if (hit) return hit;
+      // Unknown kid against a still-fresh cache: the issuer may have
+      // rotated. Refetch, but not more often than the floor allows.
+      if (this.now() - cached.fetchedAt < this.jwksMinRefetchMs) return null;
+    }
+
+    const loaded = await this.loadKeySet(jwksUri);
+    if (!loaded) return null;
+    return selectKey(loaded.keys, kid, kty);
+  }
+
+  private async loadKeySet(jwksUri: string): Promise<KeySetEntry | null> {
+    const existing = this.inflight.get(jwksUri);
+    if (existing) return existing;
+
+    const task = this.fetchKeySet(jwksUri)
+      .then((entry) => {
+        if (entry) this.keySets.set(jwksUri, entry);
+        return entry;
+      })
+      .finally(() => {
+        this.inflight.delete(jwksUri);
+      });
+
+    this.inflight.set(jwksUri, task);
+    return task;
+  }
+
+  private async fetchKeySet(jwksUri: string): Promise<KeySetEntry | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetcher(jwksUri, { method: "GET", signal: controller.signal });
+      if (!res.ok) return null;
+      const json = (await res.json()) as { keys?: unknown };
+      if (!json || !Array.isArray(json.keys)) return null;
+      const keys = json.keys.map(parseJwk).filter((k): k is ParsedJwk => k !== null);
+      if (keys.length === 0) return null;
+      return { keys, fetchedAt: this.now() };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Chains verifiers, taking the first that accepts the token. Deployments
+ * that serve more than one kind of caller need this: a human's IdP token
+ * and a platform's signed assertion arrive in the same header and only
+ * their issuer tells them apart.
+ *
+ * Order matters only for cost, not for correctness — each verifier is
+ * responsible for declining tokens that are not its own. Putting cheap,
+ * local-rejecting verifiers (like `JwksVerifier`) first avoids paying a
+ * network round trip to prove a token was never for that verifier.
+ */
+export class CompositeVerifier implements IdTokenVerifier {
+  constructor(private readonly verifiers: IdTokenVerifier[]) {}
+
+  async verify(idToken: string): Promise<VerifiedClaim | null> {
+    for (const verifier of this.verifiers) {
+      const claim = await verifier.verify(idToken);
+      if (claim) return claim;
+    }
+    return null;
+  }
+}
+
+function selectKey(keys: ParsedJwk[], kid: string | undefined, kty: string): ParsedJwk | null {
+  const candidates = keys.filter((k) => k.kty === kty);
+  if (kid) return candidates.find((k) => k.kid === kid) ?? null;
+  // No `kid` in the header: only unambiguous when the issuer publishes a
+  // single key of that type. Picking one of several would mean trying
+  // keys until one matches, which turns a malformed token into work.
+  return candidates.length === 1 ? (candidates[0] as ParsedJwk) : null;
+}
+
+function parseJwk(raw: unknown): ParsedJwk | null {
+  if (!raw || typeof raw !== "object") return null;
+  const jwk = raw as Record<string, unknown>;
+  const kty = jwk.kty;
+  if (typeof kty !== "string") return null;
+  const str = (k: string) => (typeof jwk[k] === "string" ? (jwk[k] as string) : undefined);
+
+  if (kty === "RSA") {
+    const n = str("n");
+    const e = str("e");
+    if (!n || !e) return null;
+    return { kty, n, e, kid: str("kid"), alg: str("alg") };
+  }
+  if (kty === "EC") {
+    const crv = str("crv");
+    const x = str("x");
+    const y = str("y");
+    if (!crv || !x || !y) return null;
+    return { kty, crv, x, y, kid: str("kid"), alg: str("alg") };
+  }
+  return null;
+}
+
+async function verifySignature(
+  jwk: ParsedJwk,
+  alg: SupportedAlg,
+  parts: JwtParts,
+): Promise<boolean> {
+  try {
+    // Hand WebCrypto only the fields the key type needs. Passing the
+    // issuer's JWK through verbatim risks `use` / `key_ops` combinations
+    // that some runtimes reject outright.
+    if (alg === "RS256") {
+      const key = await crypto.subtle.importKey(
+        "jwk",
+        { kty: "RSA", n: jwk.n, e: jwk.e, ext: true },
+        { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+        false,
+        ["verify"],
+      );
+      return await crypto.subtle.verify(
+        { name: "RSASSA-PKCS1-v1_5" },
+        key,
+        parts.signature,
+        parts.signingInput,
+      );
+    }
+
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      { kty: "EC", crv: jwk.crv, x: jwk.x, y: jwk.y, ext: true },
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      key,
+      parts.signature,
+      parts.signingInput,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Split and decode a compact JWS. Returns null for anything that is not
+ * three base64url segments with JSON in the first two.
+ */
+function parseJwt(token: string): JwtParts | null {
+  let raw = token.trim();
+  if (raw.toLowerCase().startsWith("bearer ")) raw = raw.slice(7).trim();
+  const segments = raw.split(".");
+  if (segments.length !== 3) return null;
+  const [h, p, s] = segments as [string, string, string];
+  if (!h || !p || !s) return null;
+  try {
+    const header = JSON.parse(new TextDecoder().decode(base64UrlToBytes(h))) as unknown;
+    const payload = JSON.parse(new TextDecoder().decode(base64UrlToBytes(p))) as unknown;
+    if (!isPlainObject(header) || !isPlainObject(payload)) return null;
+    return {
+      header,
+      payload,
+      signingInput: new TextEncoder().encode(`${h}.${p}`),
+      signature: base64UrlToBytes(s),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAudience(aud: unknown): string | null {
+  if (typeof aud === "string" && aud.length > 0) return aud;
+  if (Array.isArray(aud) && aud.length === 1 && typeof aud[0] === "string" && aud[0].length > 0) {
+    return aud[0];
+  }
+  return null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function base64UrlToBytes(input: string): Uint8Array<ArrayBuffer> {
+  const padded = input.padEnd(input.length + ((4 - (input.length % 4)) % 4), "=");
+  const b64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+  const decoded = Buffer.from(b64, "base64");
+  // Copy into a plain ArrayBuffer-backed view: WebCrypto's BufferSource
+  // does not accept the SharedArrayBuffer-capable type Buffer carries.
+  const bytes = new Uint8Array(decoded.byteLength);
+  bytes.set(decoded);
+  return bytes;
+}

--- a/src/middleware/builtin/impersonator-verify/factory.ts
+++ b/src/middleware/builtin/impersonator-verify/factory.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
+import { GoogleTokeninfoVerifier } from "@/middleware/auth/google-tokeninfo.ts";
+import { CompositeVerifier, JwksVerifier } from "@/middleware/auth/jwks.ts";
+import type { IdTokenVerifier } from "@/middleware/auth/types.ts";
 import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
 import { ImpersonatorVerifyMiddleware } from "./middleware.ts";
 import type {
   ImpersonatorRequirement,
+  ImpersonatorVerifierKind,
   ImpersonatorVerifyEnforce,
   ImpersonatorVerifyOptions,
 } from "./types.ts";
@@ -18,10 +22,24 @@ const requirementSchema: z.ZodType<ImpersonatorRequirement> = z.union([
   z.literal("optional"),
 ]);
 
+const verifierKindSchema: z.ZodType<ImpersonatorVerifierKind> = z.union([
+  z.literal("google-tokeninfo"),
+  z.literal("jwks"),
+]);
+
+const jwksIssuerSchema = z.object({
+  issuer: z.string().min(1),
+  jwksUri: z.string().min(1),
+});
+
 const optionsSchema = z.object({
   enforce: enforceSchema.default("deny"),
   requirement: requirementSchema.default("optional"),
   expectedAudiences: z.array(z.string().min(1)).default([]),
+  verifiers: z.array(verifierKindSchema).min(1).default(["google-tokeninfo"]),
+  jwksIssuers: z.array(jwksIssuerSchema).default([]),
+  identityClaim: z.string().min(1).default("email"),
+  emailVerifiedClaim: z.string().default("email_verified"),
 });
 
 function splitList(raw: string | undefined): string[] | undefined {
@@ -30,6 +48,55 @@ function splitList(raw: string | undefined): string[] | undefined {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/**
+ * Parse `iss=https://.../jwks,iss2=https://.../jwks`. Split on the first
+ * `=` only, since an issuer is frequently a URL and a JWKS URL can carry
+ * a query string.
+ */
+function parseJwksIssuers(raw: string | undefined) {
+  const entries = splitList(raw);
+  if (!entries) return undefined;
+  return entries.map((entry) => {
+    const at = entry.indexOf("=");
+    if (at <= 0 || at === entry.length - 1) {
+      throw new Error(`Invalid JWKS issuer mapping "${entry}"; expected "<issuer>=<jwks-url>".`);
+    }
+    return {
+      issuer: entry.slice(0, at).trim(),
+      jwksUri: entry.slice(at + 1).trim(),
+    };
+  });
+}
+
+/**
+ * Assemble the verifier chain from configuration. Kept separate from the
+ * middleware so the middleware stays unaware of which issuers exist.
+ */
+function buildVerifier(options: {
+  verifiers: ImpersonatorVerifierKind[];
+  jwksIssuers: Array<{ issuer: string; jwksUri: string }>;
+  identityClaim: string;
+  emailVerifiedClaim: string;
+}): IdTokenVerifier {
+  const chain = options.verifiers.map((kind): IdTokenVerifier => {
+    if (kind === "google-tokeninfo") return new GoogleTokeninfoVerifier();
+    if (options.jwksIssuers.length === 0) {
+      // Fail loudly at startup rather than build a verifier that silently
+      // rejects every token it is handed.
+      throw new Error(
+        "impersonator-verify: the jwks verifier is enabled but no issuers are configured " +
+          "(set N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS).",
+      );
+    }
+    return new JwksVerifier({
+      issuers: options.jwksIssuers,
+      identityClaim: options.identityClaim,
+      emailVerifiedClaim: options.emailVerifiedClaim,
+    });
+  });
+  return chain.length === 1 ? (chain[0] as IdTokenVerifier) : new CompositeVerifier(chain);
 }
 
 function fromEnv(env: NodeJS.ProcessEnv): Partial<ImpersonatorVerifyOptions> {
@@ -42,6 +109,18 @@ function fromEnv(env: NodeJS.ProcessEnv): Partial<ImpersonatorVerifyOptions> {
   }
   const aud = splitList(env.N8N_IMPERSONATOR_VERIFY_EXPECTED_AUDIENCES);
   if (aud) out.expectedAudiences = aud;
+  const verifiers = splitList(env.N8N_IMPERSONATOR_VERIFY_VERIFIERS);
+  if (verifiers) out.verifiers = verifiers as ImpersonatorVerifierKind[];
+  const issuers = parseJwksIssuers(env.N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS);
+  if (issuers) out.jwksIssuers = issuers;
+  if (env.N8N_IMPERSONATOR_VERIFY_IDENTITY_CLAIM) {
+    out.identityClaim = env.N8N_IMPERSONATOR_VERIFY_IDENTITY_CLAIM;
+  }
+  // Compared against undefined, not truthiness: an empty value is the
+  // documented way to turn the check off.
+  if (env.N8N_IMPERSONATOR_VERIFY_EMAIL_VERIFIED_CLAIM !== undefined) {
+    out.emailVerifiedClaim = env.N8N_IMPERSONATOR_VERIFY_EMAIL_VERIFIED_CLAIM;
+  }
   return out;
 }
 
@@ -58,6 +137,16 @@ function fromCLI(opts: Record<string, unknown>): Partial<ImpersonatorVerifyOptio
   }
   const aud = list("impersonatorVerifyExpectedAudiences");
   if (aud) out.expectedAudiences = aud;
+  const verifiers = list("impersonatorVerifyVerifiers");
+  if (verifiers) out.verifiers = verifiers as ImpersonatorVerifierKind[];
+  const issuers = parseJwksIssuers(s("impersonatorVerifyJwksIssuers"));
+  if (issuers) out.jwksIssuers = issuers;
+  if (s("impersonatorVerifyIdentityClaim")) {
+    out.identityClaim = s("impersonatorVerifyIdentityClaim");
+  }
+  if (typeof opts.impersonatorVerifyEmailVerifiedClaim === "string") {
+    out.emailVerifiedClaim = opts.impersonatorVerifyEmailVerifiedClaim;
+  }
   return out;
 }
 
@@ -66,8 +155,12 @@ export const impersonatorVerifyFactory: ServerMiddlewareFactory<ImpersonatorVeri
   loadFromEnv: fromEnv,
   loadFromCLI: fromCLI,
   build(merged) {
-    const parsed = optionsSchema.parse(merged) as ImpersonatorVerifyOptions;
-    return new ImpersonatorVerifyMiddleware(parsed);
+    const parsed = optionsSchema.parse(merged);
+    const injected = (merged as { verifier?: IdTokenVerifier } | null)?.verifier;
+    return new ImpersonatorVerifyMiddleware({
+      ...(parsed as ImpersonatorVerifyOptions),
+      verifier: injected ?? buildVerifier(parsed),
+    });
   },
 };
 

--- a/src/middleware/builtin/impersonator-verify/types.ts
+++ b/src/middleware/builtin/impersonator-verify/types.ts
@@ -1,7 +1,23 @@
+import type { JwksIssuer } from "@/middleware/auth/jwks.ts";
 import type { IdTokenVerifier } from "@/middleware/auth/types.ts";
 
 /** Same enforce semantics as oauth-verify. */
 export type ImpersonatorVerifyEnforce = "off" | "warn" | "deny";
+
+/**
+ * Verifier implementations the factory can assemble from configuration.
+ *
+ * - `google-tokeninfo` — Google-issued id_tokens, checked against
+ *   Google's tokeninfo endpoint. The historical default.
+ * - `jwks` — any issuer publishing a JWK Set. Needed when the identity is
+ *   asserted by something other than the user's own IdP login: a platform
+ *   signing on behalf of a user it authenticated, a CI system's OIDC
+ *   token, a workload identity.
+ *
+ * Listing both accepts either, which is the normal state for a gateway
+ * serving humans and machines through one header.
+ */
+export type ImpersonatorVerifierKind = "google-tokeninfo" | "jwks";
 
 /**
  * Policy when the request lacks an impersonator token entirely (as opposed
@@ -38,4 +54,28 @@ export interface ImpersonatorVerifyOptions {
    * unset, the factory defaults to `GoogleTokeninfoVerifier`.
    */
   verifier?: IdTokenVerifier;
+  /**
+   * Verifiers to try, in order, when `verifier` is not injected. Order is
+   * a cost decision, not a security one — every verifier declines tokens
+   * that are not its own. Default `["google-tokeninfo"]`.
+   */
+  verifiers?: ImpersonatorVerifierKind[];
+  /**
+   * Issuers the `jwks` verifier accepts, as `iss` → JWKS URL. Required
+   * when `jwks` is selected: an issuer is only trusted because it is
+   * listed here.
+   */
+  jwksIssuers?: JwksIssuer[];
+  /**
+   * Claim the `jwks` verifier reads the caller's identity from. Default
+   * `email`. Point it at another claim for issuers that mint usernames or
+   * opaque subjects instead.
+   */
+  identityClaim?: string;
+  /**
+   * Boolean claim the `jwks` verifier requires to be `true`, following
+   * OIDC's `email_verified`. Empty string disables the check, which is
+   * necessary for issuers that do not emit it.
+   */
+  emailVerifiedClaim?: string;
 }

--- a/tests/middleware/auth/jwks.test.ts
+++ b/tests/middleware/auth/jwks.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, test } from "bun:test";
+import { CompositeVerifier, type FetchLike, JwksVerifier } from "@/middleware/auth/jwks.ts";
+import type { IdTokenVerifier, VerifiedClaim } from "@/middleware/auth/types.ts";
+import {
+  b64url,
+  encodeSegment,
+  generateEcKeys as generateEc,
+  generateRsaKeys as generateRsa,
+  signJwt as sign,
+} from "./jwt-test-keys.ts";
+
+/**
+ * These tests sign with real keys rather than stubbing the crypto. A
+ * verifier that is only ever handed tokens a mock declared valid proves
+ * nothing about whether it would accept a forged one.
+ */
+
+const ISSUER = "signer@example.com";
+const JWKS_URI = "https://keys.example.com/jwks";
+const AUDIENCE = "example-gateway";
+
+/** Claims a well-behaved issuer emits. `now` is fixed so tests are stable. */
+const NOW_MS = 1_700_000_000_000;
+const NOW_SEC = Math.floor(NOW_MS / 1000);
+
+function claims(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iss: ISSUER,
+    sub: "user@example.com",
+    email: "user@example.com",
+    email_verified: true,
+    aud: AUDIENCE,
+    iat: NOW_SEC,
+    exp: NOW_SEC + 300,
+    ...extra,
+  };
+}
+
+/** JWKS endpoint stub that counts how many times it was hit. */
+function jwksEndpoint(jwks: Array<Record<string, unknown>>) {
+  const state = { calls: 0, keys: jwks };
+  const fetcher: FetchLike = async (url) => {
+    state.calls++;
+    if (url !== JWKS_URI) return new Response("not found", { status: 404 });
+    return new Response(JSON.stringify({ keys: state.keys }), { status: 200 });
+  };
+  return { fetcher, state };
+}
+
+function verifierFor(
+  fetcher: FetchLike,
+  opts: Partial<ConstructorParameters<typeof JwksVerifier>[0]> = {},
+): JwksVerifier {
+  return new JwksVerifier({
+    issuers: [{ issuer: ISSUER, jwksUri: JWKS_URI }],
+    fetcher,
+    now: () => NOW_MS,
+    ...opts,
+  });
+}
+
+describe("JwksVerifier: accepts what the listed issuer signed", () => {
+  test("verifies an RS256 assertion and surfaces its claims", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const verified = await verifierFor(fetcher).verify(await sign(keys, claims()));
+
+    expect(verified).not.toBeNull();
+    expect(verified?.email).toBe("user@example.com");
+    expect(verified?.emailVerified).toBe(true);
+    expect(verified?.aud).toBe(AUDIENCE);
+    expect(verified?.iss).toBe(ISSUER);
+    expect(verified?.sub).toBe("user@example.com");
+    expect(verified?.exp).toBe(NOW_SEC + 300);
+  });
+
+  test("verifies an ES256 assertion", async () => {
+    const keys = await generateEc("e1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims(), { alg: "ES256" });
+
+    expect(await verifierFor(fetcher).verify(token)).not.toBeNull();
+  });
+
+  test("accepts a single-element array audience", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ aud: [AUDIENCE] }));
+
+    expect((await verifierFor(fetcher).verify(token))?.aud).toBe(AUDIENCE);
+  });
+
+  test("accepts a key published without a kid when it is the only one", async () => {
+    const keys = await generateRsa("unused");
+    const { kid: _kid, ...noKid } = keys.publicJwk;
+    const { fetcher } = jwksEndpoint([noKid]);
+    const token = await sign(keys, claims(), { header: { kid: undefined } });
+
+    expect(await verifierFor(fetcher).verify(token)).not.toBeNull();
+  });
+});
+
+describe("JwksVerifier: rejects forgeries", () => {
+  test("rejects a token whose signature was tampered with", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims());
+    const [h, p] = token.split(".");
+    const forged = `${h}.${p}.${b64url(new Uint8Array(256))}`;
+
+    expect(await verifierFor(fetcher).verify(forged)).toBeNull();
+  });
+
+  test("rejects a payload edited after signing", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims());
+    const [h, , s] = token.split(".");
+    const swapped = `${h}.${encodeSegment(claims({ email: "attacker@example.com" }))}.${s}`;
+
+    expect(await verifierFor(fetcher).verify(swapped)).toBeNull();
+  });
+
+  test("rejects a token signed by a key the issuer does not publish", async () => {
+    const published = await generateRsa("k1");
+    const attacker = await generateRsa("k1"); // same kid, different key
+    const { fetcher } = jwksEndpoint([published.publicJwk]);
+
+    expect(await verifierFor(fetcher).verify(await sign(attacker, claims()))).toBeNull();
+  });
+
+  test("rejects alg=none", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const header = { alg: "none", kid: "k1", typ: "JWT" };
+    const unsigned = `${encodeSegment(header)}.${encodeSegment(claims())}.`;
+
+    expect(await verifierFor(fetcher).verify(unsigned)).toBeNull();
+  });
+
+  test("rejects an HMAC alg even when the header claims the published kid", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const header = { alg: "HS256", kid: "k1", typ: "JWT" };
+    const token = `${encodeSegment(header)}.${encodeSegment(claims())}.${b64url(new Uint8Array(32))}`;
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+
+  test("rejects an RS256 header pointing at an EC key", async () => {
+    const ec = await generateEc("k1");
+    const rsa = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([ec.publicJwk]);
+
+    expect(await verifierFor(fetcher).verify(await sign(rsa, claims()))).toBeNull();
+  });
+
+  test("rejects malformed tokens", async () => {
+    const { fetcher } = jwksEndpoint([]);
+    const verifier = verifierFor(fetcher);
+
+    expect(await verifier.verify("")).toBeNull();
+    expect(await verifier.verify("not-a-jwt")).toBeNull();
+    expect(await verifier.verify("only.two")).toBeNull();
+    expect(await verifier.verify("bm90LWpzb24.bm90LWpzb24.c2ln")).toBeNull();
+  });
+
+  test("rejects an unknown kid without letting it hammer the issuer", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher, state } = jwksEndpoint([keys.publicJwk]);
+    const verifier = verifierFor(fetcher);
+    const token = await sign(keys, claims(), { header: { kid: "nope" } });
+
+    expect(await verifier.verify(token)).toBeNull();
+    expect(await verifier.verify(token)).toBeNull();
+    // One fetch for the cold cache; the second lookup is inside the
+    // refetch floor and must not reach the network again.
+    expect(state.calls).toBe(1);
+  });
+
+  test("rejects when the key set cannot be fetched", async () => {
+    const keys = await generateRsa("k1");
+    const failing: FetchLike = async () => new Response("boom", { status: 500 });
+
+    expect(await verifierFor(failing).verify(await sign(keys, claims()))).toBeNull();
+  });
+
+  test("rejects when no kid is present and the issuer publishes several keys", async () => {
+    const a = await generateRsa("a");
+    const b = await generateRsa("b");
+    const { fetcher } = jwksEndpoint([a.publicJwk, b.publicJwk]);
+    const token = await sign(a, claims(), { header: { kid: undefined } });
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+});
+
+describe("JwksVerifier: issuer allowlist is the trust boundary", () => {
+  test("rejects an unlisted issuer", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ iss: "other@example.com" }));
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+
+  test("rejects an unlisted issuer without any network call", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher, state } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ iss: "other@example.com" }));
+
+    await verifierFor(fetcher).verify(token);
+    // This is what makes the verifier safe to place first in a chain: a
+    // token that was never ours costs nothing to decline.
+    expect(state.calls).toBe(0);
+  });
+
+  test("rejects everything when no issuer is configured", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const verifier = verifierFor(fetcher, { issuers: [] });
+
+    expect(await verifier.verify(await sign(keys, claims()))).toBeNull();
+  });
+});
+
+describe("JwksVerifier: time window", () => {
+  test("rejects an expired token", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ exp: NOW_SEC - 120 }));
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+
+  test("tolerates expiry inside the configured skew", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ exp: NOW_SEC - 30 }));
+
+    expect(await verifierFor(fetcher, { clockSkewSec: 60 }).verify(token)).not.toBeNull();
+  });
+
+  test("rejects a token with no expiry at all", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const { exp: _exp, ...noExp } = claims();
+
+    expect(await verifierFor(fetcher).verify(await sign(keys, noExp))).toBeNull();
+  });
+
+  test("rejects a token that is not valid yet", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ nbf: NOW_SEC + 600 }));
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+
+  test("rejects a token issued far in the future", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ iat: NOW_SEC + 600, exp: NOW_SEC + 900 }));
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+});
+
+describe("JwksVerifier: claim policy is configurable", () => {
+  test("rejects a multi-valued audience rather than picking one", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const token = await sign(keys, claims({ aud: [AUDIENCE, "other"] }));
+
+    expect(await verifierFor(fetcher).verify(token)).toBeNull();
+  });
+
+  test("rejects when the email_verified convention is not honored", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+
+    expect(
+      await verifierFor(fetcher).verify(await sign(keys, claims({ email_verified: false }))),
+    ).toBeNull();
+    const { email_verified: _ev, ...missing } = claims();
+    expect(await verifierFor(fetcher).verify(await sign(keys, missing))).toBeNull();
+  });
+
+  test("skips the email_verified check when the claim name is cleared", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const { email_verified: _ev, ...missing } = claims();
+    const verifier = verifierFor(fetcher, { emailVerifiedClaim: "" });
+
+    expect(await verifier.verify(await sign(keys, missing))).not.toBeNull();
+  });
+
+  test("reads the identity from a configured claim", async () => {
+    // The shape a CI OIDC token takes: a username, no email anywhere.
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const { email: _e, email_verified: _ev, ...ci } = claims();
+    const token = await sign(keys, { ...ci, actor: "octocat" });
+    const verifier = verifierFor(fetcher, { identityClaim: "actor", emailVerifiedClaim: "" });
+
+    expect((await verifier.verify(token))?.email).toBe("octocat");
+  });
+
+  test("rejects when the identity claim is absent or not a string", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher } = jwksEndpoint([keys.publicJwk]);
+    const { email: _e, ...noEmail } = claims();
+
+    expect(await verifierFor(fetcher).verify(await sign(keys, noEmail))).toBeNull();
+    expect(await verifierFor(fetcher).verify(await sign(keys, claims({ email: 42 })))).toBeNull();
+  });
+});
+
+describe("JwksVerifier: key set handling", () => {
+  test("caches the key set across verifications", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher, state } = jwksEndpoint([keys.publicJwk]);
+    const verifier = verifierFor(fetcher);
+
+    await verifier.verify(await sign(keys, claims()));
+    await verifier.verify(await sign(keys, claims()));
+
+    expect(state.calls).toBe(1);
+  });
+
+  test("collapses concurrent cold lookups into one fetch", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher, state } = jwksEndpoint([keys.publicJwk]);
+    const verifier = verifierFor(fetcher);
+    const token = await sign(keys, claims());
+
+    const results = await Promise.all([verifier.verify(token), verifier.verify(token)]);
+
+    expect(results.every((r) => r !== null)).toBe(true);
+    expect(state.calls).toBe(1);
+  });
+
+  test("picks up a rotated key once the refetch floor has passed", async () => {
+    const oldKeys = await generateRsa("old");
+    const newKeys = await generateRsa("new");
+    const { fetcher, state } = jwksEndpoint([oldKeys.publicJwk]);
+    let clock = NOW_MS;
+    const verifier = verifierFor(fetcher, {
+      now: () => clock,
+      // Long TTL so the refetch is attributable to the unknown kid alone.
+      jwksCacheTtlMs: 60 * 60 * 1000,
+      jwksMinRefetchMs: 30_000,
+    });
+
+    await verifier.verify(await sign(oldKeys, claims()));
+    expect(state.calls).toBe(1);
+
+    state.keys = [newKeys.publicJwk];
+    clock += 60_000;
+
+    expect(await verifier.verify(await sign(newKeys, claims()))).not.toBeNull();
+    expect(state.calls).toBe(2);
+  });
+
+  test("refetches after the cache TTL expires", async () => {
+    const keys = await generateRsa("k1");
+    const { fetcher, state } = jwksEndpoint([keys.publicJwk]);
+    let clock = NOW_MS;
+    const verifier = verifierFor(fetcher, { now: () => clock, jwksCacheTtlMs: 1_000 });
+
+    await verifier.verify(await sign(keys, claims()));
+    clock += 5_000;
+    await verifier.verify(await sign(keys, claims()));
+
+    expect(state.calls).toBe(2);
+  });
+});
+
+describe("CompositeVerifier", () => {
+  const accept: VerifiedClaim = { aud: "a", emailVerified: true, email: "a@example.com" };
+
+  function counting(result: VerifiedClaim | null) {
+    const state = { calls: 0 };
+    const verifier: IdTokenVerifier = {
+      verify: async () => {
+        state.calls++;
+        return result;
+      },
+    };
+    return { verifier, state };
+  }
+
+  test("returns the first acceptance and stops there", async () => {
+    const first = counting(accept);
+    const second = counting(accept);
+
+    const claim = await new CompositeVerifier([first.verifier, second.verifier]).verify("t");
+
+    expect(claim).toEqual(accept);
+    expect(second.state.calls).toBe(0);
+  });
+
+  test("falls through to the next verifier on rejection", async () => {
+    const first = counting(null);
+    const second = counting(accept);
+
+    const claim = await new CompositeVerifier([first.verifier, second.verifier]).verify("t");
+
+    expect(claim).toEqual(accept);
+    expect(first.state.calls).toBe(1);
+  });
+
+  test("rejects when every verifier rejects", async () => {
+    const composite = new CompositeVerifier([counting(null).verifier, counting(null).verifier]);
+
+    expect(await composite.verify("t")).toBeNull();
+  });
+
+  test("rejects when there are no verifiers at all", async () => {
+    expect(await new CompositeVerifier([]).verify("t")).toBeNull();
+  });
+});

--- a/tests/middleware/auth/jwt-test-keys.ts
+++ b/tests/middleware/auth/jwt-test-keys.ts
@@ -1,0 +1,62 @@
+/**
+ * Real key generation and JWS signing for verifier tests.
+ *
+ * Shared rather than stubbed on purpose: a verifier only proves it
+ * rejects forgeries if the test can actually produce one.
+ */
+
+export type TestKeys = { privateKey: CryptoKey; publicJwk: Record<string, unknown> };
+
+export async function generateRsaKeys(kid: string): Promise<TestKeys> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.publicKey)) as Record<string, unknown>;
+  return { privateKey: pair.privateKey, publicJwk: { ...jwk, kid, alg: "RS256", use: "sig" } };
+}
+
+export async function generateEcKeys(kid: string): Promise<TestKeys> {
+  const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.publicKey)) as Record<string, unknown>;
+  return { privateKey: pair.privateKey, publicJwk: { ...jwk, kid, alg: "ES256", use: "sig" } };
+}
+
+export function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+export function encodeSegment(value: unknown): string {
+  return b64url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/**
+ * Sign a compact JWS. `header` overrides are shallow-merged so a test can
+ * misdeclare `alg` / `kid` while still producing a real signature.
+ */
+export async function signJwt(
+  keys: TestKeys,
+  payload: Record<string, unknown>,
+  overrides: { header?: Record<string, unknown>; alg?: "RS256" | "ES256" } = {},
+): Promise<string> {
+  const alg = overrides.alg ?? "RS256";
+  const header = { alg, kid: keys.publicJwk.kid, typ: "JWT", ...overrides.header };
+  const signingInput = `${encodeSegment(header)}.${encodeSegment(payload)}`;
+  const params =
+    alg === "RS256" ? { name: "RSASSA-PKCS1-v1_5" } : { name: "ECDSA", hash: "SHA-256" };
+  const signature = await crypto.subtle.sign(
+    params,
+    keys.privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${b64url(new Uint8Array(signature))}`;
+}

--- a/tests/middleware/builtin/impersonator-verify/jwks-wiring.test.ts
+++ b/tests/middleware/builtin/impersonator-verify/jwks-wiring.test.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { impersonatorVerifyFactory } from "@/middleware/builtin/impersonator-verify/factory.ts";
+import type { ServerMiddleware, ServerMiddlewareContext } from "@/middleware/types.ts";
+import { generateRsaKeys, signJwt, type TestKeys } from "../../auth/jwt-test-keys.ts";
+
+/**
+ * The contract a signing platform has to meet, exercised the way
+ * production reaches it: environment variables in, a real HTTP JWKS
+ * endpoint, a real signature.
+ *
+ * Everything below is what an integrating platform must get right. If a
+ * change here breaks, the platform's minted assertions stop being
+ * accepted — so these cases double as the wire spec.
+ */
+
+const ISSUER = "signer@example.com";
+const AUDIENCE = "example-gateway";
+const ASSERTED_USER = "user@example.com";
+const TRUSTED_BEARER = "caller@example.com";
+
+let keys: TestKeys;
+let otherKeys: TestKeys;
+let server: ReturnType<typeof Bun.serve>;
+let jwksUri: string;
+
+beforeAll(async () => {
+  keys = await generateRsaKeys("k1");
+  otherKeys = await generateRsaKeys("k1");
+  server = Bun.serve({
+    port: 0,
+    fetch: () => Response.json({ keys: [keys.publicJwk] }),
+  });
+  jwksUri = `http://127.0.0.1:${server.port}/jwks`;
+});
+
+afterAll(async () => {
+  await server.stop(true);
+});
+
+function envFor(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    N8N_IMPERSONATOR_VERIFY_ENFORCE: "deny",
+    N8N_IMPERSONATOR_VERIFY_REQUIREMENT: "require",
+    N8N_IMPERSONATOR_VERIFY_EXPECTED_AUDIENCES: AUDIENCE,
+    N8N_IMPERSONATOR_VERIFY_VERIFIERS: "jwks",
+    N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS: `${ISSUER}=${jwksUri}`,
+    ...overrides,
+  };
+}
+
+function buildFromEnv(overrides: Record<string, string> = {}): ServerMiddleware {
+  const env = envFor(overrides);
+  return impersonatorVerifyFactory.build(impersonatorVerifyFactory.loadFromEnv(env));
+}
+
+/** A request that has already cleared a trusted bearer, as oauth-verify leaves it. */
+function ctxWith(token: string): ServerMiddlewareContext {
+  const headers = new Headers({ "X-Impersonator-Id-Token": token });
+  const ctx: ServerMiddlewareContext = {
+    workflow: null,
+    mode: "proxy",
+    request: new Request("https://gateway.local/api/v1/workflows", { headers }),
+    identity: TRUSTED_BEARER,
+    auth: {
+      bearer: { email: TRUSTED_BEARER, aud: "https://gateway.local", verified: true },
+      effective: { email: TRUSTED_BEARER, layer: "bearer" },
+    },
+  };
+  (ctx as { __oauthVerifyBearerIsTrusted?: boolean }).__oauthVerifyBearerIsTrusted = true;
+  return ctx;
+}
+
+function assertion(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    iss: ISSUER,
+    sub: ASSERTED_USER,
+    email: ASSERTED_USER,
+    email_verified: true,
+    aud: AUDIENCE,
+    iat: nowSec,
+    exp: nowSec + 300,
+    ...extra,
+  };
+}
+
+describe("impersonator-verify wired to jwks from the environment", () => {
+  test("accepts a correctly minted assertion and rewrites the identity", async () => {
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(keys, assertion()));
+
+    const verdict = await mw.evaluate(ctx);
+
+    expect(verdict.block).toBe(false);
+    // Downstream authz reads this. If it still said the caller, the whole
+    // per-user gate would be judging the platform instead of the person.
+    expect(ctx.identity).toBe(ASSERTED_USER);
+    expect(ctx.auth?.effective).toEqual({ email: ASSERTED_USER, layer: "impersonator" });
+    expect(ctx.auth?.impersonator?.email).toBe(ASSERTED_USER);
+  });
+
+  test("rejects an assertion signed by a key the issuer does not publish", async () => {
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(otherKeys, assertion()));
+
+    const verdict = await mw.evaluate(ctx);
+
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.status).toBe(401);
+    expect(ctx.identity).toBe(TRUSTED_BEARER);
+  });
+
+  test("rejects an assertion from an issuer that is not configured", async () => {
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(keys, assertion({ iss: "rogue@example.com" })));
+
+    expect((await mw.evaluate(ctx)).block).toBe(true);
+  });
+
+  test("rejects an assertion minted for a different audience", async () => {
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(keys, assertion({ aud: "some-other-gateway" })));
+
+    expect((await mw.evaluate(ctx)).block).toBe(true);
+  });
+
+  test("rejects an expired assertion", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(keys, assertion({ exp: nowSec - 3600 })));
+
+    expect((await mw.evaluate(ctx)).block).toBe(true);
+  });
+
+  test("rejects a valid assertion when the bearer is not trusted to forward one", async () => {
+    const mw = buildFromEnv();
+    const ctx = ctxWith(await signJwt(keys, assertion()));
+    (ctx as { __oauthVerifyBearerIsTrusted?: boolean }).__oauthVerifyBearerIsTrusted = false;
+
+    // The signature is genuine; the relay is not authorized. Both gates
+    // have to hold, otherwise anyone who can reach the gateway could
+    // replay a leaked assertion.
+    expect((await mw.evaluate(ctx)).block).toBe(true);
+  });
+
+  test("honors a non-email identity claim with the verified-claim check cleared", async () => {
+    const mw = buildFromEnv({
+      N8N_IMPERSONATOR_VERIFY_IDENTITY_CLAIM: "actor",
+      N8N_IMPERSONATOR_VERIFY_EMAIL_VERIFIED_CLAIM: "",
+    });
+    const { email: _e, email_verified: _v, ...rest } = assertion();
+    const ctx = ctxWith(await signJwt(keys, { ...rest, actor: "octocat" }));
+
+    expect((await mw.evaluate(ctx)).block).toBe(false);
+    expect(ctx.identity).toBe("octocat");
+  });
+
+  test("keeps accepting jwks assertions when chained behind another verifier", async () => {
+    const mw = buildFromEnv({ N8N_IMPERSONATOR_VERIFY_VERIFIERS: "jwks,google-tokeninfo" });
+    const ctx = ctxWith(await signJwt(keys, assertion()));
+
+    // Listing jwks first means the platform's own assertion never costs a
+    // round trip to a foreign issuer's endpoint.
+    expect((await mw.evaluate(ctx)).block).toBe(false);
+    expect(ctx.identity).toBe(ASSERTED_USER);
+  });
+});
+
+describe("impersonator-verify configuration errors surface at startup", () => {
+  test("refuses to build a jwks verifier with no issuers", () => {
+    expect(() =>
+      impersonatorVerifyFactory.build(
+        impersonatorVerifyFactory.loadFromEnv({
+          N8N_IMPERSONATOR_VERIFY_VERIFIERS: "jwks",
+        }),
+      ),
+    ).toThrow(/no issuers are configured/);
+  });
+
+  test("refuses a malformed issuer mapping", () => {
+    expect(() =>
+      impersonatorVerifyFactory.loadFromEnv({
+        N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS: "missing-the-url",
+      }),
+    ).toThrow(/expected "<issuer>=<jwks-url>"/);
+  });
+
+  test("refuses an unknown verifier name", () => {
+    expect(() =>
+      impersonatorVerifyFactory.build(
+        impersonatorVerifyFactory.loadFromEnv({
+          N8N_IMPERSONATOR_VERIFY_VERIFIERS: "totally-made-up",
+        }),
+      ),
+    ).toThrow();
+  });
+});
+
+describe("impersonator-verify env parsing", () => {
+  test("splits the issuer mapping on the first separator only", () => {
+    const partial = impersonatorVerifyFactory.loadFromEnv({
+      N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS:
+        "https://issuer.example.com=https://keys.example.com/jwks?v=2",
+    });
+    expect(partial.jwksIssuers).toEqual([
+      { issuer: "https://issuer.example.com", jwksUri: "https://keys.example.com/jwks?v=2" },
+    ]);
+  });
+
+  test("reads multiple issuers", () => {
+    const partial = impersonatorVerifyFactory.loadFromEnv({
+      N8N_IMPERSONATOR_VERIFY_JWKS_ISSUERS:
+        "a@example.com=https://a/jwks,b@example.com=https://b/jwks",
+    });
+    expect(partial.jwksIssuers).toHaveLength(2);
+  });
+
+  test("treats an empty verified-claim as an explicit opt-out, not as unset", () => {
+    const partial = impersonatorVerifyFactory.loadFromEnv({
+      N8N_IMPERSONATOR_VERIFY_EMAIL_VERIFIED_CLAIM: "",
+    });
+    expect(partial.emailVerifiedClaim).toBe("");
+  });
+
+  test("defaults to the Google verifier when nothing is configured", () => {
+    const partial = impersonatorVerifyFactory.loadFromEnv({});
+    expect(partial.verifiers).toBeUndefined();
+    // Building with no overrides must not throw, i.e. the default path is
+    // unchanged for deployments that never heard of jwks.
+    expect(() => impersonatorVerifyFactory.build(partial)).not.toThrow();
+  });
+});


### PR DESCRIPTION
`impersonator-verify` only accepted tokens Google's tokeninfo endpoint vouches for. A platform that authenticates a user and then acts on their behalf has no such token to forward, so it could not name a user at all.

Adds a JWKS verifier — fetch the issuer's published keys, verify the signature locally — selectable and chainable from configuration.

- `iss` -> JWKS URL allowlist is the only source of trust
- unlisted issuers are refused with no network call
- `identityClaim` / `emailVerifiedClaim` for issuers that don't mint OIDC email claims
- `CompositeVerifier` accepts either kind on the same header
- defaults unchanged; no new dependency (WebCrypto)

## Testing

Tests sign with generated keys instead of stubbing crypto, so tampered payloads, foreign signers, `alg=none`, HMAC confusion, key-type mismatch, expiry and unknown `kid` are all exercised against real signatures. 60 new tests; lint and typecheck clean.