### PR TITLE
feat(webhook): call a named webhook node through the authenticated egress path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Proxy** - Transparent HTTP proxy that intercepts workflow saves to the n8n public API and runs lint server-side, blocking violations before they reach n8n
 - **Format** - Auto-organize node positions for cleaner workflow layouts
 - **Test** - Execute CLI tests against workflows via webhook endpoints
+- **Webhook** - List and call a workflow's webhook nodes through the authenticated egress path
 - **Workflow management** - List, get, create, update, delete, activate, and deactivate workflows via the n8n API
 - **Execution management** - List executions, get execution details, delete, retry, and stop executions
 - **Tag management** - List, get, create, update, and delete tags
@@ -336,6 +337,56 @@ n8n-cli test <workflow-id> [options]
 | `--activate` | Automatically activate the workflow if inactive |
 | `--dry-run` | Show webhook URL without executing |
 | `--show-inputs` | Display workflow input parameters without executing |
+
+### `webhook`
+
+Call a workflow's webhook through the CLI's authenticated egress path.
+
+```bash
+n8n-cli webhook list <workflow-id>
+n8n-cli webhook call <workflow-id> --node "<node name>" [options]
+```
+
+**Why this exists, given `curl`.** When n8n sits behind a gateway that
+authenticates callers per request, the credentials are minted by the
+[egress middleware chain](#talking-to-an-authenticating-gateway) inside this
+process. Every other command already goes through it; webhook URLs sit outside
+`/api/v1` and had no way in. Reproducing that outside the CLI means
+reimplementing token minting, impersonation and caching — so the transport is
+the one part that belongs here.
+
+`webhook call` options:
+
+| Option | Description |
+|--------|-------------|
+| `-n, --node <name>` | **Required.** Exact name of the webhook node to call |
+| `-d, --data <json>` | JSON body to send |
+| `--timeout <ms>` | HTTP request timeout in milliseconds (default: 30000) |
+| `--dry-run` | Print the resolved URL without calling it |
+| `--allow-inactive` | Call even when the workflow is inactive |
+
+**`--node` is required on purpose.** The command never searches, guesses, or
+falls back to "the only webhook in the workflow". Every webhook in an n8n
+instance is a live entry point and some are wired to inbound events from other
+systems; a caller that has to name the node cannot fire one it did not mean to.
+Use `webhook list` to see what a workflow exposes.
+
+**No policy beyond that.** This command takes no position on which webhooks are
+safe to call, what they should be named, or whether they ought to return data.
+Those are deployment policy: they differ per organization, and a naming
+convention compiled into a released binary is a convention nobody can change.
+If you are building "let an agent run a workflow on request", put the rules —
+which nodes qualify, whether the response may carry data, who may ask — in the
+layer that owns them, and hand this command a node name.
+
+Set `N8N_WEBHOOK_TOKEN` when the node uses n8n's header auth; it is sent as
+`x-n8n-webhook-token` (override the header with `N8N_WEBHOOK_TOKEN_HEADER`).
+That authenticates the request to n8n itself, separately from the gateway
+credentials the egress middlewares attach.
+
+Compared with [`test`](#test): `test` targets `[CLI Test]` webhooks by
+convention, waits for the execution and reports its status — a development
+affordance. `webhook` addresses any webhook by name and just performs the call.
 
 ### `workflow`
 
@@ -959,7 +1010,10 @@ n8n-cli version
 | `N8N_API_KEY` | n8n API key (required, unless an egress chain supplies credentials — see below) |
 | `N8N_API_TIMEOUT` | Request timeout in milliseconds |
 | `N8N_DEFAULT_PROJECT` | Default project ID for apply |
-| `N8N_CLIENT_MIDDLEWARES` | Comma-separated egress middlewares applied to every API call (see below) |
+| `N8N_CLIENT_MIDDLEWARES` | Comma-separated egress middlewares applied to every request (see below) |
+| `N8N_CLI_TEST_TOKEN` | Shared secret sent as `x-n8n-cli-test-token` by [`test`](#test) |
+| `N8N_WEBHOOK_TOKEN` | Shared secret sent by [`webhook call`](#webhook) for n8n's header auth |
+| `N8N_WEBHOOK_TOKEN_HEADER` | Header name for the above (default: `x-n8n-webhook-token`) |
 | `APPLY_FILTER_BY_TAGS` | Comma-separated tags to filter apply targets |
 | `CHECKS_FILTER_BY_TAGS` | Comma-separated tags to filter lint/fmt targets (AND condition) |
 | `PROXY_FILTER_BY_TAGS` | Comma-separated tags to scope proxy middleware enforcement (AND condition) |
@@ -969,7 +1023,8 @@ n8n-cli version
 When n8n sits behind a gateway that authenticates callers per request — for example
 the [`proxy`](#proxy) subcommand deployed in front of it, or an identity-aware proxy —
 point `N8N_API_URL` at the gateway and enable the egress middlewares it expects.
-They run on every API call the CLI makes, so ordinary commands (`apply`, `import`,
+They run on every request the CLI makes — API calls and the webhook calls behind
+`test` / `webhook call` alike — so ordinary commands (`apply`, `import`,
 `workflow ...`) work unchanged:
 
 ```bash

--- a/src/api/webhook.ts
+++ b/src/api/webhook.ts
@@ -1,0 +1,66 @@
+import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
+
+/** Options for a single webhook call. */
+export interface WebhookCallOptions {
+  method: string;
+  /** JSON-serialized as the request body. Omit for a bodyless call. */
+  data?: unknown;
+  timeoutMs: number;
+  /** Extra request headers, applied before the middleware chain runs. */
+  headers?: Record<string, string>;
+  /**
+   * Egress middlewares, in order.
+   *
+   * Webhook calls do not go through `Client` — the URL lives outside
+   * `/api/v1` — but they leave the machine through the same door, so they need
+   * the same credentials. Without this, pointing `N8N_API_URL` at an
+   * authenticating gateway would leave every webhook call as the one
+   * unauthenticated request the CLI makes, rejected at the edge.
+   */
+  clientMiddlewares?: ClientMiddleware[];
+}
+
+/** Raw outcome of a webhook call. Status is reported, never interpreted. */
+export interface WebhookCallResult {
+  status: number;
+  body: string;
+}
+
+/** POSTs (or GETs, ...) a webhook URL, applying the egress middleware chain. */
+export async function callWebhook(
+  url: string,
+  opts: WebhookCallOptions,
+): Promise<WebhookCallResult> {
+  const headers = new Headers({
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    ...(opts.headers ?? {}),
+  });
+
+  const chain = opts.clientMiddlewares ?? [];
+  if (chain.length > 0) {
+    await runClientPipeline(chain, headers, {
+      method: opts.method,
+      pathname: new URL(url).pathname,
+      upstreamUrl: url,
+    });
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+
+  try {
+    const resp = await fetch(url, {
+      method: opts.method,
+      headers,
+      body: opts.data !== undefined ? JSON.stringify(opts.data) : undefined,
+      signal: controller.signal,
+    });
+    return { status: resp.status, body: await resp.text() };
+  } catch (e) {
+    throw new Error(`webhook request failed: ${e instanceof Error ? e.message : String(e)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -55,7 +55,12 @@ export function registerTestCommand(program: Command): void {
         }
       }
 
-      const executor = new Executor(ctx.config.apiURL, ctx.workflowService, ctx.executionService);
+      const executor = new Executor(
+        ctx.config.apiURL,
+        ctx.workflowService,
+        ctx.executionService,
+        ctx.clientMiddlewares,
+      );
 
       const result = await executor.execute(workflow, {
         data,

--- a/src/cli/commands/webhook.ts
+++ b/src/cli/commands/webhook.ts
@@ -1,0 +1,192 @@
+import type { Command } from "commander";
+import type { Workflow } from "../../api/types.ts";
+import { callWebhook } from "../../api/webhook.ts";
+import {
+  buildWebhookURL,
+  listWebhookNodes,
+  resolveWebhookNode,
+  WebhookNodeNotFoundError,
+} from "../../webhook/resolver.ts";
+import { resolveContext } from "../root.ts";
+
+/**
+ * Registers `webhook`, a primitive for calling a workflow's webhook through
+ * the CLI's authenticated egress path.
+ *
+ * Why this exists at all, given `curl`: when n8n sits behind a gateway that
+ * authenticates callers per request, the credentials are minted by the egress
+ * middleware chain (`N8N_CLIENT_MIDDLEWARES`) inside this process. Every other
+ * command already goes through it; webhook URLs sit outside `/api/v1` and had
+ * no way in. Reproducing the chain outside the CLI means reimplementing token
+ * minting, impersonation and caching — so the one thing that genuinely belongs
+ * here is the transport.
+ *
+ * Everything else is left to the caller. This command takes no position on
+ * which webhooks are safe to call, what they should be named, or whether they
+ * ought to return data: those are deployment policy, they differ per
+ * organization, and a naming convention compiled into a released binary is a
+ * convention nobody can change. Callers that need such a policy enforce it in
+ * the layer that owns it, and pass this command a node name.
+ */
+export function registerWebhookCommand(program: Command): void {
+  const webhook = program
+    .command("webhook")
+    .description("Call a workflow's webhook through the authenticated egress path");
+
+  webhook
+    .command("list")
+    .description("List a workflow's webhook nodes")
+    .argument("<workflow-id>", "Workflow ID")
+    .action(async (workflowId: string) => {
+      const ctx = resolveContext(program);
+      const workflow = await getWorkflow(ctx, workflowId);
+      const nodes = listWebhookNodes(workflow).map((w) => ({
+        node: w.node.name,
+        path: w.path,
+        httpMethod: w.httpMethod,
+        url: buildWebhookURL(ctx.config.apiURL, w.path),
+      }));
+
+      if (ctx.config.output === "json") {
+        console.log(JSON.stringify(nodes, null, 2));
+        return;
+      }
+      if (nodes.length === 0) {
+        console.log("No enabled webhook nodes.");
+        return;
+      }
+      for (const n of nodes) {
+        console.log(`${n.httpMethod}  ${n.node}`);
+        console.log(`      ${n.url}`);
+      }
+    });
+
+  webhook
+    .command("call")
+    .description("Call one named webhook node and return as soon as n8n responds")
+    .argument("<workflow-id>", "Workflow ID")
+    .requiredOption(
+      "-n, --node <name>",
+      "Exact name of the webhook node to call. Required: this command never picks one for you",
+    )
+    .option("-d, --data <json>", "JSON body to send")
+    .option("--timeout <ms>", "HTTP request timeout in milliseconds", "30000")
+    .option("--dry-run", "Print the resolved URL without calling it", false)
+    .option(
+      "--allow-inactive",
+      "Call even if the workflow is inactive (its webhook is probably unregistered)",
+      false,
+    )
+    .action(async (workflowId: string, opts: Record<string, unknown>) => {
+      const ctx = resolveContext(program);
+      const workflow = await getWorkflow(ctx, workflowId);
+
+      let data: unknown;
+      if (typeof opts.data === "string" && opts.data) {
+        try {
+          data = JSON.parse(opts.data);
+        } catch (e) {
+          fail(`invalid JSON data: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+
+      let resolved: ReturnType<typeof resolveWebhookNode>;
+      try {
+        resolved = resolveWebhookNode(workflow, String(opts.node));
+      } catch (e) {
+        if (e instanceof WebhookNodeNotFoundError) {
+          console.error(`Error: ${e.message}`);
+          console.error(
+            `List what this workflow exposes with:\n  n8n-cli webhook list ${workflowId}`,
+          );
+          process.exit(1);
+        }
+        fail(e instanceof Error ? e.message : String(e));
+      }
+
+      const url = buildWebhookURL(ctx.config.apiURL, resolved.path);
+
+      if (opts.dryRun) {
+        report(ctx, { workflowId, node: resolved.node.name, url, dryRun: true }, () => {
+          console.log(`Would call: ${resolved.httpMethod} ${url}`);
+        });
+        return;
+      }
+
+      // An inactive workflow's webhook is not registered, so the call 404s.
+      // Overridable rather than fatal: n8n also serves a test-mode webhook for
+      // an inactive workflow while its editor is open.
+      if (!workflow.active && !opts.allowInactive) {
+        console.error(
+          `Error: workflow "${workflow.name}" (${workflowId}) is not active, so its webhook is probably not registered.`,
+        );
+        console.error("Activate it, or pass --allow-inactive to call anyway.");
+        process.exit(1);
+      }
+
+      let status: number;
+      let body: string;
+      try {
+        ({ status, body } = await callWebhook(url, {
+          method: resolved.httpMethod,
+          data,
+          timeoutMs: Number(opts.timeout),
+          headers: extraHeaders(),
+          clientMiddlewares: ctx.clientMiddlewares,
+        }));
+      } catch (e) {
+        fail(e instanceof Error ? e.message : String(e));
+      }
+
+      report(ctx, { workflowId, node: resolved.node.name, url, status, body }, () => {
+        console.log(`Called: ${resolved.node.name} (${workflowId})`);
+        console.log(`  Status: ${status}`);
+        if (body) console.log(`  Response: ${body.slice(0, 1000)}`);
+      });
+
+      if (status < 200 || status >= 300) process.exit(1);
+    });
+}
+
+/**
+ * Header the caller's own shared secret goes in, when the webhook node uses
+ * n8n's header auth. Separate from anything the egress chain attaches: that
+ * authenticates the caller to a gateway, this authenticates the request to n8n.
+ */
+const WEBHOOK_TOKEN_HEADER = "x-n8n-webhook-token";
+const WEBHOOK_TOKEN_ENV = "N8N_WEBHOOK_TOKEN";
+const WEBHOOK_TOKEN_HEADER_ENV = "N8N_WEBHOOK_TOKEN_HEADER";
+
+function extraHeaders(): Record<string, string> {
+  const token = process.env[WEBHOOK_TOKEN_ENV];
+  if (!token) return {};
+  return { [process.env[WEBHOOK_TOKEN_HEADER_ENV] || WEBHOOK_TOKEN_HEADER]: token };
+}
+
+async function getWorkflow(
+  ctx: ReturnType<typeof resolveContext>,
+  workflowId: string,
+): Promise<Workflow> {
+  try {
+    return await ctx.workflowService.getWorkflow(workflowId);
+  } catch (e) {
+    return fail(`failed to get workflow: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+function report(
+  ctx: ReturnType<typeof resolveContext>,
+  payload: Record<string, unknown>,
+  text: () => void,
+): void {
+  if (ctx.config.output === "json") {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    text();
+  }
+}
+
+function fail(message: string): never {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -29,6 +29,13 @@ export interface GlobalContext {
   executionService: ExecutionService;
   credentialService: CredentialService;
   dataTableService: DataTableService;
+  /**
+   * The egress chain the API client uses, exposed so commands that reach
+   * outside `/api/v1` — webhook calls — send the same credentials. Without it
+   * those would be the only unauthenticated requests the CLI makes, and a
+   * gateway would reject them while every other command worked.
+   */
+  clientMiddlewares: ClientMiddleware[];
 }
 
 /**
@@ -53,10 +60,12 @@ function buildEgressChain(): ClientMiddleware[] {
 }
 
 function createContext(config: Config): GlobalContext {
-  const client = new Client(config.apiURL, config.apiKey, config.timeoutMs, buildEgressChain());
+  const clientMiddlewares = buildEgressChain();
+  const client = new Client(config.apiURL, config.apiKey, config.timeoutMs, clientMiddlewares);
   return {
     config,
     client,
+    clientMiddlewares,
     workflowService: new WorkflowService(client),
     tagService: new TagService(client),
     executionService: new ExecutionService(client),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { registerProxyCommand } from "./cli/commands/proxy.ts";
 import { registerTagCommand } from "./cli/commands/tag.ts";
 import { registerTestCommand } from "./cli/commands/test.ts";
 import { registerTraceCommand } from "./cli/commands/trace.ts";
+import { registerWebhookCommand } from "./cli/commands/webhook.ts";
+
 import { registerWorkflowCommand } from "./cli/commands/workflow.ts";
 import { createProgram } from "./cli/root.ts";
 import { maybeShowUpdateNotice, runUpdateCheck } from "./cli/update-check.ts";
@@ -35,6 +37,7 @@ registerNodeSchemaCommand(program);
 registerFmtCommand(program);
 registerTestCommand(program);
 registerTraceCommand(program);
+registerWebhookCommand(program);
 registerProxyCommand(program);
 
 try {

--- a/src/test/executor.ts
+++ b/src/test/executor.ts
@@ -1,7 +1,9 @@
 import type { Execution, ExecutionService } from "../api/execution-service.ts";
 import { isTerminalStatus } from "../api/execution-service.ts";
 import type { Workflow } from "../api/types.ts";
+import { callWebhook } from "../api/webhook.ts";
 import type { WorkflowService } from "../api/workflow-service.ts";
+import type { ClientMiddleware } from "../middleware/types.ts";
 import { buildWebhookURL, detectTestWebhook, type WebhookInfo } from "./detector.ts";
 
 /** TestOptions represents options for running a workflow test */
@@ -73,6 +75,16 @@ export class Executor {
     private readonly baseURL: string,
     private readonly workflowService: WorkflowService,
     private readonly executionService: ExecutionService,
+    /**
+     * Egress middlewares for the webhook call itself.
+     *
+     * The execution lookups below already go through the API client, so they
+     * carry whatever a gateway requires. The webhook POST does not use that
+     * client — its URL sits outside `/api/v1` — so without the chain here the
+     * first request of a test is the one request that arrives unauthenticated,
+     * and the whole command fails at the edge on an otherwise working setup.
+     */
+    private readonly clientMiddlewares: ClientMiddleware[] = [],
   ) {}
 
   /** Execute runs a test against a workflow */
@@ -157,35 +169,19 @@ export class Executor {
 
   /** callWebhook sends an HTTP request to the webhook */
   private async callWebhook(info: WebhookInfo, opts: TestOptions): Promise<[number, string]> {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    };
-
-    // Add authentication header if token is provided
+    // Authenticates the request at n8n's own webhook node (header auth), which
+    // is a separate concern from the gateway credentials the middleware chain
+    // attaches.
     const token = process.env.N8N_CLI_TEST_TOKEN;
-    if (token) {
-      headers["x-n8n-cli-test-token"] = token;
-    }
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
-
-    try {
-      const resp = await fetch(info.fullURL, {
-        method: info.httpMethod,
-        headers,
-        body: opts.data !== undefined ? JSON.stringify(opts.data) : undefined,
-        signal: controller.signal,
-      });
-
-      const body = await resp.text();
-      return [resp.status, body];
-    } catch (e) {
-      throw new Error(`webhook request failed: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      clearTimeout(timer);
-    }
+    const { status, body } = await callWebhook(info.fullURL, {
+      method: info.httpMethod,
+      data: opts.data,
+      timeoutMs: opts.timeoutMs,
+      headers: token ? { "x-n8n-cli-test-token": token } : {},
+      clientMiddlewares: this.clientMiddlewares,
+    });
+    return [status, body];
   }
 
   /** waitForLatestExecution waits for the most recent execution to complete */

--- a/src/webhook/resolver.ts
+++ b/src/webhook/resolver.ts
@@ -1,0 +1,86 @@
+import type { Node, Workflow } from "../api/types.ts";
+
+/** A webhook node resolved to something callable. */
+export interface ResolvedWebhook {
+  node: Node;
+  path: string;
+  httpMethod: string;
+  url: string;
+}
+
+/** Raised when the named node is absent, disabled, or not a webhook. */
+export class WebhookNodeNotFoundError extends Error {
+  readonly workflowId: string;
+  readonly nodeName: string;
+
+  constructor(workflowId: string, workflowName: string, nodeName: string, reason: string) {
+    super(`webhook node "${nodeName}" in workflow "${workflowName}" (${workflowId}): ${reason}`);
+    this.name = "WebhookNodeNotFoundError";
+    this.workflowId = workflowId;
+    this.nodeName = nodeName;
+  }
+}
+
+/**
+ * Resolves a webhook node the caller named, to a URL that can be called.
+ *
+ * The node is addressed by its exact name and nothing else. This command will
+ * not search, guess, or fall back to "the only webhook in the workflow": every
+ * webhook in an n8n instance is a live entry point, and some of them are wired
+ * to inbound events from other systems. A caller that has to name the node
+ * cannot fire one it did not mean to.
+ *
+ * Which webhooks a given workflow *intends* to expose for manual calls is a
+ * policy question, and policies differ per deployment — naming conventions,
+ * response modes, auth requirements. This resolver takes no position on any of
+ * it; the caller decides what it is willing to call and passes the name.
+ */
+export function resolveWebhookNode(workflow: Workflow | null, nodeName: string): ResolvedWebhook {
+  if (!workflow) throw new Error("workflow is nil");
+
+  const id = workflow.id ?? "";
+  const node = workflow.nodes?.find((n) => n.name === nodeName);
+  if (!node) {
+    throw new WebhookNodeNotFoundError(id, workflow.name, nodeName, "no node with that name");
+  }
+  if (node.type !== "n8n-nodes-base.webhook") {
+    throw new WebhookNodeNotFoundError(
+      id,
+      workflow.name,
+      nodeName,
+      `node type is "${node.type}", expected "n8n-nodes-base.webhook"`,
+    );
+  }
+  if (node.disabled) {
+    // n8n does not register a disabled node's webhook, so the URL 404s. Saying
+    // so here beats letting the caller debug an opaque 404.
+    throw new WebhookNodeNotFoundError(id, workflow.name, nodeName, "node is disabled");
+  }
+
+  const path = readPath(node);
+  return { node, path, httpMethod: readHttpMethod(node), url: "" };
+}
+
+/** Builds the webhook URL for a path against an API/gateway base URL. */
+export function buildWebhookURL(baseURL: string, path: string): string {
+  const base = baseURL.replace(/\/+$/, "").replace(/\/api\/v1$/, "");
+  return `${base}/webhook/${path.replace(/^\//, "")}`;
+}
+
+/** Lists the callable webhook nodes of a workflow, for discovery by a caller. */
+export function listWebhookNodes(workflow: Workflow | null): ResolvedWebhook[] {
+  if (!workflow) return [];
+  return (workflow.nodes ?? [])
+    .filter((n) => n.type === "n8n-nodes-base.webhook" && !n.disabled)
+    .map((node) => ({ node, path: readPath(node), httpMethod: readHttpMethod(node), url: "" }));
+}
+
+function readPath(node: Node): string {
+  const path = node.parameters?.path;
+  return typeof path === "string" && path !== "" ? path : node.id;
+}
+
+function readHttpMethod(node: Node): string {
+  const method = node.parameters?.httpMethod;
+  return typeof method === "string" && method !== "" ? method.toUpperCase() : "POST";
+}

--- a/tests/api/webhook.test.ts
+++ b/tests/api/webhook.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { callWebhook } from "../../src/api/webhook.ts";
+import type { ClientMiddleware } from "../../src/middleware/types.ts";
+
+const realFetch = globalThis.fetch;
+
+interface Captured {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string | null;
+}
+
+function stubFetch(status = 200, body = "ok"): Captured[] {
+  const calls: Captured[] = [];
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : null,
+    });
+    return new Response(body, { status });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("callWebhook", () => {
+  it("sends JSON with the default content headers", async () => {
+    const calls = stubFetch();
+    await callWebhook("https://gw.example.com/webhook/x", {
+      method: "POST",
+      data: { a: 1 },
+      timeoutMs: 1000,
+    });
+
+    expect(calls[0]?.headers.get("Content-Type")).toBe("application/json");
+    expect(calls[0]?.body).toBe('{"a":1}');
+  });
+
+  it("omits the body when no data is given", async () => {
+    const calls = stubFetch();
+    await callWebhook("https://gw.example.com/webhook/x", { method: "GET", timeoutMs: 1000 });
+    expect(calls[0]?.body).toBeNull();
+  });
+
+  it("runs the middleware chain in order, letting later entries see earlier headers", async () => {
+    const calls = stubFetch();
+    const first: ClientMiddleware = {
+      name: "first",
+      apply: (h) => {
+        h.set("X-Step", "1");
+      },
+    };
+    const second: ClientMiddleware = {
+      name: "second",
+      apply: (h) => {
+        h.set("X-Step", `${h.get("X-Step")},2`);
+      },
+    };
+
+    await callWebhook("https://gw.example.com/webhook/x", {
+      method: "POST",
+      timeoutMs: 1000,
+      clientMiddlewares: [first, second],
+    });
+
+    expect(calls[0]?.headers.get("X-Step")).toBe("1,2");
+  });
+
+  it("lets middleware override a caller-supplied header", async () => {
+    const calls = stubFetch();
+    const mw: ClientMiddleware = {
+      name: "auth",
+      apply: (h) => {
+        h.set("Authorization", "Bearer minted");
+      },
+    };
+
+    await callWebhook("https://gw.example.com/webhook/x", {
+      method: "POST",
+      timeoutMs: 1000,
+      headers: { Authorization: "Bearer stale" },
+      clientMiddlewares: [mw],
+    });
+
+    expect(calls[0]?.headers.get("Authorization")).toBe("Bearer minted");
+  });
+
+  it("propagates a middleware failure without sending the request", async () => {
+    const calls = stubFetch();
+    const mw: ClientMiddleware = {
+      name: "boom",
+      apply: () => {
+        throw new Error("no credentials");
+      },
+    };
+
+    await expect(
+      callWebhook("https://gw.example.com/webhook/x", {
+        method: "POST",
+        timeoutMs: 1000,
+        clientMiddlewares: [mw],
+      }),
+    ).rejects.toThrow("no credentials");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns non-2xx responses instead of throwing", async () => {
+    stubFetch(403, "Forbidden");
+    const res = await callWebhook("https://gw.example.com/webhook/x", {
+      method: "POST",
+      timeoutMs: 1000,
+    });
+    expect(res).toEqual({ status: 403, body: "Forbidden" });
+  });
+
+  it("wraps a transport failure with context", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      callWebhook("https://gw.example.com/webhook/x", { method: "POST", timeoutMs: 1000 }),
+    ).rejects.toThrow("webhook request failed: ECONNREFUSED");
+  });
+});

--- a/tests/webhook/resolver.test.ts
+++ b/tests/webhook/resolver.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import type { Node, Workflow } from "../../src/api/types.ts";
+import {
+  buildWebhookURL,
+  listWebhookNodes,
+  resolveWebhookNode,
+  WebhookNodeNotFoundError,
+} from "../../src/webhook/resolver.ts";
+
+function webhookNode(overrides: Partial<Node> = {}, params: Record<string, unknown> = {}): Node {
+  return {
+    id: "node-1",
+    name: "Manual entry",
+    type: "n8n-nodes-base.webhook",
+    typeVersion: 2.1,
+    position: [0, 0],
+    webhookId: "abc",
+    parameters: { httpMethod: "POST", path: "hooks/abc", ...params },
+    ...overrides,
+  };
+}
+
+function makeWorkflow(nodes: Node[], overrides: Partial<Workflow> = {}): Workflow {
+  return { id: "wf-1", name: "Nightly sync", active: true, nodes, connections: {}, ...overrides };
+}
+
+describe("resolveWebhookNode", () => {
+  it("resolves a node addressed by its exact name", () => {
+    const resolved = resolveWebhookNode(makeWorkflow([webhookNode()]), "Manual entry");
+    expect(resolved.path).toBe("hooks/abc");
+    expect(resolved.httpMethod).toBe("POST");
+  });
+
+  it("defaults the method to POST when the node does not set one", () => {
+    const node = webhookNode();
+    delete (node.parameters as Record<string, unknown>).httpMethod;
+    expect(resolveWebhookNode(makeWorkflow([node]), "Manual entry").httpMethod).toBe("POST");
+  });
+
+  it("upper-cases a lower-case method", () => {
+    const resolved = resolveWebhookNode(
+      makeWorkflow([webhookNode({}, { httpMethod: "get" })]),
+      "Manual entry",
+    );
+    expect(resolved.httpMethod).toBe("GET");
+  });
+
+  it("falls back to the node id when the node has no path", () => {
+    const node = webhookNode();
+    delete (node.parameters as Record<string, unknown>).path;
+    expect(resolveWebhookNode(makeWorkflow([node]), "Manual entry").path).toBe("node-1");
+  });
+
+  it("never guesses: an unmatched name is an error even with exactly one webhook", () => {
+    expect(() => resolveWebhookNode(makeWorkflow([webhookNode()]), "Other")).toThrow(
+      WebhookNodeNotFoundError,
+    );
+  });
+
+  it("matches names exactly, not by prefix", () => {
+    expect(() => resolveWebhookNode(makeWorkflow([webhookNode()]), "Manual")).toThrow(
+      WebhookNodeNotFoundError,
+    );
+  });
+
+  it("refuses a node of another type that happens to share the name", () => {
+    const workflow = makeWorkflow([webhookNode({ type: "n8n-nodes-base.formTrigger" })]);
+    expect(() => resolveWebhookNode(workflow, "Manual entry")).toThrow(/expected/);
+  });
+
+  it("refuses a disabled node, whose webhook n8n never registered", () => {
+    const workflow = makeWorkflow([webhookNode({ disabled: true })]);
+    expect(() => resolveWebhookNode(workflow, "Manual entry")).toThrow(/disabled/);
+  });
+
+  it("picks the named node out of several webhooks", () => {
+    const workflow = makeWorkflow([
+      webhookNode(),
+      webhookNode({ id: "node-2", name: "Partner callback" }, { path: "hooks/partner" }),
+    ]);
+    expect(resolveWebhookNode(workflow, "Partner callback").path).toBe("hooks/partner");
+  });
+
+  it("rejects a null workflow", () => {
+    expect(() => resolveWebhookNode(null, "x")).toThrow("workflow is nil");
+  });
+});
+
+describe("listWebhookNodes", () => {
+  it("lists enabled webhook nodes only", () => {
+    const workflow = makeWorkflow([
+      webhookNode(),
+      webhookNode({ id: "n2", name: "Disabled one", disabled: true }),
+      webhookNode({ id: "n3", name: "A form", type: "n8n-nodes-base.formTrigger" }),
+      { id: "n4", name: "Set", type: "n8n-nodes-base.set", typeVersion: 1, position: [0, 0] },
+    ]);
+    expect(listWebhookNodes(workflow).map((w) => w.node.name)).toEqual(["Manual entry"]);
+  });
+
+  it("returns nothing for a workflow with no nodes array", () => {
+    expect(
+      listWebhookNodes({ id: "x", name: "e", active: true, connections: {} } as Workflow),
+    ).toEqual([]);
+  });
+
+  it("returns nothing for a null workflow", () => {
+    expect(listWebhookNodes(null)).toEqual([]);
+  });
+});
+
+describe("buildWebhookURL", () => {
+  it("appends the path to a bare base URL", () => {
+    expect(buildWebhookURL("https://gw.example.com", "hooks/abc")).toBe(
+      "https://gw.example.com/webhook/hooks/abc",
+    );
+  });
+
+  it("strips a trailing /api/v1 and slashes", () => {
+    expect(buildWebhookURL("https://gw.example.com/api/v1/", "/hooks/abc")).toBe(
+      "https://gw.example.com/webhook/hooks/abc",
+    );
+  });
+});


### PR DESCRIPTION
> **Rewritten from the first version.** It originally compiled a node-naming convention and a response-mode policy into the CLI. Both were organization-specific, so they are gone: this is now just the primitive for calling a webhook over the authenticated path, and the convention lives with the caller.

## What

```bash
n8n-cli webhook list <workflow-id>
n8n-cli webhook call <workflow-id> --node "<node name>" [-d '{"...":"..."}']
```

Two commits:

1. **`fix:`** — webhook calls now run through the egress middleware chain.
2. **`feat:`** — the `webhook` command itself.

## Why the CLI needs this at all, given `curl`

When n8n sits behind a gateway that authenticates callers per request, the credentials are minted by the egress middleware chain (`N8N_CLIENT_MIDDLEWARES`) **inside this process** — id_token minting, service-account impersonation, in-process caching. Reproducing that outside the CLI means reimplementing all of it. The transport is the one part that genuinely belongs here.

## The bug in commit 1

`Client.doRequest` applies the egress chain to every call. Webhook URLs sit outside `/api/v1`, so `test` bypassed `Client` and used a bare `fetch`. Against an authenticating gateway that made the webhook POST **the one unauthenticated request the CLI sends** — `test` failed at the edge on a setup where `apply` and `import` worked. The README's claim that the middlewares "run on every API call" quietly did not cover it.

Extracted `callWebhook`, and exposed the chain on `GlobalContext` so any command reaching outside `/api/v1` gets the same credentials. Direct-to-n8n is unchanged: empty chain → byte-identical request.

## One safety property, no policy

`--node` is **required**. The command never searches, guesses, or falls back to "the only webhook in the workflow". Every webhook in an n8n instance is a live entry point and some are wired to inbound events from other systems — a caller that must name the node cannot fire one it did not mean to. `webhook list` exists to find the name.

Beyond that it takes no position on **which** webhooks are safe to call, what they should be named, or whether they may return data. Those are deployment policy: they differ per organization, and a naming convention compiled into a released binary is a convention nobody can change. Callers building "let an agent run a workflow on request" enforce their rules in the layer that owns them and pass a node name.

Two small exceptions, both about the call physically working rather than about policy:

- a **disabled** node is refused — n8n never registered its webhook, so the URL 404s and the error would point at the wrong thing
- an **inactive** workflow is refused by default, with `--allow-inactive` because n8n does serve a test-mode webhook while the editor is open

## Tests

22 new tests:

- `tests/webhook/resolver.test.ts` (16) — exact-name addressing including the near misses (prefix match rejected, unmatched name rejected *even when there is exactly one webhook*, wrong node type sharing the name, disabled node), method/path defaulting and upper-casing, picking one out of several, listing filters.
- `tests/api/webhook.test.ts` (6) — middleware chain ordering, middleware overriding a caller header, a throwing middleware aborting *before* the request, non-2xx returned rather than thrown, transport failure wrapped, body omitted when no data.

`bun test` 1096 pass, `tsc --noEmit` and `biome check` clean.

One failure is unrelated and also fails on `origin/main`: `tests/lint/rules/no-plaintext-secrets.test.ts > detects literal in a password-masked param`. It comes from the locally-generated `src/generated/node-schemas.json` differing from CI's — CI is green.

## Related

- #56 — proxy `--extra-routes` (independent; lets a deployment bring a non-API path under the authentication chain)
- #57 — `impersonator-token` header passthrough fix (independent security hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QnXCsLbo5s4inhYAVKZJc