### PR TITLE
feat(proxy): append endpoints to the policy table without restating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,8 @@ n8n-cli proxy [options]
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
 | `--middleware <list>` | Comma-separated middleware chain (default: `lint`; env: `N8N_MIDDLEWARES`). Example: `lint,authz` |
 | `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`). Non-matching saves are forwarded transparently |
+| `--routes <table>` | Replace the policy-relevant endpoint table (env: `N8N_PROXY_ROUTES`). See below |
+| `--extra-routes <table>` | Append to the endpoint table instead of replacing it (env: `N8N_PROXY_EXTRA_ROUTES`). See below |
 
 **Enforcement levels:**
 
@@ -886,7 +888,28 @@ n8n-cli proxy [options]
 - `POST /api/v1/workflows` (create)
 - `PUT /api/v1/workflows/:id` (update)
 
-All other paths (including the n8n editor's internal `/rest/*` routes) are forwarded transparently. The `X-N8N-API-KEY` header is passed through as-is.
+Plus tag assignment, delete, activate and deactivate. All other paths (including the n8n editor's internal `/rest/*` routes and `/webhook/*`) are forwarded transparently — no middleware runs on them. The `X-N8N-API-KEY` header is passed through as-is.
+
+**Changing which endpoints are policy-relevant:**
+
+Both flags take the same one-route-per-line (or comma-separated) format; `#` starts a comment:
+
+```
+METHOD /path/:id -> action [body=workflow]
+```
+
+`:id` matches exactly one path segment and is handed to middleware as `ctx.workflowId`. `body=workflow` marks routes that carry a workflow definition — middleware that reads one (lint) is skipped on routes without it, so a route declared without `body=workflow` will not be rejected for "not being a workflow".
+
+Use `--routes` to describe a different API surface entirely; it replaces the table. Use `--extra-routes` to bring one more endpoint under policy — it appends, so a later change to the built-in table still reaches the deployment. Base routes win ties, so an appended entry cannot reclassify an already-gated endpoint.
+
+A transparently-forwarded path runs no middleware, which means no authentication middleware either. If a deployment authenticates callers with `oauth-verify` / `impersonator-verify` and wants a non-API path held to the same bar, that path has to be in the table:
+
+```bash
+n8n-cli proxy \
+  --extra-routes 'POST /webhook/__agent-trigger__/:id -> trigger'
+```
+
+Middleware that should not judge the new action can be scoped out of it — `authz`, for instance, takes `--authz-actions`.
 
 **Example: run the proxy in front of a production n8n**
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import { parseTagFilter } from "@/common/tags.ts";
 import { parseMiddlewareList } from "@/middleware/registry.ts";
 import { parseEnforceLevel } from "@/proxy/config.ts";
-import { parseRoutes } from "@/proxy/rest/router.ts";
+import { resolveRouteTable } from "@/proxy/rest/router.ts";
 import { startProxy } from "@/proxy/server.ts";
 
 interface ProxyOptions {
@@ -19,6 +19,7 @@ interface ProxyOptions {
   clientMiddleware?: string;
   tags?: string;
   routes?: string;
+  extraRoutes?: string;
   // iap-auth client-middleware options.
   iapAuthAudience?: string;
   iapAuthTokenSource?: string;
@@ -156,6 +157,13 @@ export function registerProxyCommand(program: Command): void {
         '"METHOD /path/:id -> action [body=workflow]" (env: N8N_PROXY_ROUTES). ' +
         "Defaults to workflow create/update/tags/delete/activate.",
     )
+    .option(
+      "--extra-routes <table>",
+      "Additional policy-relevant endpoints, same format as --routes " +
+        "(env: N8N_PROXY_EXTRA_ROUTES). Appended to the default table (or to " +
+        "--routes when both are given), so one endpoint can be brought under " +
+        "policy without restating the rest.",
+    )
     // Authz options — only meaningful when "authz" is in the server-middleware chain.
     .option("--authz-enforce <level>", "Authz enforcement level: off, warn, error")
     .option("--authz-on-error <mode>", "Behavior when groups API fails: deny, allow")
@@ -261,7 +269,10 @@ export function registerProxyCommand(program: Command): void {
       const middlewares = parseMiddlewareList(opts.serverMiddleware);
       const clientMiddlewares = parseMiddlewareList(opts.clientMiddleware);
       const filterByTags = parseTagFilter(opts.tags ?? process.env.PROXY_FILTER_BY_TAGS);
-      const routes = parseRoutes(opts.routes ?? process.env.N8N_PROXY_ROUTES);
+      const routes = resolveRouteTable(
+        opts.routes ?? process.env.N8N_PROXY_ROUTES,
+        opts.extraRoutes ?? process.env.N8N_PROXY_EXTRA_ROUTES,
+      );
 
       const handle = startProxy({
         routes,

--- a/src/proxy/rest/router.ts
+++ b/src/proxy/rest/router.ts
@@ -86,6 +86,29 @@ export function parseRoutes(raw: string | undefined): RouteSpec[] | undefined {
   });
 }
 
+/**
+ * Resolves the effective route table from the two knobs the proxy exposes.
+ *
+ * `--routes` replaces the table wholesale, which is right when an operator is
+ * describing a different API surface, but wrong for the common case of adding
+ * one endpoint: restating the five workflow-mutation routes just to append a
+ * sixth means a later change to the defaults silently misses this deployment.
+ * `--extra-routes` appends instead, so a deployment can bring one more path
+ * under policy without pinning the rest.
+ *
+ * Extras append *after* the base, so a base route always wins a tie — an
+ * appended entry cannot quietly reclassify an endpoint that is already gated.
+ */
+export function resolveRouteTable(
+  explicitRaw: string | undefined,
+  extraRaw: string | undefined,
+): RouteSpec[] | undefined {
+  const explicit = parseRoutes(explicitRaw);
+  const extra = parseRoutes(extraRaw);
+  if (!extra) return explicit;
+  return [...(explicit ?? DEFAULT_ROUTES), ...extra];
+}
+
 function matchPattern(pattern: string, pathname: string): { id?: string } | null {
   const pParts = pattern.split("/");
   const aParts = pathname.split("/");

--- a/tests/proxy/router.extra-routes.test.ts
+++ b/tests/proxy/router.extra-routes.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerFactory, resetRegistry } from "@/middleware/registry.ts";
+import type {
+  ServerMiddleware,
+  ServerMiddlewareContext,
+  ServerMiddlewareFactory,
+} from "@/middleware/types.ts";
+import { registerBuiltins } from "@/middleware/wiring.ts";
+import { DEFAULT_ROUTES, matchWorkflowMutation, resolveRouteTable } from "@/proxy/rest/router.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+const TRIGGER_ROUTE = "POST /webhook/__agent-trigger__/:id -> trigger";
+
+describe("resolveRouteTable", () => {
+  test("returns undefined when neither knob is set, so callers fall back to defaults", () => {
+    expect(resolveRouteTable(undefined, undefined)).toBeUndefined();
+  });
+
+  test("--routes alone still replaces the table wholesale", () => {
+    const routes = resolveRouteTable("POST /api/v1/only -> only", undefined);
+    expect(routes).toEqual([
+      { method: "POST", pattern: "/api/v1/only", action: "only", bodyIsWorkflow: false },
+    ]);
+  });
+
+  test("--extra-routes alone appends to the defaults rather than replacing them", () => {
+    const routes = resolveRouteTable(undefined, TRIGGER_ROUTE);
+    expect(routes).toHaveLength(DEFAULT_ROUTES.length + 1);
+    expect(routes?.slice(0, DEFAULT_ROUTES.length)).toEqual(DEFAULT_ROUTES);
+    expect(routes?.at(-1)).toEqual({
+      method: "POST",
+      pattern: "/webhook/__agent-trigger__/:id",
+      action: "trigger",
+      bodyIsWorkflow: false,
+    });
+  });
+
+  test("both knobs together append the extras to the explicit table", () => {
+    const routes = resolveRouteTable("POST /api/v1/only -> only", TRIGGER_ROUTE);
+    expect(routes?.map((r) => r.action)).toEqual(["only", "trigger"]);
+  });
+
+  test("a base route wins a tie, so an extra cannot reclassify a gated endpoint", () => {
+    const routes = resolveRouteTable(undefined, "POST /api/v1/workflows -> sneaky");
+    const hit = matchWorkflowMutation("POST", "/api/v1/workflows", routes);
+    expect(hit?.action).toBe("create");
+  });
+
+  test("a malformed extra throws instead of being dropped", () => {
+    expect(() => resolveRouteTable(undefined, "not a route")).toThrow(/Invalid proxy route/);
+  });
+
+  test("blank extras are ignored", () => {
+    expect(resolveRouteTable(undefined, "   ")).toBeUndefined();
+  });
+});
+
+describe("matchWorkflowMutation with an appended trigger route", () => {
+  const routes = resolveRouteTable(undefined, TRIGGER_ROUTE);
+
+  test("matches a trigger webhook path", () => {
+    expect(matchWorkflowMutation("POST", "/webhook/__agent-trigger__/abc", routes)).toEqual({
+      action: "trigger",
+      id: "abc",
+      bodyIsWorkflow: false,
+    });
+  });
+
+  test("leaves other webhook paths transparent", () => {
+    expect(matchWorkflowMutation("POST", "/webhook/__cli-test__/abc", routes)).toBeNull();
+  });
+
+  test("does not match a GET on the same path", () => {
+    expect(matchWorkflowMutation("GET", "/webhook/__agent-trigger__/abc", routes)).toBeNull();
+  });
+
+  test("still matches the default workflow routes", () => {
+    expect(matchWorkflowMutation("POST", "/api/v1/workflows", routes)?.action).toBe("create");
+  });
+});
+
+/** Middleware that records every context it judged. */
+function recorder(name: string, seen: ServerMiddlewareContext[]): ServerMiddlewareFactory<object> {
+  return {
+    name,
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name,
+      evaluate(ctx) {
+        seen.push(ctx);
+        return { block: false, violations: [] };
+      },
+    }),
+  };
+}
+
+describe("proxy: an appended trigger route runs middleware but stays out of lint's way", () => {
+  let upstream: ReturnType<typeof startUpstream>;
+  let proxy: ProxyHandle;
+  let judged: ServerMiddlewareContext[];
+
+  function startUpstream() {
+    const seen: Array<{ method: string; pathname: string; body: string }> = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        seen.push({
+          method: req.method,
+          pathname: new URL(req.url).pathname,
+          body: await req.text(),
+        });
+        return new Response(JSON.stringify({ message: "Workflow was started" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    return { server, port: server.port as number, seen };
+  }
+
+  beforeEach(() => {
+    resetRegistry();
+    registerBuiltins();
+    judged = [];
+    registerFactory(recorder("op-level", judged));
+    upstream = startUpstream();
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      // lint blocks anything it judges that is not a workflow definition, so
+      // its silence here is the assertion that it was filtered out.
+      enforce: "error",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      middlewares: ["op-level", "lint"],
+      routes: resolveRouteTable(undefined, TRIGGER_ROUTE),
+    });
+  });
+
+  afterEach(async () => {
+    await proxy?.stop();
+    await upstream.server.stop(true);
+    resetRegistry();
+  });
+
+  test("the trigger call is judged, then forwarded verbatim", async () => {
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/webhook/__agent-trigger__/abc`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"reason":"manual"}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(judged.map((c) => c.action)).toEqual(["trigger"]);
+    // No definition on this route, so nothing should have been handed a body
+    // to judge — that is what keeps lint from rejecting it as "not a workflow".
+    expect(judged[0]?.rawJSON).toBeUndefined();
+    expect(judged[0]?.workflow).toBeNull();
+    expect(upstream.seen).toEqual([
+      { method: "POST", pathname: "/webhook/__agent-trigger__/abc", body: '{"reason":"manual"}' },
+    ]);
+  });
+
+  test("an ungated webhook path is forwarded without being judged at all", async () => {
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/webhook/__cli-test__/abc`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
+    expect(judged).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
**Closed — the premise behind this does not hold. See the closing comment.**

## Problem (as originally framed)

A transparently-forwarded path runs no server middleware, and that includes the authentication middlewares. `handle()` sends anything that does not match the route table straight to `handleTransparentForward`, which skips the pipeline entirely. A deployment running `oauth-verify` / `impersonator-verify` therefore verifies the caller on workflow writes, but a non-API path it also cares about is authenticated only by whatever guards the proxy's own front door.

## Change

`--extra-routes` / `N8N_PROXY_EXTRA_ROUTES` — same format as `--routes`, but appended:

```
resolveRouteTable(explicit, extra)
  neither     → undefined  (caller falls back to DEFAULT_ROUTES — unchanged)
  --routes    → replaces, as today
  --extra     → DEFAULT_ROUTES ++ extras
  both        → explicit ++ extras
```

Extras append after the base, so a base route wins a tie — an appended entry cannot quietly reclassify an endpoint that is already gated.

## Why it was closed

The framing assumed we needed to opt paths in one at a time, because putting a whole path prefix under the chain would reject callers that cannot supply the credentials it expects. That turned out not to be the case: such callers do not reach the proxy at all. With every caller that does reach it already holding those credentials, there is nothing to distinguish by path, and a configurable "which paths get verified" table is the wrong shape. Running the non-body-reading server middleware on transparent forwards is both simpler and needs no configuration.

Leaving the branch and the tests here in case the append-a-route capability is wanted for some other reason.