### PR TITLE
fix(impersonator-token): never forward a caller-supplied identity header

### DIFF
--- a/src/middleware/builtin/impersonator-token/middleware.ts
+++ b/src/middleware/builtin/impersonator-token/middleware.ts
@@ -53,6 +53,24 @@ export class ImpersonatorTokenMiddleware implements ClientMiddleware {
   constructor(private readonly options: ImpersonatorTokenOptions) {}
 
   async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
+    // Drop whatever is already on the header before doing any work, mirroring
+    // how iap-auth treats Authorization.
+    //
+    // In proxy mode these headers come from the *incoming* request, so without
+    // this a caller could supply their own X-Impersonator-Id-Token and have it
+    // forwarded verbatim on any path where this middleware then declines to
+    // write one — an empty token, or a mint failure under the default
+    // onError=skip. It would reach the upstream looking like the proxy vouched
+    // for it. Deleting first makes the header mean exactly one thing: this
+    // middleware minted it on this hop.
+    //
+    // `impersonator-verify` checks the signature, so this is not the only
+    // thing standing between a forged header and a trusted identity — but a
+    // receiver that reads the header without verifying is a plausible
+    // deployment, and the header should not survive a hop that failed to
+    // authenticate it.
+    headers.delete(this.options.headerName);
+
     try {
       const token = await this.options.tokenSource.getToken(await this.resolveAudience());
       if (!token) return;

--- a/tests/middleware/builtin/impersonator-token/middleware.test.ts
+++ b/tests/middleware/builtin/impersonator-token/middleware.test.ts
@@ -67,6 +67,78 @@ describe("ImpersonatorTokenMiddleware", () => {
     expect(headers.get("H")).toBeNull();
   });
 
+  test("drops a caller-supplied header when the mint fails under onError=skip", async () => {
+    // The proxy hands this middleware the incoming request's headers, so a
+    // forged X-Impersonator-Id-Token must not survive a hop that declined to
+    // authenticate it.
+    const src: UserTokenSource = {
+      getToken: () => Promise.reject(new Error("source unavailable")),
+    };
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: src,
+      onError: "skip",
+    });
+    const headers = new Headers({ "X-Impersonator-Id-Token": "forged-by-caller" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("x-impersonator-id-token")).toBeNull();
+  });
+
+  test("drops a caller-supplied header when the source returns an empty token", async () => {
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: { getToken: () => Promise.resolve("") },
+      onError: "throw",
+    });
+    const headers = new Headers({ "X-Impersonator-Id-Token": "forged-by-caller" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("x-impersonator-id-token")).toBeNull();
+  });
+
+  test("drops a caller-supplied header before throwing under onError=throw", async () => {
+    const src: UserTokenSource = {
+      getToken: () => Promise.reject(new Error("source unavailable")),
+    };
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: src,
+      onError: "throw",
+    });
+    const headers = new Headers({ "X-Impersonator-Id-Token": "forged-by-caller" });
+    await expect(mw.apply(headers, baseCtx)).rejects.toThrow(/source unavailable/);
+    expect(headers.get("x-impersonator-id-token")).toBeNull();
+  });
+
+  test("replaces a caller-supplied header with the freshly minted token", async () => {
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: new StaticUserTokenSource("minted"),
+      onError: "throw",
+    });
+    const headers = new Headers({ "X-Impersonator-Id-Token": "forged-by-caller" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("x-impersonator-id-token")).toBe("minted");
+  });
+
+  test("leaves other headers alone", async () => {
+    const mw = new ImpersonatorTokenMiddleware({
+      audience: "aud",
+      headerName: "X-Impersonator-Id-Token",
+      tokenSource: new StaticUserTokenSource("minted"),
+      onError: "throw",
+    });
+    const headers = new Headers({
+      "X-Impersonator-Id-Token": "forged",
+      authorization: "Bearer sa-token",
+    });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer sa-token");
+  });
+
   test("requests the token using configured audience", async () => {
     let seenAud: string | undefined;
     const src: UserTokenSource = {


### PR DESCRIPTION
## Problem

`ImpersonatorTokenMiddleware.apply()` set the header on success and otherwise left the `Headers` object untouched:

```ts
try {
  const token = await this.options.tokenSource.getToken(...);
  if (!token) return;                     // ← header left as-is
  headers.set(this.options.headerName, token);
} catch (err) {
  if (this.options.onError === "throw") throw err;
  // ← header left as-is
}
```

In **proxy mode** those headers come from the *incoming* request. So on any path where the middleware declines to write one — an empty token, or a mint failure under the default `onError: "skip"` — a caller-supplied `X-Impersonator-Id-Token` is forwarded verbatim, arriving upstream as though the proxy had vouched for it.

`iap-auth` already guards against exactly this for `Authorization`, with the comment "Always replaces any incoming Authorization … The previous value is dropped before the new one is set." The asymmetry looks accidental rather than intended.

## Fix

Delete the header at the top of `apply()`, before any work. That makes its presence mean exactly one thing: **this middleware minted it on this hop.**

## How bad is it

Not critical. `impersonator-verify` verifies the token's signature and audience against the issuer's JWKS, so a receiver running the matching server middleware rejects a forged value regardless. But:

- The header is documented as usable by "any handler that reads a signed Google id_token side header", and a receiver that reads it without verifying is a plausible deployment.
- Independently of exploitability, a credential header should not survive a hop that failed to authenticate it. Failing open on identity is the wrong default even when something downstream happens to catch it.

## No behavior change for the CLI

`Client.doRequest` and the webhook path both build a fresh `Headers` per request, so there was never anything to drop there.

## Tests

5 new cases in `tests/middleware/builtin/impersonator-token/middleware.test.ts`, covering each way the middleware can decline to write:

- mint fails, `onError: "skip"` → caller's header gone
- source returns an empty token → caller's header gone
- mint fails, `onError: "throw"` → caller's header gone *before* the throw (the pipeline aborts, but a caller catching the error must not find the forged value still attached)
- success → caller's header replaced by the minted token, not merely joined
- other headers (`Authorization`) untouched

`bun test tests/middleware tests/proxy tests/api` → 300 pass. `tsc --noEmit` and `biome check` clean.

## Context

Noticed while reading this middleware for unrelated work. Standalone hardening — independent of any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QnXCsLbo5s4inhYAVKZJc