### PR TITLE
feat(proxy): let the gateway hold webhook tokens instead of every caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,44 @@ no external refresh step is involved.
 
 Available egress middlewares: `iap-auth` (Bearer id_token; sources `metadata`,
 `adc-impersonate`, `env`, `static`), `impersonator-token`
-(`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`.
+(`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`,
+`webhook-token-inject`.
+
+#### webhook-token-inject
+
+Webhook nodes can require a shared secret in a header. `webhook-token-inject`
+lets the proxy hold those secrets instead of every caller, so a caller that has
+already authenticated to the proxy needs nothing else to fire a webhook — while
+a request arriving through some other ingress still carries no token and is
+rejected by n8n.
+
+Rules are path-scoped, because a webhook token is not a gateway credential: it
+is the secret one specific family of webhook nodes checks. Injecting it on every
+upstream call would mean anyone able to reach the proxy could satisfy that
+header wherever it happens to be checked.
+
+```bash
+export N8N_CLIENT_MIDDLEWARES="iap-auth,api-key-inject,webhook-token-inject"
+export N8N_WEBHOOK_TOKEN_INJECT_RULES='[
+  {"pathPrefix":"/webhook/ops-triggers/","header":"x-ops-trigger-token","tokenEnvVar":"OPS_TRIGGER_TOKEN"},
+  {"pathPrefix":"/webhook/smoke-tests/","header":"x-smoke-test-token","tokenEnvVar":"SMOKE_TEST_TOKEN"}
+]'
+export OPS_TRIGGER_TOKEN="..."   # typically mounted from a secret store
+export SMOKE_TEST_TOKEN="..."
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `pathPrefix` | yes | Matched against the incoming pathname. Keep the trailing slash — `/webhook/ops` would also match `/webhook/opsx`. |
+| `header` | yes | Any valid HTTP header name. |
+| `tokenEnvVar` | either this | Name of an env var holding the token. Preferred: the rule set itself travels through env/CLI, where a literal would land in process listings and config dumps. |
+| `token` | or this | Literal value, for deployments that already render config from a secret store. |
+| `conflictPolicy` | no | `set-if-absent` (default) keeps a token the caller brought, which eases migration; `replace` makes the proxy the single holder. |
+
+Every matching rule is applied, not just the first, so a broad rule can be
+combined with narrower ones; when two matching rules share a header the later
+one decides. A rule naming an unset `tokenEnvVar` fails at startup rather than
+silently injecting nothing.
 
 ### CLAUDE.md Integration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -33,6 +33,10 @@ interface ProxyOptions {
   apiKeyInjectKeyEnvVar?: string;
   apiKeyInjectHeader?: string;
   apiKeyInjectConflictPolicy?: string;
+  // webhook-token-inject client-middleware options. Rules travel as JSON; the
+  // token values inside them should be env-var references rather than literals
+  // for the same reason api-key-inject refuses a raw key here.
+  webhookTokenInjectRules?: string;
   // impersonator-token client-middleware options. Attaches the user's own
   // Google id_token as a side header so the server can attribute the call
   // to the human running the CLI (instead of the impersonated SA).
@@ -145,6 +149,16 @@ export function registerProxyCommand(program: Command): void {
     .option(
       "--api-key-inject-conflict-policy <policy>",
       "Behavior when the incoming request already carries the header: replace (default) or set-if-absent",
+    )
+    // webhook-token-inject options — only meaningful when "webhook-token-inject"
+    // is in the client-middleware chain.
+    .option(
+      "--webhook-token-inject-rules <json>",
+      "JSON array of path-scoped webhook token rules: " +
+        '[{"pathPrefix":"/webhook/x/","header":"x-token","tokenEnvVar":"X_TOKEN"}]. ' +
+        "Each rule needs exactly one of tokenEnvVar (preferred) or token, and an " +
+        "optional conflictPolicy of set-if-absent (default) or replace. " +
+        "env: N8N_WEBHOOK_TOKEN_INJECT_RULES",
     )
     .option(
       "--tags <tags>",
@@ -362,6 +376,7 @@ function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unkn
   copy("apiKeyInjectKeyEnvVar");
   copy("apiKeyInjectHeader");
   copy("apiKeyInjectConflictPolicy");
+  copy("webhookTokenInjectRules");
   copy("impersonatorTokenAudience");
   copy("impersonatorTokenSource");
   copy("impersonatorTokenEnvVar");

--- a/src/middleware/builtin/webhook-token-inject/factory.ts
+++ b/src/middleware/builtin/webhook-token-inject/factory.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { WebhookTokenInjectMiddleware } from "./middleware.ts";
+
+/** RFC 7230 field-name: one or more token characters. */
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/**
+ * A rule as written in configuration.
+ *
+ * The token is supplied one of two ways:
+ *   - `tokenEnvVar`: name of an env var holding it. Preferred — the rule set
+ *     itself travels through env/CLI, and a value written inline there lands
+ *     in process listings, deployment manifests and config dumps.
+ *   - `token`: the literal value, for setups that already inject config from a
+ *     secret store and have nowhere else to put it.
+ *
+ * Exactly one of the two: accepting both would leave which one wins to
+ * chance, and a rule silently reading the wrong secret fails in the least
+ * debuggable way possible.
+ */
+const ruleSchema = z
+  .object({
+    pathPrefix: z
+      .string({ message: "webhook-token-inject: rule.pathPrefix is required" })
+      .min(1, { message: "webhook-token-inject: rule.pathPrefix must not be empty" })
+      .startsWith("/", {
+        message: "webhook-token-inject: rule.pathPrefix must start with '/'",
+      }),
+    header: z
+      .string({ message: "webhook-token-inject: rule.header is required" })
+      .regex(HEADER_NAME, {
+        message: "webhook-token-inject: rule.header must be a valid HTTP header name",
+      }),
+    token: z.string().min(1).optional(),
+    tokenEnvVar: z.string().min(1).optional(),
+    conflictPolicy: z
+      .union([z.literal("replace"), z.literal("set-if-absent")])
+      .default("set-if-absent"),
+  })
+  .refine((r) => Boolean(r.token) !== Boolean(r.tokenEnvVar), {
+    message:
+      "webhook-token-inject: each rule needs exactly one of token / tokenEnvVar " +
+      "(tokenEnvVar is preferred — it keeps the secret out of the rule set)",
+  });
+
+const optionsSchema = z.object({
+  rules: z
+    .array(ruleSchema)
+    .min(1, {
+      message:
+        "webhook-token-inject: at least one rule is required " +
+        "(set N8N_WEBHOOK_TOKEN_INJECT_RULES). An enabled middleware with no " +
+        "rules would silently inject nothing.",
+    })
+    .max(64, { message: "webhook-token-inject: at most 64 rules" }),
+});
+
+type WebhookTokenInjectRawOptions = z.infer<typeof optionsSchema>;
+
+function parseRules(raw: string, source: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`webhook-token-inject: ${source} is not valid JSON: ${message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `webhook-token-inject: ${source} must be a JSON array of rules, got ${typeof parsed}`,
+    );
+  }
+  return parsed;
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<WebhookTokenInjectRawOptions> {
+  const raw = env.N8N_WEBHOOK_TOKEN_INJECT_RULES;
+  if (!raw) return {};
+  return {
+    rules: parseRules(
+      raw,
+      "N8N_WEBHOOK_TOKEN_INJECT_RULES",
+    ) as WebhookTokenInjectRawOptions["rules"],
+  };
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<WebhookTokenInjectRawOptions> {
+  const raw = opts.webhookTokenInjectRules;
+  if (typeof raw !== "string" || raw.length === 0) return {};
+  return {
+    rules: parseRules(raw, "--webhook-token-inject-rules") as WebhookTokenInjectRawOptions["rules"],
+  };
+}
+
+/**
+ * Resolves `tokenEnvVar` indirections against the process environment.
+ *
+ * An unresolvable reference is an error rather than a skipped rule: a rule
+ * that quietly stops injecting turns into upstream 401/403s far from the
+ * misconfiguration that caused them.
+ */
+function resolveTokens(
+  rules: WebhookTokenInjectRawOptions["rules"],
+  env: NodeJS.ProcessEnv,
+): {
+  pathPrefix: string;
+  header: string;
+  token: string;
+  conflictPolicy: "replace" | "set-if-absent";
+}[] {
+  return rules.map((rule) => {
+    let token = rule.token;
+    if (rule.tokenEnvVar) {
+      const value = env[rule.tokenEnvVar];
+      if (!value) {
+        throw new Error(
+          `webhook-token-inject: rule for ${rule.pathPrefix} references ` +
+            `tokenEnvVar "${rule.tokenEnvVar}", which is unset or empty`,
+        );
+      }
+      token = value;
+    }
+    // `token` is present here: the schema refinement guarantees exactly one of
+    // the two sources, and the env branch above either assigned or threw.
+    return {
+      pathPrefix: rule.pathPrefix,
+      header: rule.header,
+      token: token as string,
+      conflictPolicy: rule.conflictPolicy,
+    };
+  });
+}
+
+export const webhookTokenInjectFactory: ClientMiddlewareFactory<WebhookTokenInjectRawOptions> = {
+  name: "webhook-token-inject",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    return new WebhookTokenInjectMiddleware({ rules: resolveTokens(parsed.rules, process.env) });
+  },
+};
+
+/** Exposed for unit tests that build options directly. */
+export const webhookTokenInjectOptionsSchema = optionsSchema;
+/** Exposed for unit tests covering the env-var indirection. */
+export const resolveWebhookTokenRules = resolveTokens;

--- a/src/middleware/builtin/webhook-token-inject/middleware.ts
+++ b/src/middleware/builtin/webhook-token-inject/middleware.ts
@@ -1,0 +1,69 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
+
+/**
+ * One path-scoped token injection.
+ *
+ * Scoping is the point. A webhook token is not a gateway credential: it is the
+ * shared secret one specific family of webhook nodes checks. Injecting it on
+ * every upstream call would mean "anyone who can reach the proxy can satisfy
+ * that header anywhere it is checked" — including webhooks the operator never
+ * meant to expose through this path. Each rule therefore names the prefix it
+ * is allowed to speak for.
+ */
+export interface WebhookTokenRule {
+  /**
+   * Prefix matched against the *incoming* request pathname (e.g.
+   * `/webhook/some-namespace/`). Trailing slash matters: `/webhook/ab` would
+   * otherwise also match `/webhook/abc`.
+   */
+  pathPrefix: string;
+  /** Header the token is written to. */
+  header: string;
+  /** Token value. Never logged, never echoed back to the caller. */
+  token: string;
+  /**
+   * Behavior when the incoming request already carries a value for `header`:
+   *   - "set-if-absent": leave it intact. Default — a caller that still brings
+   *     its own token keeps working while a deployment migrates.
+   *   - "replace": overwrite, making the proxy the single token holder.
+   */
+  conflictPolicy: "replace" | "set-if-absent";
+}
+
+export interface WebhookTokenInjectOptions {
+  /**
+   * Rules in declaration order. **Every** matching rule is applied, not just
+   * the first: distinct webhook families use distinct headers, and a
+   * deployment may legitimately want a broad rule plus a narrower one on top.
+   * When two matching rules share a header, the later one decides (subject to
+   * its own conflictPolicy).
+   */
+  rules: WebhookTokenRule[];
+}
+
+/**
+ * Client middleware that attaches webhook tokens to upstream requests whose
+ * path falls under a configured prefix.
+ *
+ * Used to make the proxy the single holder of the shared secrets that webhook
+ * nodes check. Callers then need only authenticate to the proxy itself; they
+ * never hold — and cannot leak — the webhook tokens. A request that bypasses
+ * the proxy carries no token and is rejected by n8n, which is what keeps a
+ * second, unauthenticated ingress from becoming an open door.
+ *
+ * Carries no knowledge of any particular naming convention: prefixes, header
+ * names and tokens are all supplied by configuration.
+ */
+export class WebhookTokenInjectMiddleware implements ClientMiddleware {
+  readonly name = "webhook-token-inject";
+
+  constructor(private readonly options: WebhookTokenInjectOptions) {}
+
+  apply(headers: Headers, ctx: ClientMiddlewareContext): void {
+    for (const rule of this.options.rules) {
+      if (!ctx.pathname.startsWith(rule.pathPrefix)) continue;
+      if (rule.conflictPolicy === "set-if-absent" && headers.has(rule.header)) continue;
+      headers.set(rule.header, rule.token);
+    }
+  }
+}

--- a/src/middleware/client-wiring.ts
+++ b/src/middleware/client-wiring.ts
@@ -1,6 +1,7 @@
 import { apiKeyInjectFactory } from "./builtin/api-key-inject/factory.ts";
 import { iapAuthFactory } from "./builtin/iap-auth/factory.ts";
 import { impersonatorTokenFactory } from "./builtin/impersonator-token/factory.ts";
+import { webhookTokenInjectFactory } from "./builtin/webhook-token-inject/factory.ts";
 import { knownClientMiddlewareNames, registerClientFactory } from "./client-registry.ts";
 
 /**
@@ -13,6 +14,7 @@ export function registerClientBuiltins(): void {
   registerClientFactory(iapAuthFactory);
   registerClientFactory(apiKeyInjectFactory);
   registerClientFactory(impersonatorTokenFactory);
+  registerClientFactory(webhookTokenInjectFactory);
 }
 
 /**

--- a/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
+++ b/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveWebhookTokenRules,
+  webhookTokenInjectFactory,
+  webhookTokenInjectOptionsSchema,
+} from "@/middleware/builtin/webhook-token-inject/factory.ts";
+import { WebhookTokenInjectMiddleware } from "@/middleware/builtin/webhook-token-inject/middleware.ts";
+
+function ctx(pathname: string) {
+  return {
+    request: new Request(`http://proxy.local${pathname}`),
+    method: "POST",
+    pathname,
+    upstreamUrl: `http://upstream.local${pathname}`,
+  };
+}
+
+const agentRule = {
+  pathPrefix: "/webhook/agent/",
+  header: "x-agent-token",
+  token: "agent-secret",
+  conflictPolicy: "set-if-absent" as const,
+};
+
+const testRule = {
+  pathPrefix: "/webhook/cli-test/",
+  header: "x-cli-test-token",
+  token: "cli-test-secret",
+  conflictPolicy: "set-if-absent" as const,
+};
+
+describe("WebhookTokenInjectMiddleware", () => {
+  test("injects the token on a path under the rule's prefix", () => {
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/agent/abc-123"));
+    expect(headers.get("x-agent-token")).toBe("agent-secret");
+  });
+
+  test("leaves paths outside the prefix untouched", () => {
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/something-else/abc-123"));
+    expect(headers.has("x-agent-token")).toBe(false);
+  });
+
+  test("does not leak onto the REST API surface", () => {
+    // The whole point of scoping: an API call must not carry a webhook secret.
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/api/v1/workflows"));
+    expect(headers.has("x-agent-token")).toBe(false);
+  });
+
+  test("a prefix without a trailing slash does not spill into sibling paths", () => {
+    // /webhook/agent must not match /webhook/agentic/... — hence the trailing
+    // slash in the documented prefix form.
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/agentic/abc"));
+    expect(headers.has("x-agent-token")).toBe(false);
+  });
+
+  test("routes each family to its own token", () => {
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule, testRule] });
+
+    const a = new Headers();
+    mw.apply(a, ctx("/webhook/agent/x"));
+    expect(a.get("x-agent-token")).toBe("agent-secret");
+    expect(a.has("x-cli-test-token")).toBe(false);
+
+    const b = new Headers();
+    mw.apply(b, ctx("/webhook/cli-test/x"));
+    expect(b.get("x-cli-test-token")).toBe("cli-test-secret");
+    expect(b.has("x-agent-token")).toBe(false);
+  });
+
+  test("applies every matching rule, not just the first", () => {
+    // A broad rule plus a narrower one on top: both headers must arrive.
+    const broad = { ...agentRule, pathPrefix: "/webhook/", header: "x-broad", token: "broad" };
+    const mw = new WebhookTokenInjectMiddleware({ rules: [broad, agentRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect(headers.get("x-broad")).toBe("broad");
+    expect(headers.get("x-agent-token")).toBe("agent-secret");
+  });
+
+  test("when matching rules share a header the later one wins", () => {
+    const first = { ...agentRule, token: "first", conflictPolicy: "replace" as const };
+    const second = { ...agentRule, token: "second", conflictPolicy: "replace" as const };
+    const mw = new WebhookTokenInjectMiddleware({ rules: [first, second] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect(headers.get("x-agent-token")).toBe("second");
+  });
+
+  test("set-if-absent keeps a caller-supplied token", () => {
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers({ "x-agent-token": "caller-owned" });
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect(headers.get("x-agent-token")).toBe("caller-owned");
+  });
+
+  test("replace makes the proxy the single token holder", () => {
+    const mw = new WebhookTokenInjectMiddleware({
+      rules: [{ ...agentRule, conflictPolicy: "replace" }],
+    });
+    const headers = new Headers({ "x-agent-token": "caller-owned" });
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect(headers.get("x-agent-token")).toBe("agent-secret");
+  });
+
+  test("header matching is case-insensitive, so a differently-cased caller value is honoured", () => {
+    // Headers normalises names; set-if-absent must not double-write.
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });
+    const headers = new Headers({ "X-Agent-Token": "caller-owned" });
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect(headers.get("x-agent-token")).toBe("caller-owned");
+  });
+
+  test("no rules configured is inert rather than throwing", () => {
+    // The factory rejects an empty rule set; the class itself stays total.
+    const mw = new WebhookTokenInjectMiddleware({ rules: [] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/webhook/agent/x"));
+    expect([...headers.keys()]).toEqual([]);
+  });
+});
+
+describe("webhookTokenInjectOptionsSchema", () => {
+  test("defaults conflictPolicy to set-if-absent", () => {
+    const parsed = webhookTokenInjectOptionsSchema.parse({
+      rules: [{ pathPrefix: "/webhook/a/", header: "x-a", token: "t" }],
+    });
+    expect(parsed.rules[0]!.conflictPolicy).toBe("set-if-absent");
+  });
+
+  test("rejects an empty rule set", () => {
+    expect(() => webhookTokenInjectOptionsSchema.parse({ rules: [] })).toThrow(/at least one rule/);
+  });
+
+  test("rejects a prefix that is not absolute", () => {
+    expect(() =>
+      webhookTokenInjectOptionsSchema.parse({
+        rules: [{ pathPrefix: "webhook/a/", header: "x-a", token: "t" }],
+      }),
+    ).toThrow(/must start with/);
+  });
+
+  test("rejects a header name with illegal characters", () => {
+    expect(() =>
+      webhookTokenInjectOptionsSchema.parse({
+        rules: [{ pathPrefix: "/webhook/a/", header: "x a", token: "t" }],
+      }),
+    ).toThrow(/valid HTTP header name/);
+  });
+
+  test("rejects a rule carrying neither token nor tokenEnvVar", () => {
+    expect(() =>
+      webhookTokenInjectOptionsSchema.parse({
+        rules: [{ pathPrefix: "/webhook/a/", header: "x-a" }],
+      }),
+    ).toThrow(/exactly one of token \/ tokenEnvVar/);
+  });
+
+  test("rejects a rule carrying both", () => {
+    expect(() =>
+      webhookTokenInjectOptionsSchema.parse({
+        rules: [{ pathPrefix: "/webhook/a/", header: "x-a", token: "t", tokenEnvVar: "V" }],
+      }),
+    ).toThrow(/exactly one of token \/ tokenEnvVar/);
+  });
+});
+
+describe("token resolution", () => {
+  test("reads the value named by tokenEnvVar", () => {
+    const rules = webhookTokenInjectOptionsSchema.parse({
+      rules: [{ pathPrefix: "/webhook/a/", header: "x-a", tokenEnvVar: "SOME_TOKEN" }],
+    }).rules;
+    const resolved = resolveWebhookTokenRules(rules, { SOME_TOKEN: "from-env" });
+    expect(resolved[0]!.token).toBe("from-env");
+  });
+
+  test("an unset tokenEnvVar fails loudly instead of injecting nothing", () => {
+    const rules = webhookTokenInjectOptionsSchema.parse({
+      rules: [{ pathPrefix: "/webhook/a/", header: "x-a", tokenEnvVar: "MISSING_TOKEN" }],
+    }).rules;
+    expect(() => resolveWebhookTokenRules(rules, {})).toThrow(/unset or empty/);
+  });
+
+  test("an empty tokenEnvVar value is treated as unset", () => {
+    const rules = webhookTokenInjectOptionsSchema.parse({
+      rules: [{ pathPrefix: "/webhook/a/", header: "x-a", tokenEnvVar: "EMPTY_TOKEN" }],
+    }).rules;
+    expect(() => resolveWebhookTokenRules(rules, { EMPTY_TOKEN: "" })).toThrow(/unset or empty/);
+  });
+});
+
+describe("webhookTokenInjectFactory config loading", () => {
+  test("parses a rule set from env", () => {
+    const loaded = webhookTokenInjectFactory.loadFromEnv({
+      N8N_WEBHOOK_TOKEN_INJECT_RULES: JSON.stringify([
+        { pathPrefix: "/webhook/a/", header: "x-a", token: "t" },
+      ]),
+    } as NodeJS.ProcessEnv);
+    expect(loaded.rules).toHaveLength(1);
+  });
+
+  test("absent env yields no options rather than an empty rule set", () => {
+    // Distinguishing the two matters: {} lets CLI flags supply the rules,
+    // while {rules: []} would fail schema validation before they are merged.
+    expect(webhookTokenInjectFactory.loadFromEnv({} as NodeJS.ProcessEnv)).toEqual({});
+  });
+
+  test("malformed JSON names the source it came from", () => {
+    expect(() =>
+      webhookTokenInjectFactory.loadFromEnv({
+        N8N_WEBHOOK_TOKEN_INJECT_RULES: "{not json",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/N8N_WEBHOOK_TOKEN_INJECT_RULES is not valid JSON/);
+  });
+
+  test("a JSON object instead of an array is rejected", () => {
+    expect(() =>
+      webhookTokenInjectFactory.loadFromEnv({
+        N8N_WEBHOOK_TOKEN_INJECT_RULES: '{"pathPrefix":"/webhook/a/"}',
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/must be a JSON array/);
+  });
+
+  test("CLI flags parse the same shape", () => {
+    const loaded = webhookTokenInjectFactory.loadFromCLI({
+      webhookTokenInjectRules: JSON.stringify([
+        { pathPrefix: "/webhook/a/", header: "x-a", token: "t" },
+      ]),
+    });
+    expect(loaded.rules).toHaveLength(1);
+  });
+
+  test("build resolves env indirection end to end", () => {
+    process.env.WTI_TEST_TOKEN = "resolved-secret";
+    try {
+      const mw = webhookTokenInjectFactory.build({
+        rules: [{ pathPrefix: "/webhook/a/", header: "x-a", tokenEnvVar: "WTI_TEST_TOKEN" }],
+      });
+      const headers = new Headers();
+      mw.apply(headers, ctx("/webhook/a/x"));
+      expect(headers.get("x-a")).toBe("resolved-secret");
+    } finally {
+      process.env.WTI_TEST_TOKEN = undefined;
+    }
+  });
+});

--- a/tests/proxy/proxy.webhook-token-inject.test.ts
+++ b/tests/proxy/proxy.webhook-token-inject.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { webhookTokenInjectFactory } from "@/middleware/builtin/webhook-token-inject/factory.ts";
+import { registerClientFactory, resetClientRegistry } from "@/middleware/client-registry.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+/**
+ * End-to-end cover for the property the whole design rests on: webhook paths
+ * are *transparently forwarded* (they match no mutation route), and client
+ * middleware still runs on that path. If that ever stopped being true, the
+ * proxy would forward webhook calls without their token and every gateway-only
+ * caller would start getting 403s from n8n — with nothing in this repo failing.
+ */
+
+interface Captured {
+  pathname: string;
+  headers: Record<string, string>;
+}
+
+function startMockUpstream(): {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: Captured[];
+} {
+  const captured: Captured[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ pathname: url.pathname, headers });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { server, port: server.port!, captured };
+}
+
+const RULES = JSON.stringify([
+  {
+    pathPrefix: "/webhook/agent-family/",
+    header: "x-agent-token",
+    token: "agent-secret",
+    conflictPolicy: "replace",
+  },
+  {
+    pathPrefix: "/webhook/test-family/",
+    header: "x-test-token",
+    token: "test-secret",
+    conflictPolicy: "set-if-absent",
+  },
+]);
+
+let upstream: ReturnType<typeof startMockUpstream>;
+let proxy: ProxyHandle;
+
+function start(): void {
+  registerClientFactory(webhookTokenInjectFactory);
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    clientMiddlewares: ["webhook-token-inject"],
+    clientMiddlewareCliOptions: { webhookTokenInjectRules: RULES },
+  });
+}
+
+beforeEach(() => {
+  resetClientRegistry();
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  await upstream.server.stop(true);
+  resetClientRegistry();
+});
+
+describe("proxy: webhook-token-inject", () => {
+  test("a transparently forwarded webhook call arrives with its token", async () => {
+    start();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/webhook/agent-family/abc-123`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(200);
+    expect(upstream.captured).toHaveLength(1);
+    expect(upstream.captured[0]!.headers["x-agent-token"]).toBe("agent-secret");
+  });
+
+  test("each webhook family gets only its own token", async () => {
+    start();
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/test-family/abc`, {
+      method: "POST",
+      body: "{}",
+    });
+    const cap = upstream.captured[0]!;
+    expect(cap.headers["x-test-token"]).toBe("test-secret");
+    expect(cap.headers["x-agent-token"]).toBeUndefined();
+  });
+
+  test("an unconfigured webhook path carries no token at all", async () => {
+    start();
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/unrelated/abc`, {
+      method: "POST",
+      body: "{}",
+    });
+    const cap = upstream.captured[0]!;
+    expect(cap.headers["x-agent-token"]).toBeUndefined();
+    expect(cap.headers["x-test-token"]).toBeUndefined();
+  });
+
+  test("the REST API surface never receives a webhook token", async () => {
+    start();
+    await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      method: "GET",
+      headers: { "x-n8n-api-key": "test-key" },
+    });
+    const cap = upstream.captured[0]!;
+    expect(cap.headers["x-agent-token"]).toBeUndefined();
+    expect(cap.headers["x-test-token"]).toBeUndefined();
+    expect(cap.headers["x-n8n-api-key"]).toBe("test-key");
+  });
+
+  test("replace overrides a token the caller brought", async () => {
+    start();
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/agent-family/abc`, {
+      method: "POST",
+      headers: { "x-agent-token": "caller-owned" },
+      body: "{}",
+    });
+    expect(upstream.captured[0]!.headers["x-agent-token"]).toBe("agent-secret");
+  });
+
+  test("set-if-absent lets a caller keep bringing its own token during a migration", async () => {
+    start();
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/test-family/abc`, {
+      method: "POST",
+      headers: { "x-test-token": "caller-owned" },
+      body: "{}",
+    });
+    expect(upstream.captured[0]!.headers["x-test-token"]).toBe("caller-owned");
+  });
+});


### PR DESCRIPTION
## The problem

A webhook node can require a shared secret in a header. Today every caller has to hold that secret: it gets distributed, each person needs access to wherever it lives, and rotating it means touching as many places as there are callers.

That is the same shape `api-key-inject` already solved for the n8n API key — the gateway holds it, callers don't.

## What this adds

`webhook-token-inject`, a client middleware that attaches webhook tokens to upstream requests whose path falls under a configured prefix.

```bash
export N8N_CLIENT_MIDDLEWARES="iap-auth,api-key-inject,webhook-token-inject"
export N8N_WEBHOOK_TOKEN_INJECT_RULES='[
  {"pathPrefix":"/webhook/ops-triggers/","header":"x-ops-trigger-token","tokenEnvVar":"OPS_TRIGGER_TOKEN"},
  {"pathPrefix":"/webhook/smoke-tests/","header":"x-smoke-test-token","tokenEnvVar":"SMOKE_TEST_TOKEN"}
]'
```

A caller that has already authenticated to the gateway then needs nothing else to fire a webhook. A request arriving through some other ingress carries no token and is rejected upstream — which is the point: it keeps a second, unauthenticated route into n8n from becoming an open door.

## Why rules are path-scoped

A webhook token is not a gateway credential. It is the secret that one specific family of webhook nodes checks. Injecting it on every upstream call would mean anyone able to reach the proxy could satisfy that header **wherever it happens to be checked**, including webhooks the operator never meant to expose this way.

Allowing several rules also means a deployment running more than one family of tokens configures them side by side, rather than collapsing them onto one shared value — a token for operational triggers and a token for smoke tests stay separate, and revoking one does not disturb the other.

## Decisions worth reviewing

| | |
|---|---|
| **Every matching rule applies**, not just the first | A broad rule plus a narrower one is reasonable to want; first-match-wins would silently drop the second header. When two matching rules share a header, the later one decides. |
| **`tokenEnvVar` preferred over inline `token`** | The rule set travels through env/CLI, where a literal would surface in process listings and config dumps. Same reasoning that made `api-key-inject` refuse a raw key on the CLI. |
| **Exactly one of `token` / `tokenEnvVar`** | Accepting both leaves which one wins to chance, and a rule reading the wrong secret fails in the least debuggable way possible. |
| **Unset `tokenEnvVar` fails at startup** | A rule that quietly stops injecting turns into upstream 401s far from the misconfiguration that caused them. |
| **`set-if-absent` is the default** | Callers still bringing their own token keep working while a deployment migrates. Switch to `replace` once they don't. |

## Nothing organisation-specific is baked in

There are no default paths or header names — the defaults are absent, not opinionated. Any convention lives in the deployment's configuration. Same reasoning as #58, where the `[Agent Trigger]` prefix and fire-and-forget check were pulled back out of this repo.

## Tests

- `tests/middleware/builtin/webhook-token-inject/middleware.test.ts` — 26 cases: prefix matching (including the sibling-path trap, `/webhook/agent` vs `/webhook/agentic`), no leakage onto `/api/v1/*`, multi-rule routing, conflict policies, case-insensitive header matching, and every schema rejection path.
- `tests/proxy/proxy.webhook-token-inject.test.ts` — end-to-end through a real proxy against a mock upstream.

The proxy test covers the property the whole design rests on: webhook paths match no mutation route, so they are **transparently forwarded**, and client middleware still runs on that path. If that ever stopped being true, gateway-only callers would start getting 403s from n8n with nothing in this repo failing.

`bun test`: 1179 pass / 0 fail. `bun run typecheck`: clean. Biome reports no new findings.

## Version

Minor bump, `2.8.0` → `2.9.0`: additive, no behaviour change for existing configurations (the middleware does nothing unless it is named in the chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FJjMV5HohRVgHtdcGsFjz