### PR TITLE
fix(release): re-sign the macOS binaries so they can actually start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,27 @@ jobs:
 
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    # macOS targets run on a macOS runner so codesign is available; see the
+    # ad-hoc signing step below for why they need it.
+    runs-on: ${{ matrix.runner }}
     needs: [test]
     strategy:
       matrix:
         include:
           - target: bun-darwin-arm64
             artifact: n8n-cli-darwin-arm64
+            runner: macos-latest
+            sign: true
           - target: bun-darwin-x64
             artifact: n8n-cli-darwin-x64
+            runner: macos-latest
+            sign: true
           - target: bun-linux-x64
             artifact: n8n-cli-linux-x64
+            runner: ubuntu-latest
           - target: bun-windows-x64
             artifact: n8n-cli-windows-x64.exe
+            runner: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
@@ -86,6 +94,27 @@ jobs:
             --define "CLI_VERSION='${{ steps.version.outputs.version }}'" \
             --define "CLI_GIT_COMMIT='${{ steps.version.outputs.commit }}'" \
             --define "CLI_BUILD_DATE='${{ steps.version.outputs.date }}'"
+
+      # `bun build --compile` appends the bundle to a copy of the bun runtime.
+      # The runtime ships with an ad-hoc (linker-signed) signature covering the
+      # original bytes, so once the bundle is appended that signature no longer
+      # matches and the binary is left in a "code or signature have been
+      # modified" state. On Apple Silicon a valid signature is mandatory, so
+      # macOS may refuse to run it at all — SIGKILL before main(), which looks
+      # like the binary silently doing nothing (`--help` prints an empty
+      # string, exit 137).
+      #
+      # Re-signing ad-hoc recomputes the hashes over the final bytes. This is
+      # not notarization and grants no Gatekeeper trust — it only makes the
+      # file internally consistent, which is what the kernel checks here.
+      #
+      # Verified afterwards so a signing failure breaks the release instead of
+      # shipping a binary that cannot start.
+      - name: Ad-hoc sign the macOS binary
+        if: matrix.sign
+        run: |
+          codesign --force --sign - "dist/${{ matrix.artifact }}"
+          codesign --verify --verbose "dist/${{ matrix.artifact }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4


### PR DESCRIPTION
## The bug

The published darwin artifacts carry an **invalid code signature**.

```
$ codesign -v n8n-cli-darwin-arm64
invalid signature (code or signature have been modified)
```

On Apple Silicon a valid signature is mandatory, so the kernel refuses to start the process. The failure mode is unhelpful — the binary looks like it does nothing:

```
$ ./n8n-cli --help
$ echo $?
137          # SIGKILL, before main()
```

**v2.8.0 and v2.9.0 are both affected**, and presumably every release before them. I hit it today after downloading v2.9.0.

## Why (not what it looks like)

The obvious suspect is the cross-compile — darwin targets are built on `ubuntu-latest`. That is not it.

`bun build --compile` appends the bundle to a copy of the bun runtime. That runtime ships with an ad-hoc (linker-signed) signature covering its **original** bytes; appending the bundle invalidates it, and bun does not re-sign afterwards.

Building natively on macOS produces exactly the same broken signature — I checked both darwin targets locally:

```
$ bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile native-arm64 --minify
$ codesign -v native-arm64
invalid signature (code or signature have been modified)
```

## The fix

```
codesign --force --sign - dist/<artifact>
```

recomputes the hashes over the final bytes. Verified locally on both targets — signature valid, and the binary runs:

```
$ codesign -f -s - native-arm64 && codesign -v native-arm64 && ./native-arm64 --help
Usage: n8n-cli [options] [command]
```

This is **not notarization** and grants no Gatekeeper trust. It only makes the file internally consistent, which is the thing being checked here.

`codesign` only exists on macOS, so the two darwin targets move to `macos-latest`. The linux and windows targets stay on `ubuntu-latest`. Verification runs immediately after signing, so a signing failure fails the release instead of publishing a binary that cannot start.

## Cost

Two of the four build jobs move to macOS runners, which bill at a higher rate than Linux. It only affects release builds, not PR CI.

If that is not wanted, the alternative is [`rcodesign`](https://github.com/indygreg/apple-platform-rs) — a Rust reimplementation that can ad-hoc sign Mach-O from Linux, keeping everything on `ubuntu-latest` at the cost of one more third-party tool in the release path. Happy to switch if you prefer that trade.

## Already-published releases

This does not repair them. Two options:

1. **Leave them.** Anyone affected can repair their own copy: `codesign -f -s - ./n8n-cli`
2. **Re-upload** the darwin assets for v2.8.0 / v2.9.0 after signing locally, and regenerate `checksums.txt`. This changes checksums for artifacts already published, which anyone pinning them would notice.

I lean toward 1 plus a note, but say the word and I will do 2.

Linux artifacts are unaffected — the n8n-proxy image runs the linux-x64 build and has never had this problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FJjMV5HohRVgHtdcGsFjz