### PR TITLE
feat(apply,proxy): stop a stale checkout from reverting a workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ A definition records the upstream `updatedAt` it was written from. Before updati
 After a successful write the local file is re-stamped with the server's new timestamp, so the next edit is not mistaken for a conflict. In a CI-driven setup this happens on the runner, which means the stamp in version control stays behind until something writes it back — either commit the re-stamped files from the apply job, or run `import` on a schedule. Until it catches up, a second change to the same workflow will report a conflict that `--force` can push through.
 
 > **Behaviour change (YAML):** YAML definitions written before this feature carry no `updatedAt`, and applies against them were unconditional. Once `import` re-writes them with a stamp, those same applies start reporting conflicts — which is the point, but it is a change in behaviour for existing repositories. JSON and `.ts` definitions already carried the stamp.
+>
+> A second consequence, on the machine that ran the apply: `import` skips a workflow whose local stamp is already current, so anything the server normalised during the write (defaulted parameters, ids it assigned) does not come back down until the workflow changes again upstream. YAML now matches what JSON has always done, and what `.ts` does deliberately. The skip is by timestamp, not by selection, so `--ids` does not override it — delete the local file, or restore the committed version whose stamp is older, and import again.
 
 For enforcement that does not depend on the client (any working copy can pass `--force`, and other tools do not run this check at all), see the proxy's [stale-write guard](#stale-write-guard).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A command-line interface for managing [n8n](https://n8n.io/) workflows as code. 
 - **Convert** - Convert workflow files between JSON, YAML and TypeScript formats locally
 - **Import** - Pull workflows from an n8n server to local files, with optional YAML/TypeScript conversion and code externalization
 - **Lint** - Validate workflow definitions against configurable rules
-- **Proxy** - Transparent HTTP proxy that intercepts workflow saves to the n8n public API and runs lint server-side, blocking violations before they reach n8n
+- **Proxy** - Transparent HTTP proxy that intercepts workflow saves to the n8n public API and runs lint server-side, blocking violations before they reach n8n, and refusing writes built from an out-of-date copy of a workflow
 - **Format** - Auto-organize node positions for cleaner workflow layouts
 - **Test** - Execute CLI tests against workflows via webhook endpoints
 - **Webhook** - List and call a workflow's webhook nodes through the authenticated egress path
@@ -108,6 +108,16 @@ n8n-cli apply [options]
 | `--no-lint` | Skip the pre-write lint check (the check is on by default; an error-level violation marks the workflow as failed and prevents the API call. `--force` does NOT bypass lint failures — they represent policy, not merge conflicts) |
 | `--lint-config <path>` | Path to `.n8nlintrc.json` used by the pre-write lint check (auto-discovered if omitted) |
 | `--lint-disable-rule <rules>` | Comma-separated rule names to disable during the pre-write lint check |
+
+#### Conflict detection
+
+A definition records the upstream `updatedAt` it was written from. Before updating, `apply` compares that stamp against the live workflow: when upstream is newer *and* the content differs, the operation is reported as a conflict instead of being pushed, because applying it would revert a change nobody imported. `--force` overrides it; `import` resolves it properly.
+
+After a successful write the local file is re-stamped with the server's new timestamp, so the next edit is not mistaken for a conflict. In a CI-driven setup this happens on the runner, which means the stamp in version control stays behind until something writes it back — either commit the re-stamped files from the apply job, or run `import` on a schedule. Until it catches up, a second change to the same workflow will report a conflict that `--force` can push through.
+
+> **Behaviour change (YAML):** YAML definitions written before this feature carry no `updatedAt`, and applies against them were unconditional. Once `import` re-writes them with a stamp, those same applies start reporting conflicts — which is the point, but it is a change in behaviour for existing repositories. JSON and `.ts` definitions already carried the stamp.
+
+For enforcement that does not depend on the client (any working copy can pass `--force`, and other tools do not run this check at all), see the proxy's [stale-write guard](#stale-write-guard).
 
 #### Exit Codes
 
@@ -928,6 +938,10 @@ n8n-cli proxy [options]
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
 | `--middleware <list>` | Comma-separated middleware chain (default: `lint`; env: `N8N_MIDDLEWARES`). Example: `lint,authz` |
 | `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`). Non-matching saves are forwarded transparently |
+| `--stale-write-enforce <level>` | Stale-write guard: `off` (default), `warn`, or `error`. Requires `stale-write` in the middleware chain |
+| `--stale-write-on-missing-base <mode>` | Callers that declare no base revision: `allow` (default) or `deny` |
+| `--stale-write-on-error <mode>` | When the stored workflow cannot be read: `deny` (default) or `allow` |
+| `--stale-write-actions <actions>` | Route actions the guard applies to (default: `update`) |
 
 **Enforcement levels:**
 
@@ -970,6 +984,36 @@ Clients then point at `http://proxy-host:8080` instead of n8n directly. From the
 **Apply-style safety checks:** beyond lint, the proxy mirrors the same default-on duplicate-name safety that `apply` enforces. On every `POST /api/v1/workflows` the proxy fetches the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and rejects creates that collide with an existing remote name. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Pass `--allow-duplicates` to disable the check entirely (e.g. during a one-off bulk import). Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
 
 **Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations.
+
+#### Stale-write guard
+
+Lint asks whether a workflow is any good. The stale-write guard asks a different question: has the author seen the state they are about to overwrite?
+
+The failure it exists for is not a bad workflow. Someone edits a workflow in the n8n UI, nobody imports the change back into the repository, and the next `apply` from any working copy silently reverts it. That write is well-formed, authorized and in scope, so every other check waves it through.
+
+Add `stale-write` to the middleware chain to turn it on:
+
+```bash
+n8n-cli proxy \
+  --upstream https://n8n.example.com \
+  --middleware lint,stale-write \
+  --stale-write-enforce error
+```
+
+The client states which upstream revision its definition was based on, in an `X-N8n-Base-Updated-At` header — `n8n-cli apply` sends the `updatedAt` recorded in the local definition. The proxy reads the *stored* workflow (uncached: the whole point is that it reflects upstream right now, under the caller's own `X-N8N-API-KEY`) and compares. A mismatch in either direction is refused:
+
+```json
+{
+  "error": "workflow_stale_write",
+  "message": "Workflow abc123 was updated upstream at 2026-03-01T10:00:00.000Z, but this write is based on 2026-02-01T10:00:00.000Z. Applying it would revert changes the caller has never seen. Import the workflow and re-apply."
+}
+```
+
+Under `--stale-write-enforce warn` the write is forwarded with an `X-N8n-Stale-Write-Warning` response header instead, which is the way to measure how often this is happening before turning enforcement on.
+
+**Callers that declare no base** — the n8n UI itself, raw API calls, older `n8n-cli` versions, and any definition that predates timestamp persistence — cannot be judged. They are allowed by default so the guard can be switched on in front of a mixed fleet. Once every writer is known to send the header, `--stale-write-on-missing-base deny` closes the gap.
+
+> Like every other check here, this is only an enforcement boundary if direct access to the n8n API is blocked at the network level. A caller that can reach n8n directly bypasses the proxy entirely.
 
 **Scoping by tags:** pass `--tags managed,prod` (or set `PROXY_FILTER_BY_TAGS`) to constrain middleware enforcement to workflow saves whose `tags` contain every listed name. Saves outside that scope are forwarded transparently — no lint, no duplicate-name check, no authz. Useful when only a subset of workflows on the upstream is under policy. Filtering is AND across the listed names.
 
@@ -1152,6 +1196,10 @@ meantime reports a conflict and needs `--force`.
 | `APPLY_FILTER_BY_TAGS` | Comma-separated tags to filter apply targets |
 | `CHECKS_FILTER_BY_TAGS` | Comma-separated tags to filter lint/fmt targets (AND condition) |
 | `PROXY_FILTER_BY_TAGS` | Comma-separated tags to scope proxy middleware enforcement (AND condition) |
+| `N8N_STALE_WRITE_ENFORCE` | Stale-write guard level: `off` (default), `warn`, `error` |
+| `N8N_STALE_WRITE_ON_MISSING_BASE` | Callers that declare no base revision: `allow` (default) or `deny` |
+| `N8N_STALE_WRITE_ON_ERROR` | When the stored workflow cannot be read: `deny` (default) or `allow` |
+| `N8N_STALE_WRITE_ACTIONS` | Comma-separated route actions the guard applies to (default: `update`) |
 
 ### Talking to an authenticating gateway
 

--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ n8n-cli proxy [options]
 | `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default) |
 | `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
-| `--middleware <list>` | Comma-separated middleware chain (default: `lint`; env: `N8N_MIDDLEWARES`). Example: `lint,authz` |
+| `--server-middleware <list>` | Comma-separated server-middleware chain (default: `lint`; env: `N8N_SERVER_MIDDLEWARES`). Example: `lint,authz` |
 | `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`). Non-matching saves are forwarded transparently |
 | `--stale-write-enforce <level>` | Stale-write guard: `off` (default), `warn`, or `error`. Requires `stale-write` in the middleware chain |
 | `--stale-write-on-missing-base <mode>` | Callers that declare no base revision: `allow` (default) or `deny` |
@@ -991,12 +991,12 @@ Lint asks whether a workflow is any good. The stale-write guard asks a different
 
 The failure it exists for is not a bad workflow. Someone edits a workflow in the n8n UI, nobody imports the change back into the repository, and the next `apply` from any working copy silently reverts it. That write is well-formed, authorized and in scope, so every other check waves it through.
 
-Add `stale-write` to the middleware chain to turn it on:
+Add `stale-write` to the server-middleware chain to turn it on:
 
 ```bash
 n8n-cli proxy \
   --upstream https://n8n.example.com \
-  --middleware lint,stale-write \
+  --server-middleware lint,stale-write \
   --stale-write-enforce error
 ```
 

--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,8 @@ Under `--stale-write-enforce warn` the write is forwarded with an `X-N8n-Stale-W
 
 > Like every other check here, this is only an enforcement boundary if direct access to the n8n API is blocked at the network level. A caller that can reach n8n directly bypasses the proxy entirely.
 
+> **Do not combine this with `--tags`.** The tag filter reads tags from the request body, and the body `apply` sends carries `name`, `nodes`, `connections`, `settings` and `staticData` — no tags. Every write from `n8n-cli` therefore falls outside any tag scope and is forwarded without running middleware at all. Since `n8n-cli` is the only client that sends a base revision, `--tags` and `--stale-write-enforce error` together leave the guard doing nothing. The same is true of lint; see the note under [Scoping by tags](#proxy).
+
 **Scoping by tags:** pass `--tags managed,prod` (or set `PROXY_FILTER_BY_TAGS`) to constrain middleware enforcement to workflow saves whose `tags` contain every listed name. Saves outside that scope are forwarded transparently — no lint, no duplicate-name check, no authz. Useful when only a subset of workflows on the upstream is under policy. Filtering is AND across the listed names.
 
 > **Scope is advisory, not an enforcement boundary.** The filter reads tags from the request body the client sent, not from the existing upstream workflow, so a caller can bypass middleware by stripping the tag from the JSON they submit. Use it to opt subsets of workflows into policy (organizational scoping), not to defend against a hostile client; for hard enforcement keep the filter empty so every save is checked, or pair the filter with API-key / network-level access controls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,7 +42,17 @@ export class Client {
   }
 
   /** doRequest performs an HTTP request with authentication */
-  private async doRequest(method: string, path: string, body?: unknown): Promise<string> {
+  private async doRequest(
+    method: string,
+    path: string,
+    body?: unknown,
+    /**
+     * Extra headers for this one call, set before the client middlewares run
+     * so a middleware can still override them. Used for proxy control headers
+     * that only apply to specific operations (see `@/api/headers.ts`).
+     */
+    extraHeaders?: Record<string, string>,
+  ): Promise<string> {
     const url = `${this.baseURL}${path}`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -60,6 +70,10 @@ export class Client {
         // responses is not.
         "Accept-Encoding": "identity",
       });
+
+      for (const [name, value] of Object.entries(extraHeaders ?? {})) {
+        headers.set(name, value);
+      }
 
       if (this.clientMiddlewares.length > 0) {
         await runClientPipeline(this.clientMiddlewares, headers, {
@@ -109,8 +123,8 @@ export class Client {
   }
 
   /** Put performs a PUT request */
-  async put(path: string, body?: unknown): Promise<string> {
-    return this.doRequest("PUT", path, body);
+  async put(path: string, body?: unknown, extraHeaders?: Record<string, string>): Promise<string> {
+    return this.doRequest("PUT", path, body, extraHeaders);
   }
 
   /** Patch performs a PATCH request */

--- a/src/api/headers.ts
+++ b/src/api/headers.ts
@@ -1,0 +1,22 @@
+/**
+ * Header names shared between the CLI's API client and the `proxy` subcommand.
+ *
+ * These are proxy control headers, not n8n ones: the client sends them, the
+ * proxy consumes them, and the proxy strips them before the call reaches n8n —
+ * which has no idea they exist. Keeping the names here means the two ends
+ * cannot drift apart.
+ */
+
+/**
+ * Upstream `updatedAt` that the client's local definition was based on, sent
+ * on workflow updates.
+ *
+ * The stale-write guard compares it against the stored workflow and rejects
+ * the write when they differ: the caller is about to overwrite a state it has
+ * never seen. Absent when the local definition carries no timestamp (a
+ * hand-written file, or one imported before timestamps were persisted).
+ */
+export const BASE_UPDATED_AT_HEADER = "X-N8n-Base-Updated-At";
+
+/** Set on a forwarded response when the stale-write guard runs in `warn` mode. */
+export const STALE_WRITE_WARNING_HEADER = "X-N8n-Stale-Write-Warning";

--- a/src/api/workflow-service.ts
+++ b/src/api/workflow-service.ts
@@ -1,4 +1,5 @@
 import type { Client } from "./client.ts";
+import { BASE_UPDATED_AT_HEADER } from "./headers.ts";
 import type { ListWorkflowsResponse, TransferInput, Workflow, WorkflowInput } from "./types.ts";
 
 /** ListOptions represents options for listing workflows */
@@ -87,10 +88,23 @@ export class WorkflowService {
     return JSON.parse(data) as Workflow;
   }
 
-  /** UpdateWorkflow updates an existing workflow */
-  async updateWorkflow(id: string, input: WorkflowInput): Promise<Workflow> {
+  /**
+   * UpdateWorkflow updates an existing workflow.
+   *
+   * `baseUpdatedAt` is the upstream timestamp the caller's definition was
+   * written from. It is advisory: n8n itself ignores it, but a `proxy` running
+   * the stale-write guard uses it to reject a write whose base is no longer
+   * the stored state. Omit it when the caller has no basis to claim one —
+   * sending a wrong value is worse than sending none.
+   */
+  async updateWorkflow(
+    id: string,
+    input: WorkflowInput,
+    baseUpdatedAt?: string,
+  ): Promise<Workflow> {
     const path = `/workflows/${encodeURIComponent(id)}`;
-    const data = await this.client.put(path, input);
+    const headers = baseUpdatedAt ? { [BASE_UPDATED_AT_HEADER]: baseUpdatedAt } : undefined;
+    const data = await this.client.put(path, input, headers);
     return JSON.parse(data) as Workflow;
   }
 

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -13,6 +13,7 @@ import type { ServerMiddleware } from "../middleware/types.ts";
 import { DEFAULT_SERVER_MIDDLEWARE_CHAIN, registerBuiltins } from "../middleware/wiring.ts";
 import { compare } from "./differ.ts";
 import { DuplicateChecker } from "./duplicate.ts";
+import { updateLocalWorkflowFile } from "./local-file.ts";
 import { Scanner } from "./scanner.ts";
 import { TagMerger } from "./tags.ts";
 import { ThreeWayDetector } from "./threeway/detector.ts";
@@ -495,9 +496,39 @@ export class Executor {
       staticData: workflow.staticData,
     };
 
-    const updated = await this.workflowService.updateWorkflow(workflow.id!, input);
+    // The local timestamp, not the one just fetched from upstream: the claim
+    // being made is "my definition is based on this state", and a freshly
+    // fetched value would always match and assert nothing.
+    const updated = await this.workflowService.updateWorkflow(
+      workflow.id!,
+      input,
+      workflow.updatedAt,
+    );
     await this.applyTagsAndProject(updated, workflow, op);
-    await updateLocalWorkflowFile(wf.path, updated);
+    await updateLocalWorkflowFile(wf.path, await this.settledWorkflow(updated, op));
+  }
+
+  /**
+   * Returns the workflow as it stands after every post-write operation.
+   *
+   * Tagging, project transfer and activation are separate API calls that each
+   * bump `updatedAt` again, so the response to the update itself is already
+   * stale by the time they finish. Stamping a local file with it would leave
+   * the file permanently one step behind upstream, and the next edit would read
+   * as a conflict. Re-fetch only when one of those calls actually ran.
+   */
+  private async settledWorkflow(updated: Workflow, op: ApplyOperation): Promise<Workflow> {
+    const mutatedAfterWrite =
+      op.tagsAdded.length > 0 || op.projectMoved || op.activated !== undefined;
+    if (!mutatedAfterWrite || !updated.id) return updated;
+
+    try {
+      return await this.workflowService.getWorkflow(updated.id);
+    } catch {
+      // Non-fatal: the write succeeded, and a stamp that is one step behind is
+      // better than failing an apply that already did its job.
+      return updated;
+    }
   }
 
   /** Applies tags and transfers workflow to target project. */
@@ -605,36 +636,6 @@ function buildMiddlewareErrorMessage(
     errorOnly.length === 1 ? "" : "s"
   })${hint}`;
   return [summary, ...lines].join("\n  ");
-}
-
-/** Updates the local workflow file with server response data. */
-async function updateLocalWorkflowFile(filePath: string, workflow: Workflow): Promise<void> {
-  // Skip non-JSON files
-  const ext = path.extname(filePath).toLowerCase();
-  if (ext !== ".json") return;
-
-  let data: string;
-  try {
-    data = fs.readFileSync(filePath, "utf-8");
-  } catch {
-    return;
-  }
-
-  let existing: Record<string, unknown>;
-  try {
-    existing = JSON.parse(data);
-  } catch {
-    return;
-  }
-
-  existing.id = workflow.id;
-  existing.name = workflow.name;
-  existing.active = workflow.active;
-  if (workflow.updatedAt) existing.updatedAt = workflow.updatedAt;
-  if (workflow.createdAt) existing.createdAt = workflow.createdAt;
-
-  const output = JSON.stringify(existing, null, 2);
-  fs.writeFileSync(filePath, `${output}\n`);
 }
 
 /**

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -477,7 +477,7 @@ export class Executor {
 
     const created = await this.workflowService.createWorkflow(input);
     await this.applyTagsAndProject(created, workflow, op);
-    await updateLocalWorkflowFile(wf.path, created);
+    await updateLocalWorkflowFile(wf.path, await this.settledWorkflow(created, op));
   }
 
   /** Performs the actual update operation. */

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { isAlreadyOwnedError, isNotFoundError } from "../api/errors.ts";
 import type { TagService } from "../api/tag-service.ts";
@@ -378,7 +377,14 @@ export class Executor {
             op.operation = "update";
             if (!this.opts.dryRun) {
               try {
-                await this.executeUpdate(wf, remoteWorkflow, op);
+                // 3-way cleared this write by comparing the local change
+                // against the state just fetched, not against the file's own
+                // stamp — which is exactly the point of the format, since the
+                // stamp may be behind whenever the last apply's re-stamp was
+                // never committed. Declare the revision that was actually
+                // checked, otherwise a stale-write guard upstream would refuse
+                // a write that has been verified against current state.
+                await this.executeUpdate(wf, remoteWorkflow, op, remoteWorkflow.updatedAt);
               } catch (err) {
                 op.operation = "error";
                 op.error = err instanceof Error ? err : new Error(String(err));
@@ -485,6 +491,15 @@ export class Executor {
     wf: WorkflowFile,
     _remote: Workflow,
     op: ApplyOperation,
+    /**
+     * Upstream revision this write was verified against, declared to any
+     * stale-write guard in front of n8n. Defaults to the local definition's own
+     * stamp, which is what the 2-way path compared. A caller that checked
+     * against something else passes that instead — but never a value it did not
+     * actually check, and never one that lets `--force` talk its way past a
+     * guard whose entire job is to be independent of the client.
+     */
+    baseUpdatedAt: string | undefined = wf.workflow?.updatedAt,
   ): Promise<void> {
     const workflow = wf.workflow!;
     // Note: pinData is intentionally excluded - n8n API rejects it as additional property
@@ -496,14 +511,7 @@ export class Executor {
       staticData: workflow.staticData,
     };
 
-    // The local timestamp, not the one just fetched from upstream: the claim
-    // being made is "my definition is based on this state", and a freshly
-    // fetched value would always match and assert nothing.
-    const updated = await this.workflowService.updateWorkflow(
-      workflow.id!,
-      input,
-      workflow.updatedAt,
-    );
+    const updated = await this.workflowService.updateWorkflow(workflow.id!, input, baseUpdatedAt);
     await this.applyTagsAndProject(updated, workflow, op);
     await updateLocalWorkflowFile(wf.path, await this.settledWorkflow(updated, op));
   }

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -524,6 +524,14 @@ export class Executor {
    * stale by the time they finish. Stamping a local file with it would leave
    * the file permanently one step behind upstream, and the next edit would read
    * as a conflict. Re-fetch only when one of those calls actually ran.
+   *
+   * The re-fetched revision is adopted only if it still describes what this
+   * apply wrote. Someone editing the same workflow in the n8n UI during that
+   * window would otherwise have their revision stamped onto a local file that
+   * does not contain their change — and the next apply would then declare a
+   * base the guard accepts, reverting them with every check satisfied. Falling
+   * back leaves the file a revision behind, which surfaces as a conflict: the
+   * safe direction to be wrong in.
    */
   private async settledWorkflow(updated: Workflow, op: ApplyOperation): Promise<Workflow> {
     const mutatedAfterWrite =
@@ -531,12 +539,26 @@ export class Executor {
     if (!mutatedAfterWrite || !updated.id) return updated;
 
     try {
-      return await this.workflowService.getWorkflow(updated.id);
+      const settled = await this.workflowService.getWorkflow(updated.id);
+      return this.describesSameWrite(updated, settled, op) ? settled : updated;
     } catch {
       // Non-fatal: the write succeeded, and a stamp that is one step behind is
       // better than failing an apply that already did its job.
       return updated;
     }
+  }
+
+  /**
+   * Whether a re-fetched workflow still holds the content this apply wrote.
+   *
+   * Both sides come from the server, so server-side normalisation cancels out
+   * and any remaining difference was made by someone else. `active` is exempt
+   * when this apply is what changed it, and tags are not compared at all —
+   * assigning them is one of the calls being accounted for here.
+   */
+  private describesSameWrite(written: Workflow, settled: Workflow, op: ApplyOperation): boolean {
+    const diff = compare(written, settled);
+    return diff.fields.every((f) => f.field === "active" && op.activated !== undefined);
   }
 
   /** Applies tags and transfers workflow to target project. */

--- a/src/apply/local-file.ts
+++ b/src/apply/local-file.ts
@@ -85,6 +85,19 @@ function updateJSONFile(filePath: string, workflow: Workflow): void {
 const YAML_STAMP_ANCHORS = ["active", "name", "id"];
 
 /**
+ * Matches a top-level mapping key, quoted or not.
+ *
+ * YAML lets a key be written `updatedAt:`, `'updatedAt':` or `"updatedAt":`,
+ * and all three mean the same key. Recognising only the bare form would make
+ * the writer *add* a second one, and a duplicate mapping key is a parse error
+ * — the file would stop loading entirely, in every command, from one silent
+ * write.
+ */
+function yamlKeyPattern(key: string): RegExp {
+  return new RegExp(`^(['"]?)${key}\\1[ \\t]*:.*$`, "m");
+}
+
+/**
  * Replaces the top-level `updatedAt:` line, or inserts one after the first
  * anchor key present.
  *
@@ -98,13 +111,13 @@ export function patchYamlStamp(text: string, updatedAt: string | undefined): str
 
   const line = `updatedAt: '${updatedAt.replaceAll("'", "''")}'`;
 
-  const existing = /^updatedAt:.*$/m.exec(text);
+  const existing = yamlKeyPattern("updatedAt").exec(text);
   if (existing) {
     return `${text.slice(0, existing.index)}${line}${text.slice(existing.index + existing[0].length)}`;
   }
 
   for (const anchor of YAML_STAMP_ANCHORS) {
-    const match = new RegExp(`^${anchor}:.*$`, "m").exec(text);
+    const match = yamlKeyPattern(anchor).exec(text);
     if (!match) continue;
     const end = match.index + match[0].length;
     return `${text.slice(0, end)}\n${line}${text.slice(end)}`;
@@ -198,6 +211,11 @@ export function patchTsStamp(text: string, updatedAt: string | undefined): strin
   if (!meta) return null;
 
   const value = findStampValue(text, meta);
+  // The key is there but its value is not a plain string literal. Inserting
+  // would produce a duplicate property, and in an object literal the *last*
+  // one wins — so the file would keep reporting its old revision forever while
+  // looking like it had been updated. Leave it untouched instead.
+  if (value === "unparseable") return null;
   if (value) {
     return `${text.slice(0, value.start)}${JSON.stringify(updatedAt)}${text.slice(value.end)}`;
   }
@@ -206,8 +224,11 @@ export function patchTsStamp(text: string, updatedAt: string | undefined): strin
 }
 
 /**
- * Finds the string literal assigned to `meta.updatedAt`, or null when the block
- * does not declare one.
+ * Finds the string literal assigned to `meta.updatedAt`.
+ *
+ * Returns null when the block declares no such property, and `"unparseable"`
+ * when it declares one whose value this writer will not touch. The caller must
+ * treat those two differently: only the first is safe to insert into.
  *
  * Only properties of `meta` itself count. `nodeIds` is keyed by node name, and
  * a node called "updatedAt" would otherwise have its ID overwritten with a
@@ -217,15 +238,23 @@ export function patchTsStamp(text: string, updatedAt: string | undefined): strin
 function findStampValue(
   text: string,
   meta: { start: number; end: number },
-): { start: number; end: number } | null {
+): { start: number; end: number } | "unparseable" | null {
   let depth = 0;
 
   for (let i = meta.start; i < meta.end; i++) {
     const ch = text[i];
 
     if (ch === '"' || ch === "'" || ch === "`") {
-      i = skipString(text, i);
-      continue;
+      const close = skipString(text, i);
+      // A quoted key is still a key: `"updatedAt": "..."` declares exactly the
+      // same property as the bare form, and skipping past it would make the
+      // caller add a second one.
+      const keyEnd = depth === 0 ? matchQuotedKey(text, i, close) : null;
+      if (keyEnd === null) {
+        i = close;
+        continue;
+      }
+      return readStampValue(text, keyEnd);
     }
     if (ch === "/" && text[i + 1] === "/") {
       const nl = text.indexOf("\n", i);
@@ -254,12 +283,28 @@ function findStampValue(
     const colon = /^\s*:\s*/.exec(text.slice(i + "updatedAt".length));
     if (!colon) continue;
 
-    const valueStart = i + "updatedAt".length + colon[0].length;
-    const quote = text[valueStart];
-    if (quote !== '"' && quote !== "'") return null;
-
-    return { start: valueStart, end: skipString(text, valueStart) + 1 };
+    return readStampValue(text, i + "updatedAt".length + colon[0].length);
   }
 
   return null;
+}
+
+/**
+ * When the string spanning `[open, close]` is the quoted key `"updatedAt"`,
+ * returns the offset just past its colon. Otherwise null.
+ */
+function matchQuotedKey(text: string, open: number, close: number): number | null {
+  if (text.slice(open + 1, close) !== "updatedAt") return null;
+  const colon = /^\s*:\s*/.exec(text.slice(close + 1));
+  return colon ? close + 1 + colon[0].length : null;
+}
+
+/** Reads the string literal at `start`, or reports that it is not one. */
+function readStampValue(
+  text: string,
+  start: number,
+): { start: number; end: number } | "unparseable" {
+  const quote = text[start];
+  if (quote !== '"' && quote !== "'") return "unparseable";
+  return { start, end: skipString(text, start) + 1 };
 }

--- a/src/apply/local-file.ts
+++ b/src/apply/local-file.ts
@@ -120,7 +120,11 @@ export function patchYamlStamp(text: string, updatedAt: string | undefined): str
     const match = yamlKeyPattern(anchor).exec(text);
     if (!match) continue;
     const end = match.index + match[0].length;
-    return `${text.slice(0, end)}\n${line}${text.slice(end)}`;
+    // Match the terminator already in use. `$` stops before a `\r`, so a bare
+    // `\n` here would leave one CRLF file with one LF line — enough to show up
+    // as churn in a repository that stores CRLF.
+    const eol = text.startsWith("\r\n", end) ? "\r\n" : "\n";
+    return `${text.slice(0, end)}${eol}${line}${text.slice(end)}`;
   }
 
   // No anchor at all: not a shape this writer recognises, so leave it be

--- a/src/apply/local-file.ts
+++ b/src/apply/local-file.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import { META_EXPORT_NAME } from "@/ts/preprocess.ts";
+
+/**
+ * Writes back what the server decided, after a successful create or update.
+ *
+ * The important field is `updatedAt`. A definition carries the upstream
+ * timestamp it was written from, and `apply` compares that against the live
+ * workflow to tell an intentional update from an accidental revert of someone
+ * else's UI edit. Leaving a stale stamp behind after a successful write would
+ * make the *next* edit of the same file look like a conflict, so every format
+ * has to be re-stamped — not just JSON, which is all this used to handle.
+ *
+ * YAML and TypeScript are rewritten surgically, one line at a time. They are
+ * authored files: `!include` refs, comments and hand-written builder code do
+ * not survive a regenerate-from-remote, so the stamp is patched in place and
+ * everything else is left exactly as the author wrote it.
+ *
+ * Failures are swallowed throughout. The remote write already succeeded; a
+ * local file that could not be re-stamped is a stale timestamp, not a lost
+ * change, and turning it into an apply error would be a worse outcome.
+ */
+export async function updateLocalWorkflowFile(filePath: string, workflow: Workflow): Promise<void> {
+  switch (path.extname(filePath).toLowerCase()) {
+    case ".json":
+      updateJSONFile(filePath, workflow);
+      return;
+    case ".yaml":
+    case ".yml":
+      patchInPlace(filePath, (text) => patchYamlStamp(text, workflow.updatedAt));
+      return;
+    case ".ts":
+      patchInPlace(filePath, (text) => patchTsStamp(text, workflow.updatedAt));
+      return;
+    default:
+      return;
+  }
+}
+
+/** Reads, transforms and writes a file, doing nothing when anything fails. */
+function patchInPlace(filePath: string, transform: (text: string) => string | null): void {
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  const patched = transform(text);
+  if (patched === null || patched === text) return;
+
+  try {
+    fs.writeFileSync(filePath, patched);
+  } catch {
+    // see the note on updateLocalWorkflowFile
+  }
+}
+
+/**
+ * JSON holds the whole server object, so the server's view of identity and
+ * state is written back alongside the timestamps.
+ */
+function updateJSONFile(filePath: string, workflow: Workflow): void {
+  patchInPlace(filePath, (data) => {
+    let existing: Record<string, unknown>;
+    try {
+      existing = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    existing.id = workflow.id;
+    existing.name = workflow.name;
+    existing.active = workflow.active;
+    if (workflow.updatedAt) existing.updatedAt = workflow.updatedAt;
+    if (workflow.createdAt) existing.createdAt = workflow.createdAt;
+
+    return `${JSON.stringify(existing, null, 2)}\n`;
+  });
+}
+
+/** Top-level keys the stamp is inserted after, best anchor first. */
+const YAML_STAMP_ANCHORS = ["active", "name", "id"];
+
+/**
+ * Replaces the top-level `updatedAt:` line, or inserts one after the first
+ * anchor key present.
+ *
+ * The value is single-quoted to match what js-yaml emits, and for a reason
+ * beyond consistency: an unquoted ISO timestamp is parsed back as a `Date`
+ * rather than a `string`, which every consumer of `Workflow.updatedAt` would
+ * then have to handle.
+ */
+export function patchYamlStamp(text: string, updatedAt: string | undefined): string | null {
+  if (!updatedAt) return null;
+
+  const line = `updatedAt: '${updatedAt.replaceAll("'", "''")}'`;
+
+  const existing = /^updatedAt:.*$/m.exec(text);
+  if (existing) {
+    return `${text.slice(0, existing.index)}${line}${text.slice(existing.index + existing[0].length)}`;
+  }
+
+  for (const anchor of YAML_STAMP_ANCHORS) {
+    const match = new RegExp(`^${anchor}:.*$`, "m").exec(text);
+    if (!match) continue;
+    const end = match.index + match[0].length;
+    return `${text.slice(0, end)}\n${line}${text.slice(end)}`;
+  }
+
+  // No anchor at all: not a shape this writer recognises, so leave it be
+  // rather than prepending a key to a file that may not be a workflow.
+  return null;
+}
+
+/**
+ * Replaces `updatedAt` inside the `meta` export, or inserts it as the first
+ * entry when the file has a `meta` block without one.
+ *
+ * Only the first `meta` object literal is considered — a `.ts` workflow has
+ * exactly one, and matching further down the file would rewrite a node
+ * parameter that happens to be named the same.
+ */
+export function patchTsStamp(text: string, updatedAt: string | undefined): string | null {
+  if (!updatedAt) return null;
+
+  const metaStart = new RegExp(`export\\s+const\\s+${META_EXPORT_NAME}\\s*=\\s*\\{`).exec(text);
+  if (!metaStart) return null;
+
+  const bodyStart = metaStart.index + metaStart[0].length;
+  const bodyEnd = text.indexOf("\n};", bodyStart);
+  if (bodyEnd === -1) return null;
+
+  const body = text.slice(bodyStart, bodyEnd);
+  const existing = /^([ \t]*)updatedAt:.*$/m.exec(body);
+  if (existing) {
+    const replaced = `${existing[1]}updatedAt: ${JSON.stringify(updatedAt)},`;
+    const patchedBody = `${body.slice(0, existing.index)}${replaced}${body.slice(existing.index + existing[0].length)}`;
+    return `${text.slice(0, bodyStart)}${patchedBody}${text.slice(bodyEnd)}`;
+  }
+
+  return `${text.slice(0, bodyStart)}\n  updatedAt: ${JSON.stringify(updatedAt)},${text.slice(bodyStart)}`;
+}

--- a/src/apply/local-file.ts
+++ b/src/apply/local-file.ts
@@ -116,6 +116,74 @@ export function patchYamlStamp(text: string, updatedAt: string | undefined): str
 }
 
 /**
+ * Locates the body of the first `meta` object literal: the offsets just inside
+ * its braces, or null when the file has no such export.
+ *
+ * The end is found by matching braces rather than by looking for a closing
+ * line, because `.ts` workflows are hand-authored and `meta` is not always
+ * spread over multiple lines. Scanning for the first `\n};` would run past a
+ * single-line `meta` and swallow the workflow code after it, putting an
+ * `updatedAt:` in some node's parameters within reach of the rewrite below.
+ *
+ * Strings and comments are skipped so a brace inside either cannot end the
+ * literal early.
+ */
+function findMetaBody(text: string): { start: number; end: number } | null {
+  // The type annotation is optional: `export const meta: TsWorkflowMeta = {`
+  // is as valid an input as the unannotated form `import` writes.
+  const opening = new RegExp(`export\\s+const\\s+${META_EXPORT_NAME}\\s*(?::[^=]+)?=\\s*\\{`).exec(
+    text,
+  );
+  if (!opening) return null;
+
+  const start = opening.index + opening[0].length;
+  let depth = 1;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipString(text, i);
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      const nl = text.indexOf("\n", i);
+      if (nl === -1) return null;
+      i = nl;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      const close = text.indexOf("*/", i + 2);
+      if (close === -1) return null;
+      i = close + 1;
+      continue;
+    }
+
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return { start, end: i };
+    }
+  }
+
+  // Unbalanced braces: the file does not parse anyway, so leave it alone.
+  return null;
+}
+
+/** Returns the index of the closing quote of the string starting at `open`. */
+function skipString(text: string, open: number): number {
+  const quote = text[open];
+  for (let i = open + 1; i < text.length; i++) {
+    if (text[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (text[i] === quote) return i;
+  }
+  return text.length;
+}
+
+/**
  * Replaces `updatedAt` inside the `meta` export, or inserts it as the first
  * entry when the file has a `meta` block without one.
  *
@@ -126,20 +194,72 @@ export function patchYamlStamp(text: string, updatedAt: string | undefined): str
 export function patchTsStamp(text: string, updatedAt: string | undefined): string | null {
   if (!updatedAt) return null;
 
-  const metaStart = new RegExp(`export\\s+const\\s+${META_EXPORT_NAME}\\s*=\\s*\\{`).exec(text);
-  if (!metaStart) return null;
+  const meta = findMetaBody(text);
+  if (!meta) return null;
 
-  const bodyStart = metaStart.index + metaStart[0].length;
-  const bodyEnd = text.indexOf("\n};", bodyStart);
-  if (bodyEnd === -1) return null;
-
-  const body = text.slice(bodyStart, bodyEnd);
-  const existing = /^([ \t]*)updatedAt:.*$/m.exec(body);
-  if (existing) {
-    const replaced = `${existing[1]}updatedAt: ${JSON.stringify(updatedAt)},`;
-    const patchedBody = `${body.slice(0, existing.index)}${replaced}${body.slice(existing.index + existing[0].length)}`;
-    return `${text.slice(0, bodyStart)}${patchedBody}${text.slice(bodyEnd)}`;
+  const value = findStampValue(text, meta);
+  if (value) {
+    return `${text.slice(0, value.start)}${JSON.stringify(updatedAt)}${text.slice(value.end)}`;
   }
 
-  return `${text.slice(0, bodyStart)}\n  updatedAt: ${JSON.stringify(updatedAt)},${text.slice(bodyStart)}`;
+  return `${text.slice(0, meta.start)}\n  updatedAt: ${JSON.stringify(updatedAt)},${text.slice(meta.start)}`;
+}
+
+/**
+ * Finds the string literal assigned to `meta.updatedAt`, or null when the block
+ * does not declare one.
+ *
+ * Only properties of `meta` itself count. `nodeIds` is keyed by node name, and
+ * a node called "updatedAt" would otherwise have its ID overwritten with a
+ * timestamp. Replacing just the value also means the author's key spelling,
+ * indentation and quote style survive.
+ */
+function findStampValue(
+  text: string,
+  meta: { start: number; end: number },
+): { start: number; end: number } | null {
+  let depth = 0;
+
+  for (let i = meta.start; i < meta.end; i++) {
+    const ch = text[i];
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipString(text, i);
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      const nl = text.indexOf("\n", i);
+      i = nl === -1 ? meta.end : nl;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      const close = text.indexOf("*/", i + 2);
+      i = close === -1 ? meta.end : close + 1;
+      continue;
+    }
+    if (ch === "{" || ch === "[") {
+      depth++;
+      continue;
+    }
+    if (ch === "}" || ch === "]") {
+      depth--;
+      continue;
+    }
+    if (depth !== 0) continue;
+
+    if (!text.startsWith("updatedAt", i)) continue;
+    // Must be a whole word, so `lastUpdatedAt` does not match.
+    if (i > meta.start && /[\w$]/.test(text[i - 1] ?? "")) continue;
+
+    const colon = /^\s*:\s*/.exec(text.slice(i + "updatedAt".length));
+    if (!colon) continue;
+
+    const valueStart = i + "updatedAt".length + colon[0].length;
+    const quote = text[valueStart];
+    if (quote !== '"' && quote !== "'") return null;
+
+    return { start: valueStart, end: skipString(text, valueStart) + 1 };
+  }
+
+  return null;
 }

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -349,7 +349,8 @@ export function registerProxyCommand(program: Command): void {
  * how to read. Keeping the projection explicit prevents commander
  * artifacts (`_optionValues`, etc.) from leaking into factory inputs.
  */
-function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
+/** Exported for unit tests that assert declared flags actually reach a factory. */
+export function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   const copy = (k: keyof ProxyOptions) => {
     if (opts[k] !== undefined) out[k] = opts[k];

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -65,6 +65,11 @@ interface ProxyOptions {
   authzOnMissingAcl?: string;
   authzBootstrapGroups?: string;
   authzActions?: string;
+  // stale-write server middleware options.
+  staleWriteEnforce?: string;
+  staleWriteOnMissingBase?: string;
+  staleWriteOnError?: string;
+  staleWriteActions?: string;
   // oauth-verify server middleware options. Verifies the incoming
   // Authorization: Bearer against Google's tokeninfo endpoint.
   oauthVerifyEnforce?: string;
@@ -215,6 +220,24 @@ export function registerProxyCommand(program: Command): void {
       "--authz-actions <actions>",
       "Comma-separated route actions this middleware authorizes (default: all it sees)",
     )
+    // Stale-write options — only meaningful when "stale-write" is in the
+    // server-middleware chain.
+    .option(
+      "--stale-write-enforce <level>",
+      "Stale-write enforcement level: off (default), warn, error. Rejects an update whose X-N8n-Base-Updated-At does not match the stored workflow",
+    )
+    .option(
+      "--stale-write-on-missing-base <mode>",
+      "What to do when the caller sends no base revision: allow (default) or deny",
+    )
+    .option(
+      "--stale-write-on-error <mode>",
+      "Behavior when the stored workflow cannot be read: deny (default) or allow",
+    )
+    .option(
+      "--stale-write-actions <actions>",
+      "Comma-separated route actions the guard applies to (default: update)",
+    )
     // oauth-verify — verifies incoming Authorization: Bearer via Google tokeninfo.
     .option(
       "--oauth-verify-enforce <level>",
@@ -346,6 +369,10 @@ function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
   copy("authzGroupsTimeoutMs");
   copy("authzWorkflowExtract");
   copy("authzWorkflowStripPrefix");
+  copy("staleWriteEnforce");
+  copy("staleWriteOnMissingBase");
+  copy("staleWriteOnError");
+  copy("staleWriteActions");
   copy("oauthVerifyEnforce");
   copy("oauthVerifyExpectedAudiences");
   copy("oauthVerifyTrustedPrincipals");

--- a/src/middleware/builtin/stale-write/factory.ts
+++ b/src/middleware/builtin/stale-write/factory.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
+import { StaleWriteMiddleware } from "./middleware.ts";
+import type {
+  StaleWriteEnforce,
+  StaleWriteOnError,
+  StaleWriteOnMissingBase,
+  StaleWriteOptions,
+} from "./types.ts";
+
+const optionsSchema = z.object({
+  // Unlike lint, this check needs cooperation from the client — a caller that
+  // sends no base revision cannot be judged. Defaulting to `error` would turn
+  // the guard on the moment someone adds "stale-write" to their chain, before
+  // they have decided what to do about writers that do not send one. Operators
+  // opt in explicitly.
+  enforce: z.union([z.literal("off"), z.literal("warn"), z.literal("error")]).default("off"),
+  onMissingBase: z.union([z.literal("allow"), z.literal("deny")]).default("allow"),
+  onError: z.union([z.literal("allow"), z.literal("deny")]).default("deny"),
+  actions: z.array(z.string()).default(["update"]),
+});
+
+/** Comma-separated list → trimmed, non-empty entries. */
+function splitList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<StaleWriteOptions> {
+  const opts: Partial<StaleWriteOptions> = {};
+  if (env.N8N_STALE_WRITE_ENFORCE) {
+    opts.enforce = env.N8N_STALE_WRITE_ENFORCE as StaleWriteEnforce;
+  }
+  if (env.N8N_STALE_WRITE_ON_MISSING_BASE) {
+    opts.onMissingBase = env.N8N_STALE_WRITE_ON_MISSING_BASE as StaleWriteOnMissingBase;
+  }
+  if (env.N8N_STALE_WRITE_ON_ERROR) {
+    opts.onError = env.N8N_STALE_WRITE_ON_ERROR as StaleWriteOnError;
+  }
+  if (env.N8N_STALE_WRITE_ACTIONS) {
+    opts.actions = splitList(env.N8N_STALE_WRITE_ACTIONS);
+  }
+  return opts;
+}
+
+function fromCLI(cliOpts: Record<string, unknown>): Partial<StaleWriteOptions> {
+  const out: Partial<StaleWriteOptions> = {};
+  const s = (k: string) => (typeof cliOpts[k] === "string" ? (cliOpts[k] as string) : undefined);
+
+  const enforce = s("staleWriteEnforce");
+  if (enforce) out.enforce = enforce as StaleWriteEnforce;
+  const onMissingBase = s("staleWriteOnMissingBase");
+  if (onMissingBase) out.onMissingBase = onMissingBase as StaleWriteOnMissingBase;
+  const onError = s("staleWriteOnError");
+  if (onError) out.onError = onError as StaleWriteOnError;
+  const actions = s("staleWriteActions");
+  if (actions) out.actions = splitList(actions);
+
+  return out;
+}
+
+export const staleWriteFactory: ServerMiddlewareFactory<StaleWriteOptions> = {
+  name: "stale-write",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged) as StaleWriteOptions;
+    return new StaleWriteMiddleware(parsed);
+  },
+};
+
+/** Exposed for unit tests that build options directly. */
+export const staleWriteOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/stale-write/middleware.ts
+++ b/src/middleware/builtin/stale-write/middleware.ts
@@ -1,0 +1,144 @@
+import { BASE_UPDATED_AT_HEADER } from "@/api/headers.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
+import type { StaleWriteOptions } from "./types.ts";
+
+/** Violation rule name, also used by the proxy to recognise a warn-mode result. */
+export const STALE_WRITE_RULE = "stale-write";
+
+/**
+ * Stale-write guard: rejects an update whose author never saw the state they
+ * are about to overwrite.
+ *
+ * The failure it exists for is not a bad workflow — lint already catches those
+ * — but a good one applied from an out-of-date checkout. Someone edits a
+ * workflow in the n8n UI, nobody imports the change back into the repository,
+ * and the next `apply` from any working copy silently reverts it. The write is
+ * well-formed and authorized, so every other check waves it through.
+ *
+ * The caller states which upstream revision its definition was based on, via
+ * the `X-N8n-Base-Updated-At` header. The guard reads the *stored* workflow and
+ * compares. Equal means the caller is up to date; different means upstream
+ * moved underneath them, and the write is refused with 409 so they can import
+ * and re-apply.
+ *
+ * Deliberately uncached, unlike the duplicate-name check next to it: the whole
+ * value of the read is that it reflects upstream *now*. A cache would let a
+ * concurrent edit slip through the window it opens.
+ *
+ * Mismatch is judged in both directions. A base *newer* than what upstream
+ * stores is not a safe write either — it means the caller's picture of the
+ * workflow does not correspond to any state upstream currently has, most
+ * likely because it was restored from a backup — so it is treated the same way.
+ */
+export class StaleWriteMiddleware implements ServerMiddleware {
+  readonly name = "stale-write";
+  /**
+   * The verdict is about *when* the definition was written, not what is in it,
+   * so this must keep running on routes that carry no workflow body.
+   */
+  readonly readsWorkflowBody = false;
+
+  constructor(private readonly options: StaleWriteOptions) {}
+
+  async evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> {
+    if (this.options.enforce === "off") return pass();
+
+    // Apply mode has its own conflict detection against the same timestamps
+    // and no HTTP request to read a header from. Nothing useful to add here.
+    if (ctx.mode !== "proxy") return pass();
+
+    const scoped = this.options.actions;
+    if (scoped.length > 0 && (!ctx.action || !scoped.includes(ctx.action))) return pass();
+
+    const id = ctx.workflowId;
+    if (!id) return pass();
+
+    const base = ctx.request?.headers.get(BASE_UPDATED_AT_HEADER)?.trim();
+    if (!base) {
+      if (this.options.onMissingBase === "allow") return pass();
+      return this.deny(
+        `Write declares no base revision (${BASE_UPDATED_AT_HEADER} header is absent). ` +
+          "Re-import the workflow so the local definition records the revision it was written from.",
+      );
+    }
+
+    if (!ctx.fetchStoredWorkflow) {
+      return this.onReadFailure("this host provides no stored-workflow reader");
+    }
+
+    let storedUpdatedAt: string | undefined;
+    try {
+      const stored = await ctx.fetchStoredWorkflow(id);
+      // No stored workflow means nothing can be reverted by this write.
+      if (!stored) return pass();
+      storedUpdatedAt = stored.updatedAt;
+    } catch (err) {
+      return this.onReadFailure(err instanceof Error ? err.message : String(err));
+    }
+
+    // Upstream does not expose a timestamp for this workflow, so the caller's
+    // claim can be neither confirmed nor refuted. Blocking here would break
+    // every write against such an instance.
+    if (!storedUpdatedAt) return pass();
+
+    if (sameInstant(base, storedUpdatedAt)) return pass();
+
+    return this.deny(
+      `Workflow ${id} was updated upstream at ${storedUpdatedAt}, but this write is based on ${base}. ` +
+        "Applying it would revert changes the caller has never seen. Import the workflow and re-apply.",
+    );
+  }
+
+  /** Read failures are a policy choice: fail closed by default. */
+  private onReadFailure(reason: string): MiddlewareVerdict {
+    if (this.options.onError === "allow") {
+      return {
+        block: false,
+        violations: [
+          {
+            rule: `${STALE_WRITE_RULE}-warning`,
+            severity: "warning",
+            message: `Stored-state lookup failed (fail-open): ${reason}`,
+          },
+        ],
+      };
+    }
+    return this.deny(`Stored-state lookup failed: ${reason}`);
+  }
+
+  private deny(message: string): MiddlewareVerdict {
+    const violations = [{ rule: STALE_WRITE_RULE, severity: "error" as const, message }];
+    if (this.options.enforce === "warn") {
+      return { block: false, violations };
+    }
+    return {
+      block: true,
+      violations,
+      denial: { status: 409, error: "workflow_stale_write", message },
+    };
+  }
+}
+
+function pass(): MiddlewareVerdict {
+  return { block: false, violations: [] };
+}
+
+/**
+ * Compares two timestamps as instants, falling back to an exact string match.
+ *
+ * Timestamps make a round trip through YAML, TypeScript and JSON before coming
+ * back as a header, and formatting differences along the way (a dropped
+ * trailing `Z`, `+00:00` for UTC) must not read as a conflict. Anything that
+ * does not parse is compared verbatim, which is strict but never wrong.
+ */
+function sameInstant(a: string, b: string): boolean {
+  if (a === b) return true;
+  const left = Date.parse(a);
+  const right = Date.parse(b);
+  if (Number.isNaN(left) || Number.isNaN(right)) return false;
+  return left === right;
+}

--- a/src/middleware/builtin/stale-write/types.ts
+++ b/src/middleware/builtin/stale-write/types.ts
@@ -1,0 +1,28 @@
+/** How a stale write is surfaced. */
+export type StaleWriteEnforce = "off" | "warn" | "error";
+
+/** What to do when the caller declares no base state. */
+export type StaleWriteOnMissingBase = "allow" | "deny";
+
+/** What to do when the stored state cannot be read. */
+export type StaleWriteOnError = "allow" | "deny";
+
+export interface StaleWriteOptions {
+  /** `off` skips the check, `warn` reports without blocking, `error` blocks. */
+  enforce: StaleWriteEnforce;
+  /**
+   * Callers that send no base timestamp. `allow` (the default) is what lets
+   * the guard be switched on in front of a mixed fleet — older CLI versions,
+   * the n8n UI itself and raw API calls all write without one. `deny` closes
+   * that gap once every writer is known to send it.
+   */
+  onMissingBase: StaleWriteOnMissingBase;
+  /** Upstream read failures: `deny` refuses the write, `allow` lets it pass. */
+  onError: StaleWriteOnError;
+  /**
+   * Routes the guard applies to. Defaults to `update` — the only operation
+   * that can silently overwrite someone else's work. A `create` has no stored
+   * state to be stale against.
+   */
+  actions: string[];
+}

--- a/src/middleware/wiring.ts
+++ b/src/middleware/wiring.ts
@@ -2,6 +2,7 @@ import { authzFactory } from "./builtin/authz/factory.ts";
 import { impersonatorVerifyFactory } from "./builtin/impersonator-verify/factory.ts";
 import { lintFactory } from "./builtin/lint/factory.ts";
 import { oauthVerifyFactory } from "./builtin/oauth-verify/factory.ts";
+import { staleWriteFactory } from "./builtin/stale-write/factory.ts";
 import { knownMiddlewareNames, registerFactory } from "./registry.ts";
 
 /**
@@ -15,6 +16,7 @@ export function registerBuiltins(): void {
   registerFactory(authzFactory);
   registerFactory(oauthVerifyFactory);
   registerFactory(impersonatorVerifyFactory);
+  registerFactory(staleWriteFactory);
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -375,11 +375,15 @@ async function handleWorkflowMutation(
       timeoutMs: deps.config.upstreamTimeoutMs,
       clientMiddlewares: deps.clientMiddlewares,
     });
-    if (verdict.violations.length > 0) {
-      const errCount = verdict.violations.filter(
-        (v) => v.severity === "error" || !v.severity,
-      ).length;
-      response.headers.set("x-n8n-lint-violations", String(verdict.violations.length));
+    // Counted over lint's own violations only. A stale write is reported on its
+    // own header below, and folding it in here would make it indistinguishable
+    // from a lint failure — a CI step gating on `x-n8n-lint-errors`, which is
+    // the documented way to roll lint out, would start failing builds for
+    // writes that warn mode deliberately chose not to block, and blame lint.
+    const lintViolations = verdict.violations.filter((v) => !v.rule.startsWith(STALE_WRITE_RULE));
+    if (lintViolations.length > 0) {
+      const errCount = lintViolations.filter((v) => v.severity === "error" || !v.severity).length;
+      response.headers.set("x-n8n-lint-violations", String(lintViolations.length));
       response.headers.set("x-n8n-lint-errors", String(errCount));
     }
     if (duplicateMatches.length > 0) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -226,6 +226,19 @@ function handleProbe(method: string, pathname: string, deps: HandlerDeps): Respo
   });
 }
 
+/**
+ * Makes a message safe to carry in a response header.
+ *
+ * The text quotes a timestamp that came from an upstream JSON document, so it
+ * is not this proxy's to trust. A control character in it would make
+ * `Headers.set` throw, and the throw would land in the forwarding try/catch and
+ * turn a write that upstream already accepted into a 502 for the client.
+ */
+function headerSafe(message: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point.
+  return message.replace(/[\u0000-\u001F\u007F]/g, " ").slice(0, 512);
+}
+
 async function handleTransparentForward(
   req: Request,
   pathname: string,
@@ -376,7 +389,7 @@ async function handleWorkflowMutation(
     if (staleWrites.length > 0) {
       response.headers.set(
         STALE_WRITE_WARNING_HEADER.toLowerCase(),
-        staleWrites[0]?.message ?? "stale write",
+        headerSafe(staleWrites[0]?.message ?? "stale write"),
       );
     }
     const action = verdict.violations.length > 0 || duplicateMatches.length > 0 ? "warn" : "pass";

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -229,14 +229,17 @@ function handleProbe(method: string, pathname: string, deps: HandlerDeps): Respo
 /**
  * Makes a message safe to carry in a response header.
  *
- * The text quotes a timestamp that came from an upstream JSON document, so it
- * is not this proxy's to trust. A control character in it would make
- * `Headers.set` throw, and the throw would land in the forwarding try/catch and
- * turn a write that upstream already accepted into a 502 for the client.
+ * The text quotes a timestamp and a workflow id that came from upstream and
+ * from the request path, so neither is this proxy's to trust. `Headers.set`
+ * rejects control characters *and* anything outside Latin-1 — a workflow id of
+ * `%E6%97%A5` is enough — and the throw would land in the forwarding try/catch,
+ * turning a write upstream had already accepted into a 502 for the client.
+ *
+ * So the value is reduced to printable ASCII. It is a human-readable hint, not
+ * a payload; the full message is in the proxy's own log either way.
  */
 function headerSafe(message: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point.
-  return message.replace(/[\u0000-\u001F\u007F]/g, " ").slice(0, 512);
+  return message.replace(/[^\x20-\x7e]/g, " ").slice(0, 512);
 }
 
 async function handleTransparentForward(

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,5 +1,7 @@
+import { STALE_WRITE_WARNING_HEADER } from "@/api/headers.ts";
 import type { Workflow } from "@/api/types.ts";
 import { hasAllTags } from "@/common/tags.ts";
+import { STALE_WRITE_RULE } from "@/middleware/builtin/stale-write/middleware.ts";
 import { buildClientMiddlewares } from "@/middleware/client-registry.ts";
 import {
   DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
@@ -366,6 +368,16 @@ async function handleWorkflowMutation(
     }
     if (duplicateMatches.length > 0) {
       response.headers.set("x-n8n-duplicate-warning", String(duplicateMatches.length));
+    }
+    // A stale write that reached this point ran under `enforce: warn`. Say so
+    // out of band, the way the duplicate check does, so a client can notice it
+    // reverted something without the write having been refused.
+    const staleWrites = verdict.violations.filter((v) => v.rule === STALE_WRITE_RULE);
+    if (staleWrites.length > 0) {
+      response.headers.set(
+        STALE_WRITE_WARNING_HEADER.toLowerCase(),
+        staleWrites[0]?.message ?? "stale write",
+      );
     }
     const action = verdict.violations.length > 0 || duplicateMatches.length > 0 ? "warn" : "pass";
     deps.logger.log({

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -6,7 +6,8 @@
  * `Proxy-Authenticate`) plus any header named in the incoming `Connection:`
  * header, and the original `Host` header (it would carry the proxy's host into
  * the upstream call). `Content-Length` is also stripped because fetch
- * recomputes it from the actual body.
+ * recomputes it from the actual body, and so are the proxy's own control
+ * headers (see `@/api/headers.ts`), which n8n has no use for.
  *
  * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) by default — the
  * client is expected to supply them and the upstream needs them to
@@ -16,8 +17,15 @@
  * On the way back, `Content-Encoding` (and the now-stale `Content-Length`) are
  * dropped from the upstream response — see `normalizeResponseEncoding`.
  */
+import { BASE_UPDATED_AT_HEADER } from "@/api/headers.ts";
 import { runClientPipeline } from "@/middleware/client-pipeline.ts";
 import type { ClientMiddleware } from "@/middleware/types.ts";
+
+/**
+ * Headers the proxy consumes itself. They address this hop, not n8n, so they
+ * are dropped for the same reason hop-by-hop headers are.
+ */
+const PROXY_CONTROL_HEADERS = [BASE_UPDATED_AT_HEADER.toLowerCase()];
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -45,6 +53,9 @@ function buildUpstreamHeaders(req: Request): Headers {
   }
 
   for (const h of HOP_BY_HOP_HEADERS) {
+    headers.delete(h);
+  }
+  for (const h of PROXY_CONTROL_HEADERS) {
     headers.delete(h);
   }
   return headers;

--- a/src/yaml/generator.ts
+++ b/src/yaml/generator.ts
@@ -349,9 +349,23 @@ export function buildYamlObject(
     id: workflow.id,
     name: workflow.name,
     active: workflow.active,
-    nodes,
-    connections: workflow.connections,
   };
+
+  // Server-assigned timestamp of the state this file was written from. It is
+  // never sent back on a write — it exists so `apply` can tell "my definition
+  // is based on the current upstream state" from "someone edited this workflow
+  // in the n8n UI after I last imported it", which is the difference between an
+  // update and an accidental revert. Only emitted when the source carries one,
+  // so hand-written files and `convert` output stay untouched.
+  //
+  // js-yaml quotes the ISO string on dump, which matters: an unquoted timestamp
+  // is parsed back as a `Date`, not a `string`.
+  if (workflow.updatedAt) {
+    result.updatedAt = workflow.updatedAt;
+  }
+
+  result.nodes = nodes;
+  result.connections = workflow.connections;
 
   if (workflow.settings) {
     result.settings = workflow.settings;

--- a/src/yaml/generator.ts
+++ b/src/yaml/generator.ts
@@ -356,7 +356,9 @@ export function buildYamlObject(
   // is based on the current upstream state" from "someone edited this workflow
   // in the n8n UI after I last imported it", which is the difference between an
   // update and an accidental revert. Only emitted when the source carries one,
-  // so hand-written files and `convert` output stay untouched.
+  // so a hand-written workflow does not acquire a revision it never had.
+  // `convert` goes through here too, and carries the stamp across when the
+  // source format already had one.
   //
   // js-yaml quotes the ISO string on dump, which matters: an unquoted timestamp
   // is parsed back as a `Date`, not a `string`.

--- a/src/yaml/loader.ts
+++ b/src/yaml/loader.ts
@@ -43,10 +43,33 @@ export function loadYamlWorkflow(filePath: string, options?: LoadYamlOptions): W
     throw new Error(`YAML file "${filePath}" did not produce a valid object`);
   }
 
+  normalizeTimestamps(parsed as Record<string, unknown>);
+
   if (resolveIncludes) {
     const stripHeaders = options?.stripFileHeaders ?? false;
     parsed = resolveIncludeRefs(parsed, baseDir, { stripFileHeaders: stripHeaders });
   }
 
   return parsed as Workflow;
+}
+
+/**
+ * Forces the workflow-level timestamps back to strings, in place.
+ *
+ * YAML's implicit typing turns an unquoted ISO timestamp into a `Date`, and
+ * `Workflow.updatedAt` is declared — and consumed — as a string: conflict
+ * detection compares it, and `apply` sends it upstream as a header. It must run
+ * before `resolveIncludeRefs`, which walks objects with `Object.entries` and so
+ * flattens any `Date` it meets into `{}`, destroying the value outright.
+ *
+ * Files written by `import` quote the value and are unaffected. This is for the
+ * hand-edited ones.
+ */
+function normalizeTimestamps(parsed: Record<string, unknown>): void {
+  for (const key of ["createdAt", "updatedAt"]) {
+    const value = parsed[key];
+    if (value instanceof Date) {
+      parsed[key] = value.toISOString();
+    }
+  }
 }

--- a/tests/api/base-updated-at-header.test.ts
+++ b/tests/api/base-updated-at-header.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Client } from "@/api/client.ts";
+import { BASE_UPDATED_AT_HEADER } from "@/api/headers.ts";
+import type { WorkflowInput } from "@/api/types.ts";
+import { WorkflowService } from "@/api/workflow-service.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
+
+/**
+ * The base-revision header, on the wire.
+ *
+ * The apply-level tests stop at the WorkflowService boundary, so without this
+ * the claim "apply declares the revision it was built on" is never checked
+ * against an actual request — and the proxy guard is useless if the header
+ * never leaves the client.
+ */
+
+function captureRequests(): { headers: Headers[]; restore: () => void } {
+  const headers: Headers[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async (_input: unknown, init: RequestInit) => {
+    headers.push(new Headers(init.headers));
+    return new Response(JSON.stringify({ id: "wf1" }), { status: 200 });
+  }) as unknown as typeof fetch;
+  return { headers, restore: () => (globalThis.fetch = originalFetch) };
+}
+
+const INPUT: WorkflowInput = { name: "wf", nodes: [], connections: {} };
+
+describe("updateWorkflow base revision", () => {
+  it("sends the declared base revision", async () => {
+    const { headers, restore } = captureRequests();
+    try {
+      const service = new WorkflowService(new Client("https://n8n.example.com", "key"));
+      await service.updateWorkflow("wf1", INPUT, "2026-03-01T10:00:00.000Z");
+      expect(headers[0]?.get(BASE_UPDATED_AT_HEADER)).toBe("2026-03-01T10:00:00.000Z");
+    } finally {
+      restore();
+    }
+  });
+
+  it("sends nothing when the caller has no base to declare", async () => {
+    const { headers, restore } = captureRequests();
+    try {
+      const service = new WorkflowService(new Client("https://n8n.example.com", "key"));
+      await service.updateWorkflow("wf1", INPUT);
+      expect(headers[0]?.has(BASE_UPDATED_AT_HEADER)).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves the standard headers alone", async () => {
+    const { headers, restore } = captureRequests();
+    try {
+      const service = new WorkflowService(new Client("https://n8n.example.com", "key"));
+      await service.updateWorkflow("wf1", INPUT, "2026-03-01T10:00:00.000Z");
+      expect(headers[0]?.get("X-N8N-API-KEY")).toBe("key");
+      expect(headers[0]?.get("Content-Type")).toBe("application/json");
+    } finally {
+      restore();
+    }
+  });
+
+  it("runs before the egress middlewares, so a gateway chain can still override", async () => {
+    const { headers, restore } = captureRequests();
+    const middleware: ClientMiddleware = {
+      name: "test",
+      apply(h) {
+        h.set(BASE_UPDATED_AT_HEADER, "rewritten");
+      },
+    };
+    try {
+      const service = new WorkflowService(
+        new Client("https://n8n.example.com", "key", 30_000, [middleware]),
+      );
+      await service.updateWorkflow("wf1", INPUT, "2026-03-01T10:00:00.000Z");
+      expect(headers[0]?.get(BASE_UPDATED_AT_HEADER)).toBe("rewritten");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/apply/apply.stale-write.test.ts
+++ b/tests/apply/apply.stale-write.test.ts
@@ -133,4 +133,45 @@ describe("apply against a YAML definition with a stamp", () => {
     expect(result.updateCount).toBe(1);
     expect(recorded.updates[0]?.baseUpdatedAt).toBeUndefined();
   });
+
+  test("a created workflow is stamped with the state that survived auto-tagging", async () => {
+    // Auto-tagging runs after the create call and bumps `updatedAt` again.
+    // Stamping the file with the create response would leave it one revision
+    // behind, and the author's very first edit would read as a conflict.
+    const file = writeLocalYaml(undefined);
+    fs.writeFileSync(
+      file,
+      ["name: brand new", "active: false", "nodes: []", "connections: {}", ""].join("\n"),
+    );
+
+    const created = {
+      id: "wf-new",
+      name: "brand new",
+      active: false,
+      nodes: [],
+      connections: {},
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    } as Workflow;
+    const settled = { ...created, updatedAt: "2026-05-01T00:00:05.000Z" } as Workflow;
+
+    const service = {
+      listAllWorkflows: async () => [],
+      getWorkflow: async () => settled,
+      createWorkflow: async () => created,
+      getWorkflowCurrentProjectID: () => "",
+    } as unknown as WorkflowService;
+
+    const exec = executor(service, { autoTags: ["managed"] });
+    exec.setTagService({
+      listTags: async () => [],
+      findOrCreateTag: async (name: string) => ({ id: `tag-${name}`, name }),
+      updateWorkflowTags: async () => {},
+    } as never);
+
+    const result = await exec.execute();
+
+    expect(result.createCount).toBe(1);
+    expect(result.operations[0]?.tagsAdded.length).toBeGreaterThan(0);
+    expect(loadYamlWorkflow(file).updatedAt).toBe("2026-05-01T00:00:05.000Z");
+  });
 });

--- a/tests/apply/apply.stale-write.test.ts
+++ b/tests/apply/apply.stale-write.test.ts
@@ -175,3 +175,65 @@ describe("apply against a YAML definition with a stamp", () => {
     expect(loadYamlWorkflow(file).updatedAt).toBe("2026-05-01T00:00:05.000Z");
   });
 });
+
+describe("the post-write re-fetch", () => {
+  /** A create that also applies auto-tags, so `settledWorkflow` re-fetches. */
+  function createScenario(settled: Workflow, created: Workflow) {
+    const file = path.join(dir, "wf__new.yaml");
+    fs.writeFileSync(
+      file,
+      ["name: brand new", "active: false", "nodes: []", "connections: {}", ""].join("\n"),
+    );
+
+    const service = {
+      listAllWorkflows: async () => [],
+      getWorkflow: async () => settled,
+      createWorkflow: async () => created,
+      getWorkflowCurrentProjectID: () => "",
+    } as unknown as WorkflowService;
+
+    const exec = executor(service, { autoTags: ["managed"] });
+    exec.setTagService({
+      listTags: async () => [],
+      findOrCreateTag: async (name: string) => ({ id: `tag-${name}`, name }),
+      updateWorkflowTags: async () => {},
+    } as never);
+
+    return { file, exec };
+  }
+
+  const created = {
+    id: "wf-new",
+    name: "brand new",
+    active: false,
+    nodes: [],
+    connections: {},
+    updatedAt: "2026-05-01T00:00:00.000Z",
+  } as Workflow;
+
+  test("adopts the settled revision when the content is still ours", async () => {
+    const settled = { ...created, updatedAt: "2026-05-01T00:00:05.000Z" } as Workflow;
+    const { file, exec } = createScenario(settled, created);
+
+    await exec.execute();
+
+    expect(loadYamlWorkflow(file).updatedAt).toBe("2026-05-01T00:00:05.000Z");
+  });
+
+  test("refuses a revision that belongs to somebody else's edit", async () => {
+    // Someone edited the workflow in the n8n UI between the tag call and the
+    // re-fetch. Stamping their revision onto a file that does not contain their
+    // change would make the next apply declare a base the guard accepts, and
+    // revert them with every check satisfied.
+    const hijacked = {
+      ...created,
+      name: "edited in the UI",
+      updatedAt: "2026-05-01T00:00:05.000Z",
+    } as Workflow;
+    const { file, exec } = createScenario(hijacked, created);
+
+    await exec.execute();
+
+    expect(loadYamlWorkflow(file).updatedAt).toBe("2026-05-01T00:00:00.000Z");
+  });
+});

--- a/tests/apply/apply.stale-write.test.ts
+++ b/tests/apply/apply.stale-write.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import type { WorkflowService } from "@/api/workflow-service.ts";
+import { Executor } from "@/apply/executor.ts";
+import { defaultApplyOptions } from "@/apply/types.ts";
+import { loadYamlWorkflow } from "@/yaml/loader.ts";
+
+/**
+ * What a persisted `updatedAt` buys `apply` for YAML definitions.
+ *
+ * Before it, YAML carried no timestamp: 3-way detection skips the format and
+ * 2-way needs a local stamp to compare, so a definition written from a stale
+ * checkout was pushed unconditionally and reverted whatever had been changed
+ * in the n8n UI. These tests pin the two halves of the fix — the conflict is
+ * now detected, and a successful write leaves the file current so the *next*
+ * edit is not mistaken for one.
+ */
+
+const REMOTE_UPDATED = "2026-03-01T10:00:00.000Z";
+const LOCAL_BASE = "2026-02-01T10:00:00.000Z";
+
+interface Recorded {
+  updates: { id: string; input: WorkflowInput; baseUpdatedAt?: string }[];
+}
+
+function remoteWorkflow(): Workflow {
+  return {
+    id: "wf1",
+    name: "remote name",
+    active: false,
+    nodes: [],
+    connections: {},
+    updatedAt: REMOTE_UPDATED,
+  } as Workflow;
+}
+
+function mockService(remote: Workflow): { service: WorkflowService; recorded: Recorded } {
+  const recorded: Recorded = { updates: [] };
+  const service = {
+    listAllWorkflows: async () => [remote],
+    getWorkflow: async () => remote,
+    createWorkflow: async (input: WorkflowInput) => ({ ...input, id: "wf1" }) as Workflow,
+    updateWorkflow: async (id: string, input: WorkflowInput, baseUpdatedAt?: string) => {
+      recorded.updates.push({ id, input, baseUpdatedAt });
+      return { ...remote, ...input, updatedAt: "2026-04-01T00:00:00.000Z" } as Workflow;
+    },
+    getWorkflowCurrentProjectID: () => "",
+  } as unknown as WorkflowService;
+  return { service, recorded };
+}
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "n8n-cli-apply-stale-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Writes a YAML definition whose content differs from the remote's. */
+function writeLocalYaml(updatedAt: string | undefined): string {
+  const file = path.join(dir, "wf__wf1.yaml");
+  const lines = ["id: wf1", "name: local name", "active: false"];
+  if (updatedAt) lines.push(`updatedAt: '${updatedAt}'`);
+  lines.push("nodes: []", "connections: {}", "");
+  fs.writeFileSync(file, lines.join("\n"));
+  return file;
+}
+
+function executor(service: WorkflowService, overrides: Record<string, unknown> = {}): Executor {
+  const opts = defaultApplyOptions();
+  opts.directory = dir;
+  opts.all = true;
+  opts.yamlEnabled = true;
+  opts.noLint = true;
+  opts.allowDuplicates = true;
+  Object.assign(opts, overrides);
+  return new Executor(service, opts);
+}
+
+describe("apply against a YAML definition with a stamp", () => {
+  test("a stale local definition is reported as a conflict, not pushed", async () => {
+    writeLocalYaml(LOCAL_BASE);
+    const { service, recorded } = mockService(remoteWorkflow());
+
+    const result = await executor(service).execute();
+
+    expect(result.conflictCount).toBe(1);
+    expect(result.operations[0]?.operation).toBe("conflict");
+    expect(recorded.updates).toHaveLength(0);
+  });
+
+  test("--force pushes the stale definition anyway", async () => {
+    writeLocalYaml(LOCAL_BASE);
+    const { service, recorded } = mockService(remoteWorkflow());
+
+    const result = await executor(service, { force: true }).execute();
+
+    expect(result.operations[0]?.forced).toBe(true);
+    expect(recorded.updates).toHaveLength(1);
+  });
+
+  test("a current definition is applied and declares the base it was built on", async () => {
+    writeLocalYaml(REMOTE_UPDATED);
+    const { service, recorded } = mockService(remoteWorkflow());
+
+    const result = await executor(service).execute();
+
+    expect(result.updateCount).toBe(1);
+    expect(recorded.updates[0]?.baseUpdatedAt).toBe(REMOTE_UPDATED);
+  });
+
+  test("the local file is re-stamped so the next edit is not a false conflict", async () => {
+    const file = writeLocalYaml(REMOTE_UPDATED);
+    const { service } = mockService(remoteWorkflow());
+
+    await executor(service).execute();
+
+    expect(loadYamlWorkflow(file).updatedAt).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  test("a definition with no stamp still applies, declaring no base", async () => {
+    writeLocalYaml(undefined);
+    const { service, recorded } = mockService(remoteWorkflow());
+
+    const result = await executor(service).execute();
+
+    expect(result.updateCount).toBe(1);
+    expect(recorded.updates[0]?.baseUpdatedAt).toBeUndefined();
+  });
+});

--- a/tests/apply/apply.threeway-base.test.ts
+++ b/tests/apply/apply.threeway-base.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import type { WorkflowService } from "@/api/workflow-service.ts";
+import { Executor } from "@/apply/executor.ts";
+import { defaultApplyOptions } from "@/apply/types.ts";
+
+/**
+ * Which revision a 3-way-cleared update declares as its base.
+ *
+ * 3-way exists precisely so a write does not depend on the local file's stamp:
+ * it compares the change against the state it just fetched. Declaring the
+ * file's own stamp anyway would hand a stale-write guard a revision nobody
+ * checked, and the guard would refuse a write that apply has already verified
+ * against current state — the common case being a CI apply whose re-stamp was
+ * never committed back.
+ */
+
+const BASE_STAMP = "2026-01-01T00:00:00.000Z";
+const REMOTE_STAMP = "2026-03-01T10:00:00.000Z";
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+let repo: string;
+
+beforeEach(() => {
+  repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "n8n-cli-3way-")));
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "config", "user.name", "test");
+});
+
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+/** Commits a JSON definition, then edits it in a second commit. */
+function commitThenEdit(): string {
+  const dir = path.join(repo, "definitions");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "wf__wf1.json");
+
+  const base = {
+    id: "wf1",
+    name: "base name",
+    active: false,
+    nodes: [],
+    connections: {},
+    updatedAt: BASE_STAMP,
+  };
+  fs.writeFileSync(file, JSON.stringify(base, null, 2));
+  git(repo, "add", ".");
+  git(repo, "commit", "-q", "-m", "base");
+
+  fs.writeFileSync(file, JSON.stringify({ ...base, name: "local edit" }, null, 2));
+  git(repo, "add", ".");
+  git(repo, "commit", "-q", "-m", "edit");
+
+  return file;
+}
+
+describe("3-way cleared update", () => {
+  test("declares the revision it was verified against, not the file's stamp", async () => {
+    commitThenEdit();
+
+    // Remote matches the committed base in content, but its stamp has moved on
+    // — the state a CI apply leaves behind when it never commits the re-stamp.
+    const remote = {
+      id: "wf1",
+      name: "base name",
+      active: false,
+      nodes: [],
+      connections: {},
+      updatedAt: REMOTE_STAMP,
+    } as Workflow;
+
+    const declared: (string | undefined)[] = [];
+    const service = {
+      listAllWorkflows: async () => [remote],
+      getWorkflow: async () => remote,
+      createWorkflow: async (input: WorkflowInput) => ({ ...input, id: "wf1" }) as Workflow,
+      updateWorkflow: async (_id: string, input: WorkflowInput, baseUpdatedAt?: string) => {
+        declared.push(baseUpdatedAt);
+        return { ...remote, ...input, updatedAt: "2026-04-01T00:00:00.000Z" } as Workflow;
+      },
+      getWorkflowCurrentProjectID: () => "",
+    } as unknown as WorkflowService;
+
+    const opts = defaultApplyOptions();
+    opts.directory = path.join(repo, "definitions");
+    opts.all = true;
+    opts.noLint = true;
+    opts.allowDuplicates = true;
+    opts.fromGitChanges = true;
+    opts.gitDiffSpec = "HEAD~1..HEAD";
+
+    const cwd = process.cwd();
+    process.chdir(repo);
+    let result: Awaited<ReturnType<Executor["execute"]>>;
+    try {
+      result = await new Executor(service, opts).execute();
+    } finally {
+      process.chdir(cwd);
+    }
+
+    expect(result.operations[0]?.threeWayUsed).toBe(true);
+    expect(result.updateCount).toBe(1);
+    expect(declared).toEqual([REMOTE_STAMP]);
+  });
+});

--- a/tests/apply/local-file.test.ts
+++ b/tests/apply/local-file.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Workflow } from "@/api/types.ts";
 import { patchTsStamp, patchYamlStamp, updateLocalWorkflowFile } from "@/apply/local-file.ts";
+import { parseTsWorkflow } from "@/ts/loader.ts";
 import { loadYamlWorkflow } from "@/yaml/loader.ts";
 
 /**
@@ -153,5 +154,100 @@ describe("updateLocalWorkflowFile", () => {
     fs.writeFileSync(file, "# notes\n");
     await updateLocalWorkflowFile(file, workflow(STAMP));
     expect(fs.readFileSync(file, "utf-8")).toBe("# notes\n");
+  });
+});
+
+describe("patchTsStamp on hand-authored shapes", () => {
+  test("finds a meta export carrying a type annotation", () => {
+    const text =
+      'export const meta: TsWorkflowMeta = {\n  active: true,\n  updatedAt: "old",\n};\n';
+    expect(patchTsStamp(text, STAMP)).toBe(
+      `export const meta: TsWorkflowMeta = {\n  active: true,\n  updatedAt: "${STAMP}",\n};\n`,
+    );
+  });
+
+  test("replaces the stamp in a single-line meta instead of duplicating the key", () => {
+    const text = 'export const meta = { active: true, updatedAt: "old" };\nconst x = 1;\n';
+    const out = patchTsStamp(text, STAMP);
+    expect(out).toBe(
+      `export const meta = { active: true, updatedAt: "${STAMP}" };\nconst x = 1;\n`,
+    );
+    expect(out?.match(/updatedAt:/g)).toHaveLength(1);
+  });
+
+  test("does not reach past a single-line meta into the workflow below it", () => {
+    const text = [
+      "export const meta = { active: true };",
+      "const node = wf.add({",
+      '  parameters: { updatedAt: "not-the-stamp" },',
+      "});",
+      "",
+    ].join("\n");
+
+    const out = patchTsStamp(text, STAMP);
+
+    expect(out).toContain('updatedAt: "not-the-stamp"');
+    expect(out).toContain(`{\n  updatedAt: "${STAMP}", active: true }`);
+  });
+
+  test("ignores a node named updatedAt inside nodeIds", () => {
+    const text = [
+      "export const meta = {",
+      "  active: true,",
+      '  nodeIds: { "updatedAt": "node-1" },',
+      "};",
+      "",
+    ].join("\n");
+
+    const out = patchTsStamp(text, STAMP);
+
+    expect(out).toContain('nodeIds: { "updatedAt": "node-1" }');
+    expect(out).toContain(`updatedAt: "${STAMP}",\n  active: true`);
+  });
+
+  test("is not confused by a brace inside a string or comment", () => {
+    const text = [
+      "export const meta = {",
+      "  // a { brace in a comment",
+      '  tags: ["has { brace"],',
+      '  updatedAt: "old",',
+      "};",
+      "",
+    ].join("\n");
+
+    expect(patchTsStamp(text, STAMP)).toContain(`updatedAt: "${STAMP}"`);
+  });
+
+  test("leaves a file with unbalanced braces alone", () => {
+    expect(patchTsStamp("export const meta = {\n  active: true,\n", STAMP)).toBeNull();
+  });
+});
+
+describe("a patched .ts file still parses", () => {
+  const workflowTail = [
+    "",
+    "const t = trigger({",
+    "  type: 'n8n-nodes-base.manualTrigger',",
+    "  version: 1,",
+    "  config: { name: 'T' }",
+    "});",
+    "",
+    "export default workflow('wf1', 'W').add(t)",
+    "",
+  ].join("\n");
+  const header = 'import { workflow, trigger } from "@n8n/workflow-sdk";\n';
+
+  test.each([
+    ['export const meta = {\n  active: true,\n  updatedAt: "old",\n};', "multi-line"],
+    [
+      'export const meta: TsWorkflowMeta = {\n  active: true,\n  updatedAt: "old",\n};',
+      "annotated",
+    ],
+    ['export const meta = { active: true, updatedAt: "old" };', "single-line"],
+    ["export const meta = {\n  active: true,\n};", "no existing stamp"],
+  ])("%s (%s)", (meta) => {
+    const patched = patchTsStamp(`${header}${meta}${workflowTail}`, STAMP);
+    expect(patched).not.toBeNull();
+    expect(parseTsWorkflow(patched as string, "wf1").updatedAt).toBe(STAMP);
   });
 });

--- a/tests/apply/local-file.test.ts
+++ b/tests/apply/local-file.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import { patchTsStamp, patchYamlStamp, updateLocalWorkflowFile } from "@/apply/local-file.ts";
+import { loadYamlWorkflow } from "@/yaml/loader.ts";
+
+/**
+ * Re-stamping local definitions after a successful write.
+ *
+ * The stamp is what apply's conflict detection compares against, so the tests
+ * that matter are the ones proving it survives a round trip as a *string* and
+ * that the surrounding authored file is left alone.
+ */
+
+const STAMP = "2026-03-01T10:00:00.000Z";
+
+function workflow(updatedAt?: string): Workflow {
+  return {
+    id: "wf1",
+    name: "example",
+    active: false,
+    nodes: [],
+    connections: {},
+    ...(updatedAt ? { updatedAt } : {}),
+  } as Workflow;
+}
+
+describe("patchYamlStamp", () => {
+  test("replaces an existing top-level stamp", () => {
+    const out = patchYamlStamp("id: wf1\nname: x\nupdatedAt: '2020-01-01T00:00:00.000Z'\n", STAMP);
+    expect(out).toBe(`id: wf1\nname: x\nupdatedAt: '${STAMP}'\n`);
+  });
+
+  test("inserts after active when no stamp is present", () => {
+    const out = patchYamlStamp("id: wf1\nname: x\nactive: false\nnodes: []\n", STAMP);
+    expect(out).toBe(`id: wf1\nname: x\nactive: false\nupdatedAt: '${STAMP}'\nnodes: []\n`);
+  });
+
+  test("falls back to name, then id, when the better anchors are missing", () => {
+    expect(patchYamlStamp("name: x\nnodes: []\n", STAMP)).toBe(
+      `name: x\nupdatedAt: '${STAMP}'\nnodes: []\n`,
+    );
+    expect(patchYamlStamp("id: wf1\nnodes: []\n", STAMP)).toBe(
+      `id: wf1\nupdatedAt: '${STAMP}'\nnodes: []\n`,
+    );
+  });
+
+  test("leaves an unrecognised document alone", () => {
+    expect(patchYamlStamp("nodes: []\n", STAMP)).toBeNull();
+  });
+
+  test("does nothing when there is no stamp to write", () => {
+    expect(patchYamlStamp("id: wf1\n", undefined)).toBeNull();
+  });
+
+  test("only touches the top-level key, not a nested one", () => {
+    const text = "id: wf1\nactive: false\nnodes:\n  - name: n\n    updatedAt: nested\n";
+    const out = patchYamlStamp(text, STAMP);
+    expect(out).toContain("    updatedAt: nested");
+    expect(out).toContain(`updatedAt: '${STAMP}'`);
+  });
+});
+
+describe("patchTsStamp", () => {
+  const meta =
+    'export const meta = {\n  active: true,\n  updatedAt: "2020-01-01T00:00:00.000Z",\n};\n';
+
+  test("replaces the stamp inside the meta export", () => {
+    const out = patchTsStamp(meta, STAMP);
+    expect(out).toBe(`export const meta = {\n  active: true,\n  updatedAt: "${STAMP}",\n};\n`);
+  });
+
+  test("inserts a stamp into a meta block that has none", () => {
+    const out = patchTsStamp("export const meta = {\n  active: true,\n};\n", STAMP);
+    expect(out).toBe(`export const meta = {\n  updatedAt: "${STAMP}",\n  active: true,\n};\n`);
+  });
+
+  test("leaves a file with no meta export alone", () => {
+    expect(patchTsStamp("export const x = 1;\n", STAMP)).toBeNull();
+  });
+});
+
+describe("updateLocalWorkflowFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "n8n-cli-stamp-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("YAML: the stamp reads back as a string, not a Date", async () => {
+    const file = path.join(dir, "wf.yaml");
+    fs.writeFileSync(file, "id: wf1\nname: example\nactive: false\nnodes: []\nconnections: {}\n");
+
+    await updateLocalWorkflowFile(file, workflow(STAMP));
+
+    const reloaded = loadYamlWorkflow(file);
+    expect(reloaded.updatedAt).toBe(STAMP);
+    expect(typeof reloaded.updatedAt).toBe("string");
+  });
+
+  test("YAML: comments and !include refs survive", async () => {
+    const file = path.join(dir, "wf.yaml");
+    const original = [
+      "# hand-written header",
+      "id: wf1",
+      "name: example",
+      "active: false",
+      "nodes:",
+      "  - name: n",
+      "    parameters:",
+      "      jsCode: !include _subfiles/wf__wf1/n.js",
+      "",
+    ].join("\n");
+    fs.writeFileSync(file, original);
+
+    await updateLocalWorkflowFile(file, workflow(STAMP));
+
+    const text = fs.readFileSync(file, "utf-8");
+    expect(text).toContain("# hand-written header");
+    expect(text).toContain("!include _subfiles/wf__wf1/n.js");
+    expect(text).toContain(`updatedAt: '${STAMP}'`);
+  });
+
+  test("JSON: identity and both timestamps are written back", async () => {
+    const file = path.join(dir, "wf.json");
+    fs.writeFileSync(file, JSON.stringify({ id: "old", name: "old", active: true }));
+
+    await updateLocalWorkflowFile(file, {
+      ...workflow(STAMP),
+      createdAt: "2026-01-01T00:00:00.000Z",
+    } as Workflow);
+
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as Record<string, unknown>;
+    expect(parsed.id).toBe("wf1");
+    expect(parsed.name).toBe("example");
+    expect(parsed.active).toBe(false);
+    expect(parsed.updatedAt).toBe(STAMP);
+    expect(parsed.createdAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("an unreadable file is not an error", async () => {
+    await updateLocalWorkflowFile(path.join(dir, "missing.yaml"), workflow(STAMP));
+  });
+
+  test("a format with no stamping rule is left untouched", async () => {
+    const file = path.join(dir, "notes.md");
+    fs.writeFileSync(file, "# notes\n");
+    await updateLocalWorkflowFile(file, workflow(STAMP));
+    expect(fs.readFileSync(file, "utf-8")).toBe("# notes\n");
+  });
+});

--- a/tests/apply/local-file.test.ts
+++ b/tests/apply/local-file.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import yaml from "js-yaml";
 import type { Workflow } from "@/api/types.ts";
 import { patchTsStamp, patchYamlStamp, updateLocalWorkflowFile } from "@/apply/local-file.ts";
 import { parseTsWorkflow } from "@/ts/loader.ts";
@@ -249,5 +250,41 @@ describe("a patched .ts file still parses", () => {
     const patched = patchTsStamp(`${header}${meta}${workflowTail}`, STAMP);
     expect(patched).not.toBeNull();
     expect(parseTsWorkflow(patched as string, "wf1").updatedAt).toBe(STAMP);
+  });
+});
+
+describe("quoted keys do not become duplicate properties", () => {
+  /**
+   * A quoted key declares the same property as the bare form. Skipping past it
+   * and inserting another is not a cosmetic problem: in an object literal the
+   * last one wins, so the file would keep reporting its old revision forever,
+   * and in YAML a duplicate mapping key stops the file loading at all.
+   */
+  test.each([
+    ['"updatedAt": "old"', 'export const meta = {\n  active: true,\n  "updatedAt": "old",\n};\n'],
+    ["'updatedAt': 'old'", "export const meta = {\n  active: true,\n  'updatedAt': 'old',\n};\n"],
+  ])(".ts with %s is replaced in place", (_label, text) => {
+    const out = patchTsStamp(text, STAMP);
+    expect(out?.match(/updatedAt/g)).toHaveLength(1);
+    expect(out).toContain(STAMP);
+  });
+
+  test(".ts whose stamp is not a plain string literal is left untouched", () => {
+    // Inserting here would duplicate the key, and the stale value would win.
+    expect(patchTsStamp("export const meta = {\n  updatedAt: `old`,\n};\n", STAMP)).toBeNull();
+  });
+
+  test.each([
+    ["single-quoted", "id: wf1\nname: x\nactive: false\n'updatedAt': 'old'\nnodes: []\n"],
+    ["double-quoted", 'id: wf1\nname: x\nactive: false\n"updatedAt": "old"\nnodes: []\n'],
+  ])("YAML with a %s key stays loadable", (_label, text) => {
+    const out = patchYamlStamp(text, STAMP) as string;
+    expect(out.match(/updatedAt/g)).toHaveLength(1);
+    expect((yaml.load(out) as Record<string, unknown>).updatedAt).toBe(STAMP);
+  });
+
+  test("YAML anchors are found even when quoted", () => {
+    const out = patchYamlStamp("'id': wf1\n'name': x\n'active': false\nnodes: []\n", STAMP);
+    expect((yaml.load(out as string) as Record<string, unknown>).updatedAt).toBe(STAMP);
   });
 });

--- a/tests/apply/local-file.test.ts
+++ b/tests/apply/local-file.test.ts
@@ -288,3 +288,19 @@ describe("quoted keys do not become duplicate properties", () => {
     expect((yaml.load(out as string) as Record<string, unknown>).updatedAt).toBe(STAMP);
   });
 });
+
+describe("line endings", () => {
+  test("an insert into a CRLF file uses CRLF", () => {
+    const out = patchYamlStamp("id: wf1\r\nname: x\r\nactive: false\r\nnodes: []\r\n", STAMP);
+    expect(out).toBe(
+      `id: wf1\r\nname: x\r\nactive: false\r\nupdatedAt: '${STAMP}'\r\nnodes: []\r\n`,
+    );
+    // No lone LF anywhere: a mixed-terminator file is pure diff churn.
+    expect(/[^\r]\n/.test(out as string)).toBe(false);
+  });
+
+  test("an insert into an LF file stays LF", () => {
+    const out = patchYamlStamp("id: wf1\nactive: false\nnodes: []\n", STAMP);
+    expect(out).toBe(`id: wf1\nactive: false\nupdatedAt: '${STAMP}'\nnodes: []\n`);
+  });
+});

--- a/tests/cli/proxy-stale-write-flags.test.ts
+++ b/tests/cli/proxy-stale-write-flags.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { Command } from "commander";
+import { extractMiddlewareCliOpts, registerProxyCommand } from "@/cli/commands/proxy.ts";
+import { staleWriteFactory } from "@/middleware/builtin/stale-write/factory.ts";
+
+/**
+ * The wiring between a declared `--stale-write-*` flag and the factory that
+ * reads it.
+ *
+ * Both halves are easy to get silently wrong: a flag can be declared on the
+ * command and never forwarded to the middleware bag (so it does nothing), or
+ * forwarded under a key no factory reads. Neither shows up as a failure — the
+ * proxy just runs with defaults.
+ */
+
+const FLAGS = [
+  { flag: "--stale-write-enforce", key: "staleWriteEnforce", value: "error" },
+  { flag: "--stale-write-on-missing-base", key: "staleWriteOnMissingBase", value: "deny" },
+  { flag: "--stale-write-on-error", key: "staleWriteOnError", value: "allow" },
+  { flag: "--stale-write-actions", key: "staleWriteActions", value: "update,tags" },
+];
+
+function declaredFlags(): string[] {
+  const program = new Command();
+  registerProxyCommand(program);
+  const proxy = program.commands.find((c) => c.name() === "proxy");
+  if (!proxy) throw new Error("proxy command was not registered");
+  return proxy.options.map((o) => o.long ?? "");
+}
+
+describe("proxy --stale-write-* flags", () => {
+  test.each(FLAGS)("$flag is declared on the command", ({ flag }) => {
+    expect(declaredFlags()).toContain(flag);
+  });
+
+  test("every declared flag is forwarded to the middleware options bag", () => {
+    const opts = Object.fromEntries(FLAGS.map((f) => [f.key, f.value]));
+    const forwarded = extractMiddlewareCliOpts(opts as never);
+
+    for (const { key, value } of FLAGS) {
+      expect(forwarded[key]).toBe(value);
+    }
+  });
+
+  test("the forwarded bag is what the factory actually reads", () => {
+    const opts = Object.fromEntries(FLAGS.map((f) => [f.key, f.value]));
+    const forwarded = extractMiddlewareCliOpts(opts as never);
+
+    expect(staleWriteFactory.loadFromCLI(forwarded)).toEqual({
+      enforce: "error",
+      onMissingBase: "deny",
+      onError: "allow",
+      actions: ["update", "tags"],
+    });
+  });
+
+  test("flags the user did not pass are left out entirely", () => {
+    expect(extractMiddlewareCliOpts({} as never)).not.toHaveProperty("staleWriteEnforce");
+  });
+});

--- a/tests/middleware/builtin/stale-write.test.ts
+++ b/tests/middleware/builtin/stale-write.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import { BASE_UPDATED_AT_HEADER } from "@/api/headers.ts";
+import type { Workflow } from "@/api/types.ts";
+import { staleWriteFactory } from "@/middleware/builtin/stale-write/factory.ts";
+import { StaleWriteMiddleware } from "@/middleware/builtin/stale-write/middleware.ts";
+import type { StaleWriteOptions } from "@/middleware/builtin/stale-write/types.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
+
+/**
+ * The guard's decision table. Each test fixes one axis: what the caller
+ * claimed, what upstream stores, and what the operator configured.
+ */
+
+const STORED = "2026-03-01T10:00:00.000Z";
+const OLDER = "2026-02-01T10:00:00.000Z";
+
+function options(overrides: Partial<StaleWriteOptions> = {}): StaleWriteOptions {
+  return {
+    enforce: "error",
+    onMissingBase: "allow",
+    onError: "deny",
+    actions: ["update"],
+    ...overrides,
+  };
+}
+
+interface ContextOverrides {
+  base?: string;
+  stored?: Workflow | null;
+  storedError?: Error;
+  action?: string;
+  workflowId?: string;
+  mode?: ServerMiddlewareContext["mode"];
+  omitFetcher?: boolean;
+}
+
+function context(overrides: ContextOverrides = {}): ServerMiddlewareContext {
+  const headers = new Headers();
+  if (overrides.base) headers.set(BASE_UPDATED_AT_HEADER, overrides.base);
+
+  const stored =
+    overrides.stored === undefined
+      ? ({
+          id: "wf1",
+          name: "x",
+          active: false,
+          nodes: [],
+          connections: {},
+          updatedAt: STORED,
+        } as Workflow)
+      : overrides.stored;
+
+  return {
+    workflow: null,
+    request: new Request("http://proxy/api/v1/workflows/wf1", { method: "PUT", headers }),
+    mode: overrides.mode ?? "proxy",
+    action: overrides.action ?? "update",
+    workflowId: overrides.workflowId ?? "wf1",
+    fetchStoredWorkflow: overrides.omitFetcher
+      ? undefined
+      : async () => {
+          if (overrides.storedError) throw overrides.storedError;
+          return stored;
+        },
+  };
+}
+
+describe("StaleWriteMiddleware", () => {
+  test("passes when the declared base matches the stored state", async () => {
+    const verdict = await new StaleWriteMiddleware(options()).evaluate(context({ base: STORED }));
+    expect(verdict.block).toBe(false);
+    expect(verdict.violations).toEqual([]);
+  });
+
+  test("blocks with 409 when upstream has moved on", async () => {
+    const verdict = await new StaleWriteMiddleware(options()).evaluate(context({ base: OLDER }));
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.status).toBe(409);
+    expect(verdict.denial?.error).toBe("workflow_stale_write");
+    expect(verdict.denial?.message).toContain(STORED);
+    expect(verdict.denial?.message).toContain(OLDER);
+  });
+
+  test("blocks a base newer than the stored state too", async () => {
+    const verdict = await new StaleWriteMiddleware(options()).evaluate(
+      context({ base: "2026-04-01T10:00:00.000Z" }),
+    );
+    expect(verdict.block).toBe(true);
+  });
+
+  test("treats equivalent timestamp spellings as the same instant", async () => {
+    const verdict = await new StaleWriteMiddleware(options()).evaluate(
+      context({ base: "2026-03-01T10:00:00.000+00:00" }),
+    );
+    expect(verdict.block).toBe(false);
+  });
+
+  test("warn mode reports the conflict without blocking", async () => {
+    const verdict = await new StaleWriteMiddleware(options({ enforce: "warn" })).evaluate(
+      context({ base: OLDER }),
+    );
+    expect(verdict.block).toBe(false);
+    expect(verdict.violations[0]?.rule).toBe("stale-write");
+    expect(verdict.denial).toBeUndefined();
+  });
+
+  test("off skips the upstream read entirely", async () => {
+    let fetched = false;
+    const ctx = context({ base: OLDER });
+    ctx.fetchStoredWorkflow = async () => {
+      fetched = true;
+      return null;
+    };
+    const verdict = await new StaleWriteMiddleware(options({ enforce: "off" })).evaluate(ctx);
+    expect(verdict.block).toBe(false);
+    expect(fetched).toBe(false);
+  });
+
+  describe("callers that declare no base", () => {
+    test("are allowed by default", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(context());
+      expect(verdict.block).toBe(false);
+    });
+
+    test("are refused under onMissingBase=deny", async () => {
+      const verdict = await new StaleWriteMiddleware(options({ onMissingBase: "deny" })).evaluate(
+        context(),
+      );
+      expect(verdict.block).toBe(true);
+      expect(verdict.denial?.status).toBe(409);
+      expect(verdict.denial?.message).toContain(BASE_UPDATED_AT_HEADER);
+    });
+
+    test("a blank header counts as absent", async () => {
+      const verdict = await new StaleWriteMiddleware(options({ onMissingBase: "deny" })).evaluate(
+        context({ base: "   " }),
+      );
+      expect(verdict.block).toBe(true);
+    });
+  });
+
+  describe("scope", () => {
+    test("ignores actions outside the configured list", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, action: "tags" }),
+      );
+      expect(verdict.block).toBe(false);
+    });
+
+    test("stays out of apply mode, which has its own conflict detection", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, mode: "apply" }),
+      );
+      expect(verdict.block).toBe(false);
+    });
+
+    test("passes when the route names no workflow", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, workflowId: "" }),
+      );
+      expect(verdict.block).toBe(false);
+    });
+  });
+
+  describe("unreadable upstream state", () => {
+    test("fails closed by default", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, storedError: new Error("boom") }),
+      );
+      expect(verdict.block).toBe(true);
+      expect(verdict.denial?.message).toContain("boom");
+    });
+
+    test("fails open under onError=allow, with a warning", async () => {
+      const verdict = await new StaleWriteMiddleware(options({ onError: "allow" })).evaluate(
+        context({ base: OLDER, storedError: new Error("boom") }),
+      );
+      expect(verdict.block).toBe(false);
+      expect(verdict.violations[0]?.severity).toBe("warning");
+    });
+
+    test("a host with no stored-workflow reader is an error, not a silent pass", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, omitFetcher: true }),
+      );
+      expect(verdict.block).toBe(true);
+    });
+  });
+
+  describe("nothing to be stale against", () => {
+    test("passes when the workflow does not exist upstream", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({ base: OLDER, stored: null }),
+      );
+      expect(verdict.block).toBe(false);
+    });
+
+    test("passes when upstream exposes no timestamp", async () => {
+      const verdict = await new StaleWriteMiddleware(options()).evaluate(
+        context({
+          base: OLDER,
+          stored: { id: "wf1", name: "x", active: false, nodes: [], connections: {} } as Workflow,
+        }),
+      );
+      expect(verdict.block).toBe(false);
+    });
+  });
+});
+
+describe("staleWriteFactory", () => {
+  test("defaults to off so adding it to a chain changes nothing on its own", () => {
+    const mw = staleWriteFactory.build({});
+    expect(mw.name).toBe("stale-write");
+    // enforce=off means even a mismatching write passes.
+    return expect(mw.evaluate(context({ base: OLDER }))).resolves.toMatchObject({ block: false });
+  });
+
+  test("reads config from env", () => {
+    const partial = staleWriteFactory.loadFromEnv({
+      N8N_STALE_WRITE_ENFORCE: "error",
+      N8N_STALE_WRITE_ON_MISSING_BASE: "deny",
+      N8N_STALE_WRITE_ON_ERROR: "allow",
+      N8N_STALE_WRITE_ACTIONS: "update, tags",
+    } as NodeJS.ProcessEnv);
+    expect(partial).toEqual({
+      enforce: "error",
+      onMissingBase: "deny",
+      onError: "allow",
+      actions: ["update", "tags"],
+    });
+  });
+
+  test("CLI flags override env", () => {
+    const merged = {
+      ...staleWriteFactory.loadFromEnv({ N8N_STALE_WRITE_ENFORCE: "warn" } as NodeJS.ProcessEnv),
+      ...staleWriteFactory.loadFromCLI({ staleWriteEnforce: "error" }),
+    };
+    expect(merged.enforce).toBe("error");
+  });
+
+  test("rejects an unknown enforcement level", () => {
+    expect(() => staleWriteFactory.build({ enforce: "sometimes" })).toThrow();
+  });
+});

--- a/tests/proxy/proxy.stale-write.test.ts
+++ b/tests/proxy/proxy.stale-write.test.ts
@@ -157,6 +157,19 @@ describe("proxy + stale-write", () => {
     expect(forwardedWrites()).toHaveLength(1);
   });
 
+  test("a stale-write warning is not counted as a lint failure", async () => {
+    // A CI step gating on x-n8n-lint-errors is the documented lint rollout
+    // path. Folding stale writes into it would fail builds for writes warn mode
+    // deliberately let through, and blame lint for them.
+    startProxyWithGuard({ staleWriteEnforce: "warn" });
+
+    const res = await put(OLDER);
+
+    expect(res.headers.get(STALE_WRITE_WARNING_HEADER)).not.toBeNull();
+    expect(res.headers.get("x-n8n-lint-violations")).toBeNull();
+    expect(res.headers.get("x-n8n-lint-errors")).toBeNull();
+  });
+
   test("a write with no base header passes by default", async () => {
     startProxyWithGuard();
 

--- a/tests/proxy/proxy.stale-write.test.ts
+++ b/tests/proxy/proxy.stale-write.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { BASE_UPDATED_AT_HEADER, STALE_WRITE_WARNING_HEADER } from "@/api/headers.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+/**
+ * End-to-end tests for the proxy with the stale-write guard enabled.
+ *
+ * The scenario under test is the one lint and authz both wave through: a
+ * well-formed, authorized update built from an out-of-date checkout, which
+ * would silently revert whatever was changed upstream in the meantime.
+ *
+ * The mock upstream answers `GET /workflows/:id` with a fixed `updatedAt` and
+ * records every request, so each test can assert both what the client got back
+ * and whether the write reached n8n at all.
+ */
+
+const STORED = "2026-03-01T10:00:00.000Z";
+const OLDER = "2026-02-01T10:00:00.000Z";
+
+interface Captured {
+  method: string;
+  path: string;
+  baseHeader: string | null;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: Captured[];
+}
+
+function startMockUpstream(): MockUpstream {
+  const captured: Captured[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      await req.text();
+      captured.push({
+        method: req.method,
+        path: url.pathname,
+        baseHeader: req.headers.get(BASE_UPDATED_AT_HEADER),
+      });
+
+      if (req.method === "GET" && url.pathname === "/api/v1/workflows/wf1") {
+        return Response.json({
+          id: "wf1",
+          name: "stored",
+          nodes: [],
+          connections: {},
+          updatedAt: STORED,
+        });
+      }
+      return Response.json({ ok: true });
+    },
+  });
+  return { server, port: server.port as number, captured };
+}
+
+let upstream: MockUpstream;
+let proxy: ProxyHandle;
+
+beforeEach(() => {
+  upstream = startMockUpstream();
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+});
+
+function startProxyWithGuard(cliOptions: Record<string, string> = {}): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    // Lint and the duplicate check are off so only the guard can reject.
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    middlewares: ["stale-write"],
+    middlewareCliOptions: { staleWriteEnforce: "error", ...cliOptions },
+  });
+  return proxy;
+}
+
+function put(base?: string): Promise<Response> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (base) headers[BASE_UPDATED_AT_HEADER] = base;
+  return fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ name: "local", nodes: [], connections: {} }),
+  });
+}
+
+/** Requests the proxy forwarded, excluding its own stored-state lookups. */
+function forwardedWrites(): Captured[] {
+  return upstream.captured.filter((c) => c.method !== "GET");
+}
+
+describe("proxy + stale-write", () => {
+  test("a current base is forwarded", async () => {
+    startProxyWithGuard();
+
+    const res = await put(STORED);
+
+    expect(res.status).toBe(200);
+    expect(forwardedWrites()).toHaveLength(1);
+  });
+
+  test("a stale base is rejected with 409 and never reaches upstream", async () => {
+    startProxyWithGuard();
+
+    const res = await put(OLDER);
+    const body = (await res.json()) as { error: string; message: string };
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe("workflow_stale_write");
+    expect(body.message).toContain(STORED);
+    expect(forwardedWrites()).toHaveLength(0);
+  });
+
+  test("the control header is stripped before the write reaches n8n", async () => {
+    startProxyWithGuard();
+
+    await put(STORED);
+
+    expect(forwardedWrites()[0]?.baseHeader).toBeNull();
+  });
+
+  test("warn mode forwards the write but flags it on the response", async () => {
+    startProxyWithGuard({ staleWriteEnforce: "warn" });
+
+    const res = await put(OLDER);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get(STALE_WRITE_WARNING_HEADER)).toContain(STORED);
+    expect(forwardedWrites()).toHaveLength(1);
+  });
+
+  test("a write with no base header passes by default", async () => {
+    startProxyWithGuard();
+
+    const res = await put();
+
+    expect(res.status).toBe(200);
+    expect(forwardedWrites()).toHaveLength(1);
+  });
+
+  test("onMissingBase=deny closes the gap for callers that declare nothing", async () => {
+    startProxyWithGuard({ staleWriteOnMissingBase: "deny" });
+
+    const res = await put();
+
+    expect(res.status).toBe(409);
+    expect(forwardedWrites()).toHaveLength(0);
+  });
+
+  test("creates are out of scope — there is no stored state to revert", async () => {
+    startProxyWithGuard({ staleWriteOnMissingBase: "deny" });
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "new", nodes: [], connections: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(forwardedWrites()).toHaveLength(1);
+  });
+
+  test("routes carrying no workflow body are still guarded when in scope", async () => {
+    startProxyWithGuard({ staleWriteActions: "update,tags" });
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1/tags`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", [BASE_UPDATED_AT_HEADER]: OLDER },
+      body: JSON.stringify([{ id: "tag1" }]),
+    });
+
+    expect(res.status).toBe(409);
+    expect(forwardedWrites()).toHaveLength(0);
+  });
+});

--- a/tests/proxy/proxy.stale-write.test.ts
+++ b/tests/proxy/proxy.stale-write.test.ts
@@ -145,13 +145,15 @@ describe("proxy + stale-write", () => {
     // the forwarding catch — turning a write upstream had already accepted into
     // a 502 for the client.
     upstream.server.stop(true);
-    upstream = startMockUpstream("2026-03-01T10:00:00.000Z\r\ninjected: yes");
+    upstream = startMockUpstream("2026-03-01T10:00:00.000Z\r\ninjected: yes \u65e5");
     startProxyWithGuard({ staleWriteEnforce: "warn" });
 
     const res = await put(OLDER);
 
     expect(res.status).toBe(200);
     expect(res.headers.get("injected")).toBeNull();
+    // Non-Latin-1 is rejected by `Headers.set` just as control characters are.
+    expect(res.headers.get(STALE_WRITE_WARNING_HEADER)).not.toContain("\u65e5");
     expect(forwardedWrites()).toHaveLength(1);
   });
 

--- a/tests/proxy/proxy.stale-write.test.ts
+++ b/tests/proxy/proxy.stale-write.test.ts
@@ -29,7 +29,7 @@ interface MockUpstream {
   captured: Captured[];
 }
 
-function startMockUpstream(): MockUpstream {
+function startMockUpstream(storedStamp: string = STORED): MockUpstream {
   const captured: Captured[] = [];
   const server = Bun.serve({
     port: 0,
@@ -48,7 +48,7 @@ function startMockUpstream(): MockUpstream {
           name: "stored",
           nodes: [],
           connections: {},
-          updatedAt: STORED,
+          updatedAt: storedStamp,
         });
       }
       return Response.json({ ok: true });
@@ -136,6 +136,22 @@ describe("proxy + stale-write", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get(STALE_WRITE_WARNING_HEADER)).toContain(STORED);
+    expect(forwardedWrites()).toHaveLength(1);
+  });
+
+  test("warn mode survives an upstream timestamp that cannot go in a header", async () => {
+    // The message quotes the upstream `updatedAt` verbatim. A control
+    // character in it used to make `Headers.set` throw, and the throw landed in
+    // the forwarding catch — turning a write upstream had already accepted into
+    // a 502 for the client.
+    upstream.server.stop(true);
+    upstream = startMockUpstream("2026-03-01T10:00:00.000Z\r\ninjected: yes");
+    startProxyWithGuard({ staleWriteEnforce: "warn" });
+
+    const res = await put(OLDER);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("injected")).toBeNull();
     expect(forwardedWrites()).toHaveLength(1);
   });
 

--- a/tests/yaml/generator.test.ts
+++ b/tests/yaml/generator.test.ts
@@ -54,6 +54,20 @@ describe("buildYamlObject", () => {
     const result = buildYamlObject(baseWorkflow, {});
     expect(result.tags).toBeUndefined();
   });
+
+  test("records updatedAt so apply can tell an update from a revert", () => {
+    const result = buildYamlObject({ ...baseWorkflow, updatedAt: "2026-03-01T10:00:00.000Z" }, {});
+    expect(result.updatedAt).toBe("2026-03-01T10:00:00.000Z");
+    // Written before the bulk of the document, where a reader will see it.
+    expect(Object.keys(result).indexOf("updatedAt")).toBeLessThan(
+      Object.keys(result).indexOf("nodes"),
+    );
+  });
+
+  test("omits updatedAt for a workflow that carries none", () => {
+    const result = buildYamlObject(baseWorkflow, {});
+    expect(result.updatedAt).toBeUndefined();
+  });
 });
 
 describe("stripJavaScriptHeaders", () => {

--- a/tests/yaml/loader.test.ts
+++ b/tests/yaml/loader.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { IncludeRef } from "@/yaml/include-schema.ts";
 import { loadYamlWorkflow } from "@/yaml/loader.ts";
@@ -93,5 +95,47 @@ describe("loadYamlWorkflow", () => {
     const jsCode = codeNode.parameters?.jsCode as string;
     expect(typeof jsCode).toBe("string");
     expect(jsCode).toContain("const items = $input.all();");
+  });
+});
+
+describe("workflow timestamps", () => {
+  /**
+   * YAML's implicit typing turns an unquoted ISO timestamp into a `Date`, which
+   * `resolveIncludeRefs` then flattens to `{}` while walking the document. That
+   * silently destroyed the value — conflict detection saw an unparseable stamp
+   * and stopped detecting anything, and `apply` sent `[object Object]` upstream
+   * as its base revision.
+   */
+  test("an unquoted updatedAt survives as an ISO string", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "yaml-ts-"));
+    try {
+      const file = path.join(dir, "wf.yaml");
+      fs.writeFileSync(
+        file,
+        "id: wf1\nname: x\nactive: false\nupdatedAt: 2026-03-01T10:00:00.000Z\nnodes: []\nconnections: {}\n",
+      );
+
+      const workflow = loadYamlWorkflow(file);
+
+      expect(typeof workflow.updatedAt).toBe("string");
+      expect(workflow.updatedAt).toBe("2026-03-01T10:00:00.000Z");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a quoted updatedAt is left exactly as written", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "yaml-ts-"));
+    try {
+      const file = path.join(dir, "wf.yaml");
+      fs.writeFileSync(
+        file,
+        "id: wf1\nname: x\nactive: false\nupdatedAt: '2026-03-01T10:00:00.000Z'\nnodes: []\nconnections: {}\n",
+      );
+
+      expect(loadYamlWorkflow(file).updatedAt).toBe("2026-03-01T10:00:00.000Z");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Problem

A workflow update that is well-formed, authorized and in scope can still be wrong: someone edits a workflow in the n8n UI, nobody imports the change back into the repository, and the next `apply` from any working copy silently reverts it. Lint has no opinion on that write and neither does authz, so it goes straight through.

For YAML repositories there was no defence at all. 3-way detection skips the format (`git show` hands back the source, not workflow JSON), 2-way needs a local `updatedAt` to compare against, and YAML definitions never carried one — so the conflict branch was dead code and every differing definition was pushed unconditionally.

## What this changes

**1. YAML definitions record the upstream revision they were written from.** JSON and `.ts` already did; YAML now emits `updatedAt` too (only when the source carries one, so hand-written files and `convert` output are untouched). That revives apply's existing 2-way conflict detection for the format.

A successful write re-stamps the local file so the *next* edit is not mistaken for a conflict. YAML and `.ts` are patched surgically, one line at a time — `!include` refs, comments and hand-written builder code do not survive a regenerate-from-remote. Tagging, project transfer and activation each bump `updatedAt` again after the write, so the final state is re-fetched when one of them ran; otherwise the file would be left permanently one revision behind.

**2. A `stale-write` server middleware for the proxy**, for enforcement that does not depend on the client — any working copy can pass `--force`, and other tools do not run the client-side check at all. `apply` declares its base revision in `X-N8n-Base-Updated-At`; the proxy reads the *stored* workflow (uncached, under the caller's own `X-N8N-API-KEY`) and refuses a mismatch with 409 `workflow_stale_write`.

```bash
n8n-cli proxy --middleware lint,stale-write --stale-write-enforce error
```

Off by default. A caller that sends no base cannot be judged — the n8n UI, raw API calls and older CLI versions all write without one — so operators decide what to do about those (`--stale-write-on-missing-base deny`) before turning it on. The control header is stripped before the request reaches n8n.

## Behaviour change

**YAML applies that were unconditional will start reporting conflicts.** Once `import` rewrites definitions with a stamp, an apply whose base is older than upstream *and* whose content differs is reported as a conflict instead of being pushed. That is the point of the change, but it is a visible change for existing YAML repositories. `--force` overrides it; `import` resolves it properly. Documented in the README next to the flag.

One operational note also in the README: in a CI-driven setup the re-stamp happens on the runner, so the stamp in version control stays behind until something writes it back — commit the re-stamped files from the apply job, or run `import` on a schedule. Until it catches up, a second change to the same workflow reports a conflict that `--force` can push through.

## Two bugs this surfaced

Both were latent — nothing read `updatedAt` on these paths before — and both are fixed here with regression tests.

- **An unquoted `updatedAt` in YAML was destroyed on load.** YAML's implicit typing turns it into a `Date`, and `resolveIncludeRefs` walks the document with `Object.entries`, so it came out the other side as `{}`. Conflict detection then saw an unparseable stamp and silently stopped detecting anything, and `apply` sent `[object Object]` as its declared base. Files written by `import` quote the value and were never affected.
- **A quoted `updatedAt` key was not recognised as the key it is,** in either format, so the writer added a second property instead of replacing the value. In a `.ts` object literal the last one wins, so the file would report its *old* revision forever while every apply updated the copy nobody reads — and it stops type-checking. In YAML a duplicate mapping key is a parse error, so one successful apply left the definition unreadable by every later command, silently, because re-stamp failures are swallowed by design.
- **`patchTsStamp` mishandled two shapes the `.ts` loader accepts.** `export const meta: TsWorkflowMeta = {` did not match at all (silent no-op, stale stamp), and because the block's end was found by scanning for the first `\n};`, a single-line `meta` let the rewrite reach past it and overwrite an `updatedAt:` in a node's parameters. It now brace-matches the literal, skipping strings and comments, and replaces only the `meta`-level property.

## Deployment note

**Do not combine the guard with `--tags`.** The tag filter reads tags from the request body, and the body `apply` sends carries no tags — so every `n8n-cli` write falls outside any tag scope and skips middleware entirely. Since `n8n-cli` is the only client that declares a base revision, the two options together leave the guard doing nothing. Pre-existing behaviour that affects lint identically, but it lands squarely on this feature's intended deployment, so it is now called out in the README.

### Also fixed along the way

- The post-write re-fetch (added here so tagging and activation do not leave the file a revision behind) adopted whatever came back, including a revision produced by someone editing the same workflow in the n8n UI during that window. That stamped their revision onto a file without their change, so the next apply would declare a base the guard accepts and revert them with every check satisfied. The revision is now adopted only when the re-fetched content is still what this apply wrote.
- The warn-mode response header interpolates a workflow id decoded from the request path and a timestamp from upstream. `Headers.set` rejects control characters and anything outside Latin-1, and the throw landed in the forwarding try/catch — so `PUT /api/v1/workflows/%E6%97%A5` turned a write n8n had already accepted into a 502. The value is reduced to printable ASCII.
- A stale-write warning was counted into `x-n8n-lint-violations` / `x-n8n-lint-errors`. Gating CI on the latter is the documented lint rollout path, so a warn-mode stale write would fail builds it had deliberately been allowed to pass, and lint would take the blame. The counters now cover lint's own violations only.
- Inserting the stamp into a CRLF file spliced in a bare `\n` (`$` stops ahead of the `\r`) — harmless to parse, pure churn in a repository that stores CRLF.
- The proxy options table named `--middleware` with env var `N8N_MIDDLEWARES`; both are wrong (`--server-middleware` / `N8N_SERVER_MIDDLEWARES`), so the documented invocation failed with `unknown option`. Corrected, and the fixed command is verified to start a proxy reporting `server-middlewares=lint,stale-write`.

## Decided, not changed

Re-stamped YAML now lands in `import`'s timestamp skip on the machine that ran the apply, so server-side normalisation does not come back down until the workflow changes again upstream. That is what JSON has always done and what `.ts` does on purpose; moving it would move all three formats. Documented in the README instead, including that the skip is by timestamp rather than by selection, so `--ids` does not override it.

## Follow-ups (not in this PR)

- `workflow update --file` also PUTs from a local file but does not send the base header yet, so writes through that path are invisible to the guard.
- Pre-existing: nested `Date` values elsewhere in a YAML document are still flattened to `{}` by `resolveIncludeRefs`; only the workflow-level timestamps are normalised here.
- Pre-existing: `extractMiddlewareCliOpts` does not forward the authz `--authz-acl-source`, `--authz-on-missing-acl`, `--authz-bootstrap-groups` and `--authz-actions` flags, so those are only settable via env. Unrelated to this change (the four `--stale-write-*` flags are forwarded, and there is now a test asserting it), left alone here.

## Tests

- `tests/middleware/builtin/stale-write.test.ts` — the guard's decision table: match, mismatch in either direction, equivalent timestamp spellings, warn mode, scope by action and mode, missing base under both policies, unreadable upstream under both policies, and the two cases where there is nothing to be stale against.
- `tests/proxy/proxy.stale-write.test.ts` — end to end through the proxy: 409 without reaching upstream, warn-mode forwarding with `X-N8n-Stale-Write-Warning`, control-header stripping, creates out of scope, non-definition routes in scope.
- `tests/apply/apply.stale-write.test.ts` — the YAML conflict is detected, `--force` pushes anyway, the base is declared, the file is re-stamped, and a created workflow is stamped with the state that survived auto-tagging.
- `tests/apply/local-file.test.ts` — surgical stamping per format, including that the YAML value reads back as a `string` and not a `Date`, and that comments and `!include` refs survive.
- `tests/api/base-updated-at-header.test.ts` — the header on the wire, since the apply-level tests stop at the service boundary.
- `tests/cli/proxy-stale-write-flags.test.ts` — each flag is declared, forwarded, and read by the factory.
- `tests/apply/apply.threeway-base.test.ts` — a 3-way-cleared update declares the revision it was verified against rather than the file's own stamp, driven through a real git repository so the 3-way path is genuinely exercised.
- `tests/yaml/loader.test.ts` — an unquoted `updatedAt` survives as an ISO string.

`make quality-gate` green (1348 pass, 0 fail).

The CI-only jobs were also reproduced locally — `make build`, `make size-check`, the `version` smoke test and the `.ts` format smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4Hf4384Jwpy9RzX1eCb8J
