### PR TITLE
feat(ci): tag and release automatically when a version bump lands on main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,73 @@
+name: Auto Tag
+
+# Tags a release whenever a version bump lands on main, so releasing is just
+# "merge the version bump PR" instead of a manual `git tag && git push`.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  # Escape hatch for a bump that never got tagged — because it landed while
+  # this workflow was broken, or alongside a change that did not touch
+  # package.json. If the tag was pushed but the release jobs failed, this is
+  # the wrong lever (the guard below will skip): re-run the failed run instead.
+  workflow_dispatch:
+
+# Serialise so two bumps landing back to back cannot race on tag creation.
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Tag version bump
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      tagged: ${{ steps.check.outputs.tagged }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+
+      # The condition is "no tag exists for the current version" rather than
+      # "package.json changed in this push": it is idempotent, survives
+      # re-runs, force pushes and squash merges, and cannot double-tag an
+      # already released version.
+      - name: Check whether this version needs a tag
+        id: check
+        run: |
+          version="v$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$(git ls-remote --tags origin "refs/tags/${version}")" ]; then
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${version} is already tagged; nothing to release."
+            exit 0
+          fi
+
+          echo "tagged=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Tagging ${version}."
+
+      - name: Create and push tag
+        if: steps.check.outputs.tagged == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" -m "$VERSION"
+          git push origin "$VERSION"
+
+  release:
+    name: Release
+    needs: [tag]
+    if: needs.tag.outputs.tagged == 'true'
+    # GITHUB_TOKEN is passed automatically; release.yml uses no other secrets.
+    # If it ever does, add `secrets: inherit` here or this path breaks quietly.
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+  # Also callable from auto-tag.yml, which creates the tag itself. A tag pushed
+  # with GITHUB_TOKEN does not fire the `push: tags` trigger above (GitHub
+  # suppresses it to avoid workflow loops), so the tagging workflow has to
+  # invoke this one directly instead of relying on the tag event.
+  workflow_call:
+    inputs:
+      version:
+        description: 'Tag to release, e.g. v2.10.1. Must already exist.'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          # On a tag push this is the tag being released; when called from
+          # auto-tag.yml the caller's ref is a branch, so check out the tag
+          # explicitly to build exactly what was tagged.
+          ref: ${{ inputs.version || github.ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
@@ -68,6 +83,11 @@ jobs:
             runner: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          # On a tag push this is the tag being released; when called from
+          # auto-tag.yml the caller's ref is a branch, so check out the tag
+          # explicitly to build exactly what was tagged.
+          ref: ${{ inputs.version || github.ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
@@ -82,8 +102,10 @@ jobs:
 
       - name: Determine version info
         id: version
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
         run: |
-          echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
@@ -131,6 +153,11 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          # On a tag push this is the tag being released; when called from
+          # auto-tag.yml the caller's ref is a branch, so check out the tag
+          # explicitly to build exactly what was tagged.
+          ref: ${{ inputs.version || github.ref }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
@@ -151,6 +178,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
+          # Explicit because the action can only infer the tag from a tag push,
+          # and workflow_call runs on the caller's branch ref.
+          tag_name: ${{ inputs.version || github.ref_name }}
           generate_release_notes: true
           files: |
             dist/n8n-cli-darwin-arm64


### PR DESCRIPTION
Releasing currently means remembering to `git tag && git push` after merging the version bump PR. That is easy to forget and easy to get wrong, and nothing catches it when it is missed.

## What changes

**`.github/workflows/auto-tag.yml` (new)** — watches `package.json` on `main` and tags the version when it has no tag yet, then invokes the release.

The guard is *"no tag exists for this version"* rather than *"package.json changed in this push"*. That makes it idempotent: re-runs, squash merges and force pushes all converge on the same result, and an already-released version can never be tagged twice.

**`.github/workflows/release.yml`** — gains a `workflow_call` entry point taking a `version` input.

This indirection is required, not stylistic: a tag pushed with `GITHUB_TOKEN` does **not** fire a `push: tags` event (GitHub suppresses it to prevent workflow loops), so the tagging workflow has to call the release workflow directly. The alternative was a PAT or GitHub App token in secrets; this avoids that credential entirely.

The checkouts now use `ref: ${{ inputs.version || github.ref }}` so the called path builds exactly what was tagged rather than whatever `main` points at, and `action-gh-release` gets an explicit `tag_name` since it can only infer one from a tag push.

**The existing `push: tags: 'v*'` trigger is untouched** — pushing a tag by hand still releases exactly as it does today.

## Known edge

If three or more version bumps merge in rapid succession, `concurrency: auto-tag` keeps only one queued run, so an intermediate bump can be cancelled and go untagged. `workflow_dispatch` will not recover it (it only ever considers the current version), so that case needs a manual tag. Rare enough that the simpler guard seemed the better trade.

## Testing

Validated as YAML only — `actionlint` is not installed here and the reusable-workflow wiring cannot be exercised locally. The real verification is the first version bump that merges after this lands; if it misbehaves, the manual tag path is still available as an immediate fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpRoSBEKAsBpH94Xsq8Fh7