### PR TITLE
feat(proxy): free up Authorization so an app behind IAP can use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,16 +1238,21 @@ Available egress middlewares: `iap-auth` (Bearer id_token; sources `metadata`,
 (`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`,
 `webhook-token-inject`, `bearer-token-inject`.
 
-Whenever a client-middleware chain is configured, the `Authorization` the caller
-sent is dropped before the chain runs. That header addresses the proxy hop, not
-n8n: it is a credential for reaching the proxy, replayable until it expires, and
+When the chain contains a middleware that supplies the upstream's credential —
+`iap-auth` or `bearer-token-inject` — the `Authorization` the caller sent is
+dropped before the chain runs. That header addresses the proxy hop, not n8n: it
+is a credential for reaching the proxy, replayable until it expires, and
 forwarding it would leak the right to call the proxy into the upstream's logs.
 Where the upstream sits behind its own identity-aware proxy it would also carry
 the wrong `aud` and only produce 401s at the second hop. Middlewares run after
 the drop and only ever add headers, so the result does not depend on chain order.
-A proxy running no client middleware keeps forwarding `Authorization` untouched —
-nothing in front of it consumed one, and webhook nodes using header or basic auth
-rely on it arriving.
+
+Chains without such a middleware — `api-key-inject` alone, or no chain at all —
+keep forwarding `Authorization` untouched: nothing in front of them consumed
+one, and webhook nodes using header or basic auth rely on it arriving. Two
+middlewares wanting the same header (`iap-auth` in its default mode alongside
+`bearer-token-inject`) is refused when the proxy starts, rather than letting
+chain order decide which credential reaches n8n.
 
 #### webhook-token-inject
 

--- a/README.md
+++ b/README.md
@@ -1345,6 +1345,14 @@ caller cannot smuggle its own gateway token through — only the token the proxy
 mints reaches IAP. Reverting is one env var: unset `N8N_IAP_AUTH_HEADER_NAME`
 and the id_token goes back to `Authorization`.
 
+**This assumes something authenticates callers in front of the proxy.** Unlike a
+webhook token, an MCP token is a general-purpose credential for the instance, and
+`/mcp-server/` is transparently forwarded, so it never passes through the
+server-middleware chain — anyone who can open a connection to the proxy's port
+gets the token attached on their behalf. Deploy the proxy behind IAP (or an
+equivalent ingress that authenticates every request) and do not expose its port
+directly.
+
 ### CLAUDE.md Integration
 
 n8n-cli can read project settings from a `CLAUDE.md` file in your repository:

--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,18 @@ no external refresh step is involved.
 Available egress middlewares: `iap-auth` (Bearer id_token; sources `metadata`,
 `adc-impersonate`, `env`, `static`), `impersonator-token`
 (`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`,
-`webhook-token-inject`.
+`webhook-token-inject`, `bearer-token-inject`.
+
+Whenever a client-middleware chain is configured, the `Authorization` the caller
+sent is dropped before the chain runs. That header addresses the proxy hop, not
+n8n: it is a credential for reaching the proxy, replayable until it expires, and
+forwarding it would leak the right to call the proxy into the upstream's logs.
+Where the upstream sits behind its own identity-aware proxy it would also carry
+the wrong `aud` and only produce 401s at the second hop. Middlewares run after
+the drop and only ever add headers, so the result does not depend on chain order.
+A proxy running no client middleware keeps forwarding `Authorization` untouched —
+nothing in front of it consumed one, and webhook nodes using header or basic auth
+rely on it arriving.
 
 #### webhook-token-inject
 
@@ -1273,6 +1284,61 @@ Every matching rule is applied, not just the first, so a broad rule can be
 combined with narrower ones; when two matching rules share a header the later
 one decides. A rule naming an unset `tokenEnvVar` fails at startup rather than
 silently injecting nothing.
+
+#### bearer-token-inject — reaching an app that wants `Authorization` for itself
+
+n8n's instance-level MCP server (`POST /mcp-server/http`) authenticates with
+`Authorization: Bearer <token>`. Behind Google IAP that header is already taken:
+IAP authenticates with `Authorization`, consumes it, and never passes it to the
+backend — so the application sees no token and answers
+`401 Unauthorized: Authorization header not sent`.
+
+IAP documents the way out. When a valid id_token arrives in
+`Proxy-Authorization`, IAP authorizes on that header instead and forwards
+`Authorization` to the backend without reading it
+([Authenticating from a proxy-authorization header](https://docs.cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header)).
+So set `iap-auth` to write its id_token to `Proxy-Authorization`, and let
+`bearer-token-inject` put the application's token in `Authorization`:
+
+| Header | Carries | Consumed by |
+| --- | --- | --- |
+| `Proxy-Authorization` | the gateway id_token | IAP |
+| `Authorization` | the application token | n8n |
+
+The switch is deployment-wide rather than path-scoped: n8n's public API
+authenticates on `X-N8N-API-KEY` and never reads `Authorization`, so freeing that
+header up costs it nothing, and one setting is easier to reason about — and to
+revert — than a per-path rule.
+
+```bash
+export N8N_CLIENT_MIDDLEWARES="iap-auth,api-key-inject,bearer-token-inject"
+export N8N_IAP_AUTH_HEADER_NAME="proxy-authorization"
+export N8N_BEARER_TOKEN_INJECT_RULES='[
+  {"pathPrefix":"/mcp-server/","tokenEnvVar":"N8N_MCP_TOKEN"}
+]'
+export N8N_MCP_TOKEN="..."   # typically mounted from a secret store
+```
+
+| Env | CLI | Notes |
+| --- | --- | --- |
+| `N8N_IAP_AUTH_HEADER_NAME` | `--iap-auth-header-name` | `authorization` (default, unchanged behavior) or `proxy-authorization`. |
+| `N8N_BEARER_TOKEN_INJECT_RULES` | `--bearer-token-inject-rules` | JSON array of rules, see below. |
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `pathPrefix` | yes | Matched against the incoming pathname. Keep the trailing slash — `/mcp-server` would also match `/mcp-server-admin`. |
+| `tokenEnvVar` | either this | Name of an env var holding the token. Preferred, for the same reason as in `webhook-token-inject`. |
+| `token` | or this | Literal value, for deployments that already render config from a secret store. |
+| `scheme` | no | Auth scheme prefixed to the token, `Bearer` by default. An empty string writes the raw value. |
+
+Rules are path-scoped because the token is one application surface's credential,
+not a gateway credential: injected everywhere, it would be handed to every
+endpoint the proxy can reach. Paths no rule covers get no `Authorization` at all.
+
+`Proxy-Authorization` remains on the hop-by-hop strip list (RFC 7230 §6.1), so a
+caller cannot smuggle its own gateway token through — only the token the proxy
+mints reaches IAP. Reverting is one env var: unset `N8N_IAP_AUTH_HEADER_NAME`
+and the id_token goes back to `Authorization`.
 
 ### CLAUDE.md Integration
 

--- a/README.md
+++ b/README.md
@@ -1248,12 +1248,14 @@ would also carry the wrong `aud` and only produce 401s at the second hop.
 Middlewares run after the drop and only ever add headers, so the result does not
 depend on chain order.
 
-Everything else keeps forwarding `Authorization` untouched — a chain of
-`api-key-inject` alone, no chain at all, or a path outside the reach of a
-path-scoped rule. Nothing in front of those consumed the header, and webhook
-nodes using header or basic auth rely on it arriving. `iap-auth` supplies its
-header on every path; `bearer-token-inject` and `webhook-token-inject` only
-where their rules match.
+Everything else keeps forwarding `Authorization` untouched, because nothing in
+front of it consumed the header and webhook nodes using header or basic auth
+rely on it arriving: a chain of `api-key-inject` alone, no chain at all, or —
+when the chain's only credential claims are path-scoped — a path none of those
+rules covers. Note the scope of each: `iap-auth` claims its header on **every**
+path, so a chain containing it drops the caller's `Authorization` everywhere;
+`bearer-token-inject` and `webhook-token-inject` claim only where their rules
+match.
 
 Two middlewares wanting the same header on paths that can overlap — `iap-auth`
 in its default mode alongside `bearer-token-inject`, say — is refused when the
@@ -1344,7 +1346,11 @@ export N8N_MCP_TOKEN="..."   # typically mounted from a secret store
 
 Rules are path-scoped because the token is one application surface's credential,
 not a gateway credential: injected everywhere, it would be handed to every
-endpoint the proxy can reach. Paths no rule covers get no `Authorization` at all.
+endpoint the proxy can reach. This middleware writes nothing on paths no rule
+covers — in the configuration above `iap-auth` still clears the caller's
+`Authorization` there, so those requests reach n8n without one; run
+`bearer-token-inject` on its own and a path outside its rules keeps whatever the
+caller sent.
 
 `Proxy-Authorization` remains on the hop-by-hop strip list (RFC 7230 §6.1), so a
 caller cannot smuggle its own gateway token through — only the token the proxy

--- a/README.md
+++ b/README.md
@@ -1238,21 +1238,27 @@ Available egress middlewares: `iap-auth` (Bearer id_token; sources `metadata`,
 (`X-Impersonator-Id-Token`; sources `adc`, `env`, `static`), `api-key-inject`,
 `webhook-token-inject`, `bearer-token-inject`.
 
-When the chain contains a middleware that supplies the upstream's credential —
-`iap-auth` or `bearer-token-inject` — the `Authorization` the caller sent is
-dropped before the chain runs. That header addresses the proxy hop, not n8n: it
-is a credential for reaching the proxy, replayable until it expires, and
-forwarding it would leak the right to call the proxy into the upstream's logs.
-Where the upstream sits behind its own identity-aware proxy it would also carry
-the wrong `aud` and only produce 401s at the second hop. Middlewares run after
-the drop and only ever add headers, so the result does not depend on chain order.
+Each middleware declares the headers it supplies, and on which paths. Where the
+chain supplies a credential header for the request at hand, the `Authorization`
+the caller sent is dropped before the chain runs. That header addresses the
+proxy hop, not n8n: it is a credential for reaching the proxy, replayable until
+it expires, and forwarding it would leak the right to call the proxy into the
+upstream's logs. Where the upstream sits behind its own identity-aware proxy it
+would also carry the wrong `aud` and only produce 401s at the second hop.
+Middlewares run after the drop and only ever add headers, so the result does not
+depend on chain order.
 
-Chains without such a middleware — `api-key-inject` alone, or no chain at all —
-keep forwarding `Authorization` untouched: nothing in front of them consumed
-one, and webhook nodes using header or basic auth rely on it arriving. Two
-middlewares wanting the same header (`iap-auth` in its default mode alongside
-`bearer-token-inject`) is refused when the proxy starts, rather than letting
-chain order decide which credential reaches n8n.
+Everything else keeps forwarding `Authorization` untouched — a chain of
+`api-key-inject` alone, no chain at all, or a path outside the reach of a
+path-scoped rule. Nothing in front of those consumed the header, and webhook
+nodes using header or basic auth rely on it arriving. `iap-auth` supplies its
+header on every path; `bearer-token-inject` and `webhook-token-inject` only
+where their rules match.
+
+Two middlewares wanting the same header on paths that can overlap — `iap-auth`
+in its default mode alongside `bearer-token-inject`, say — is refused when the
+proxy starts, rather than letting chain order decide which credential reaches
+n8n. Claims over prefixes that cannot both match one request are fine.
 
 #### webhook-token-inject
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -23,6 +23,7 @@ interface ProxyOptions {
   iapAuthAudience?: string;
   iapAuthTokenSource?: string;
   iapAuthTokenEnvVar?: string;
+  iapAuthHeaderName?: string;
   iapAuthCacheTtlMs?: string;
   iapAuthTimeoutMs?: string;
   iapAuthMetadataBaseUrl?: string;
@@ -37,6 +38,9 @@ interface ProxyOptions {
   // token values inside them should be env-var references rather than literals
   // for the same reason api-key-inject refuses a raw key here.
   webhookTokenInjectRules?: string;
+  // bearer-token-inject client-middleware options. Same shape and same
+  // reasoning as webhook-token-inject's rules.
+  bearerTokenInjectRules?: string;
   // impersonator-token client-middleware options. Attaches the user's own
   // Google id_token as a side header so the server can attribute the call
   // to the human running the CLI (instead of the impersonated SA).
@@ -403,7 +407,7 @@ export function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unk
  * read. Keeping the projection explicit prevents commander artifacts
  * (`_optionValues`, etc.) from leaking into factory inputs.
  */
-function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
+export function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   const copy = (k: keyof ProxyOptions) => {
     if (opts[k] !== undefined) out[k] = opts[k];
@@ -411,6 +415,7 @@ function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unkn
   copy("iapAuthAudience");
   copy("iapAuthTokenSource");
   copy("iapAuthTokenEnvVar");
+  copy("iapAuthHeaderName");
   copy("iapAuthCacheTtlMs");
   copy("iapAuthTimeoutMs");
   copy("iapAuthMetadataBaseUrl");
@@ -420,6 +425,7 @@ function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<string, unkn
   copy("apiKeyInjectHeader");
   copy("apiKeyInjectConflictPolicy");
   copy("webhookTokenInjectRules");
+  copy("bearerTokenInjectRules");
   copy("impersonatorTokenAudience");
   copy("impersonatorTokenSource");
   copy("impersonatorTokenEnvVar");

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -131,7 +131,7 @@ export function registerProxyCommand(program: Command): void {
     )
     .option(
       "--iap-auth-header-name <name>",
-      "Header the id_token is written to: authorization (default) or proxy-authorization. Use proxy-authorization when the upstream application needs Authorization for its own bearer token — IAP accepts the id_token there and forwards Authorization untouched. env: N8N_IAP_AUTH_HEADER_NAME",
+      "Header the id_token is written to: authorization (default) or proxy-authorization. Use proxy-authorization when the upstream application needs a bearer token of its own in Authorization — IAP then reads the id_token from Proxy-Authorization and forwards Authorization to the backend unread. The proxy, not the caller, must supply that token (see --bearer-token-inject-rules): a caller's own Authorization is still discarded. env: N8N_IAP_AUTH_HEADER_NAME",
     )
     .option(
       "--iap-auth-cache-ttl-ms <ms>",

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -126,6 +126,10 @@ export function registerProxyCommand(program: Command): void {
       "Env var holding a pre-minted id_token (token-source=env)",
     )
     .option(
+      "--iap-auth-header-name <name>",
+      "Header the id_token is written to: authorization (default) or proxy-authorization. Use proxy-authorization when the upstream application needs Authorization for its own bearer token — IAP accepts the id_token there and forwards Authorization untouched. env: N8N_IAP_AUTH_HEADER_NAME",
+    )
+    .option(
       "--iap-auth-cache-ttl-ms <ms>",
       "Id-token cache lifetime in milliseconds (default: 3000000, i.e. 50 min)",
     )
@@ -164,6 +168,17 @@ export function registerProxyCommand(program: Command): void {
         "Each rule needs exactly one of tokenEnvVar (preferred) or token, and an " +
         "optional conflictPolicy of set-if-absent (default) or replace. " +
         "env: N8N_WEBHOOK_TOKEN_INJECT_RULES",
+    )
+    // bearer-token-inject options — only meaningful when "bearer-token-inject"
+    // is in the client-middleware chain.
+    .option(
+      "--bearer-token-inject-rules <json>",
+      "JSON array of path-scoped Authorization rules: " +
+        '[{"pathPrefix":"/mcp-server/","tokenEnvVar":"MCP_TOKEN"}]. ' +
+        "Each rule needs exactly one of tokenEnvVar (preferred) or token, and an " +
+        'optional scheme (default "Bearer"). Requires --iap-auth-header-name=' +
+        "proxy-authorization when the upstream sits behind IAP. " +
+        "env: N8N_BEARER_TOKEN_INJECT_RULES",
     )
     .option(
       "--tags <tags>",

--- a/src/middleware/builtin/api-key-inject/factory.ts
+++ b/src/middleware/builtin/api-key-inject/factory.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { sanitizeHeaderValue } from "@/middleware/header-value.ts";
 import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
 import { ApiKeyInjectMiddleware } from "./middleware.ts";
 
@@ -63,7 +64,12 @@ export const apiKeyInjectFactory: ClientMiddlewareFactory<ApiKeyInjectRawOptions
   loadFromCLI: fromCLI,
   build(merged) {
     const parsed = optionsSchema.parse(merged);
-    return new ApiKeyInjectMiddleware(parsed);
+    return new ApiKeyInjectMiddleware({
+      ...parsed,
+      // Same failure as the token-injecting middlewares: a key mounted from a
+      // file carries a trailing newline, which `Headers.set` rejects mid-request.
+      apiKey: sanitizeHeaderValue(parsed.apiKey, "api-key-inject: apiKey"),
+    });
   },
 };
 

--- a/src/middleware/builtin/api-key-inject/middleware.ts
+++ b/src/middleware/builtin/api-key-inject/middleware.ts
@@ -1,3 +1,4 @@
+import type { HeaderClaim } from "@/middleware/header-claims.ts";
 import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
 
 export interface ApiKeyInjectOptions {
@@ -23,8 +24,16 @@ export interface ApiKeyInjectOptions {
  */
 export class ApiKeyInjectMiddleware implements ClientMiddleware {
   readonly name = "api-key-inject";
+  readonly headerClaims: readonly HeaderClaim[];
 
-  constructor(private readonly options: ApiKeyInjectOptions) {}
+  constructor(private readonly options: ApiKeyInjectOptions) {
+    // `header` is configurable, so this middleware can be pointed at
+    // `Authorization` like any other. Claiming it keeps that configuration
+    // inside the same conflict check as everything else instead of letting
+    // chain order decide. Under "set-if-absent" it defers to the caller and so
+    // claims nothing.
+    this.headerClaims = options.conflictPolicy === "replace" ? [{ header: options.header }] : [];
+  }
 
   apply(headers: Headers, _ctx: ClientMiddlewareContext): void {
     if (this.options.conflictPolicy === "set-if-absent" && headers.has(this.options.header)) {

--- a/src/middleware/builtin/bearer-token-inject/factory.ts
+++ b/src/middleware/builtin/bearer-token-inject/factory.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
+import { BearerTokenInjectMiddleware } from "./middleware.ts";
+
+/** RFC 7235 auth-scheme: a bare token, no separators. */
+const AUTH_SCHEME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]*$/;
+
+/**
+ * A rule as written in configuration.
+ *
+ * The token is supplied one of two ways, for the same reason
+ * `webhook-token-inject` splits them:
+ *   - `tokenEnvVar`: name of an env var holding it. Preferred — the rule set
+ *     itself travels through env/CLI, and a value written inline there lands
+ *     in process listings, deployment manifests and config dumps.
+ *   - `token`: the literal value, for setups that already inject config from a
+ *     secret store and have nowhere else to put it.
+ *
+ * Exactly one of the two: accepting both would leave which one wins to chance,
+ * and a rule silently reading the wrong secret fails in the least debuggable
+ * way possible.
+ */
+const ruleSchema = z
+  .object({
+    pathPrefix: z
+      .string({ message: "bearer-token-inject: rule.pathPrefix is required" })
+      .min(1, { message: "bearer-token-inject: rule.pathPrefix must not be empty" })
+      .startsWith("/", {
+        message: "bearer-token-inject: rule.pathPrefix must start with '/'",
+      }),
+    token: z.string().min(1).optional(),
+    tokenEnvVar: z.string().min(1).optional(),
+    scheme: z
+      .string()
+      .regex(AUTH_SCHEME, {
+        message: "bearer-token-inject: rule.scheme must be a bare auth-scheme token",
+      })
+      .default("Bearer"),
+  })
+  .refine((r) => Boolean(r.token) !== Boolean(r.tokenEnvVar), {
+    message:
+      "bearer-token-inject: each rule needs exactly one of token / tokenEnvVar " +
+      "(tokenEnvVar is preferred — it keeps the secret out of the rule set)",
+  });
+
+const optionsSchema = z.object({
+  rules: z
+    .array(ruleSchema)
+    .min(1, {
+      message:
+        "bearer-token-inject: at least one rule is required " +
+        "(set N8N_BEARER_TOKEN_INJECT_RULES). An enabled middleware with no " +
+        "rules would silently inject nothing.",
+    })
+    .max(64, { message: "bearer-token-inject: at most 64 rules" }),
+});
+
+type BearerTokenInjectRawOptions = z.infer<typeof optionsSchema>;
+
+function parseRules(raw: string, source: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`bearer-token-inject: ${source} is not valid JSON: ${message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `bearer-token-inject: ${source} must be a JSON array of rules, got ${typeof parsed}`,
+    );
+  }
+  return parsed;
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<BearerTokenInjectRawOptions> {
+  const raw = env.N8N_BEARER_TOKEN_INJECT_RULES;
+  if (!raw) return {};
+  return {
+    rules: parseRules(raw, "N8N_BEARER_TOKEN_INJECT_RULES") as BearerTokenInjectRawOptions["rules"],
+  };
+}
+
+function fromCLI(opts: Record<string, unknown>): Partial<BearerTokenInjectRawOptions> {
+  const raw = opts.bearerTokenInjectRules;
+  if (typeof raw !== "string" || raw.length === 0) return {};
+  return {
+    rules: parseRules(raw, "--bearer-token-inject-rules") as BearerTokenInjectRawOptions["rules"],
+  };
+}
+
+/**
+ * Resolves `tokenEnvVar` indirections against the process environment.
+ *
+ * An unresolvable reference is an error rather than a skipped rule: a rule that
+ * quietly stops injecting turns into upstream 401s far from the
+ * misconfiguration that caused them.
+ */
+function resolveTokens(
+  rules: BearerTokenInjectRawOptions["rules"],
+  env: NodeJS.ProcessEnv,
+): { pathPrefix: string; token: string; scheme: string }[] {
+  return rules.map((rule) => {
+    let token = rule.token;
+    if (rule.tokenEnvVar) {
+      const value = env[rule.tokenEnvVar];
+      if (!value) {
+        throw new Error(
+          `bearer-token-inject: rule for ${rule.pathPrefix} references ` +
+            `tokenEnvVar "${rule.tokenEnvVar}", which is unset or empty`,
+        );
+      }
+      token = value;
+    }
+    // `token` is present here: the schema refinement guarantees exactly one of
+    // the two sources, and the env branch above either assigned or threw.
+    return { pathPrefix: rule.pathPrefix, token: token as string, scheme: rule.scheme };
+  });
+}
+
+export const bearerTokenInjectFactory: ClientMiddlewareFactory<BearerTokenInjectRawOptions> = {
+  name: "bearer-token-inject",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    return new BearerTokenInjectMiddleware({ rules: resolveTokens(parsed.rules, process.env) });
+  },
+};
+
+/** Exposed for unit tests that build options directly. */
+export const bearerTokenInjectOptionsSchema = optionsSchema;
+/** Exposed for unit tests covering the env-var indirection. */
+export const resolveBearerTokenRules = resolveTokens;

--- a/src/middleware/builtin/bearer-token-inject/factory.ts
+++ b/src/middleware/builtin/bearer-token-inject/factory.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { sanitizeHeaderValue } from "@/middleware/header-value.ts";
 import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
 import { BearerTokenInjectMiddleware } from "./middleware.ts";
 
@@ -114,7 +115,14 @@ function resolveTokens(
     }
     // `token` is present here: the schema refinement guarantees exactly one of
     // the two sources, and the env branch above either assigned or threw.
-    return { pathPrefix: rule.pathPrefix, token: token as string, scheme: rule.scheme };
+    return {
+      pathPrefix: rule.pathPrefix,
+      token: sanitizeHeaderValue(
+        token as string,
+        `bearer-token-inject: rule for ${rule.pathPrefix}`,
+      ),
+      scheme: rule.scheme,
+    };
   });
 }
 

--- a/src/middleware/builtin/bearer-token-inject/middleware.ts
+++ b/src/middleware/builtin/bearer-token-inject/middleware.ts
@@ -1,0 +1,69 @@
+import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
+
+/**
+ * One path-scoped bearer-token injection.
+ *
+ * Scoping is the point, exactly as in `webhook-token-inject`. The token here is
+ * an application-layer credential for one specific upstream surface (n8n's
+ * instance-level MCP server, say). Putting it on every upstream call would hand
+ * that credential to every endpoint the proxy can reach, including ones the
+ * operator never meant to speak for. Each rule therefore names the prefix it is
+ * allowed to speak for.
+ */
+export interface BearerTokenRule {
+  /**
+   * Prefix matched against the *incoming* request pathname (e.g.
+   * `/mcp-server/`). Trailing slash matters: `/mcp-ser` would otherwise also
+   * match `/mcp-server-admin`.
+   */
+  pathPrefix: string;
+  /** Token value. Never logged, never echoed back to the caller. */
+  token: string;
+  /**
+   * Auth scheme prefixed to the token, e.g. `Bearer` → `Authorization: Bearer
+   * <token>`. Empty string writes the raw value, for the rare upstream that
+   * wants an unprefixed credential.
+   */
+  scheme: string;
+}
+
+export interface BearerTokenInjectOptions {
+  /**
+   * Rules in declaration order. **Every** matching rule is applied, not just
+   * the first, and the last match wins — all rules write the same header, so a
+   * broad rule plus a narrower one on top resolves the way the reading order
+   * suggests.
+   */
+  rules: BearerTokenRule[];
+}
+
+/**
+ * Client middleware that attaches an application-layer token as
+ * `Authorization` on upstream requests whose path falls under a configured
+ * prefix.
+ *
+ * This exists because `Authorization` is contested when the upstream sits
+ * behind Google IAP: IAP authenticates with that header and consumes it, so an
+ * application that also wants a bearer token there never sees one. Configuring
+ * `iap-auth` to emit `proxy-authorization` frees `Authorization` up, and this
+ * middleware fills it — see the README section on MCP for the full split.
+ *
+ * Only ever sets its header, never deletes: the client's own `Authorization`
+ * is discarded before the pipeline runs (see `forwardRequest`), so this
+ * middleware's position in the chain does not change the outcome. The one
+ * ordering constraint left is a self-inflicted one — running this alongside
+ * `iap-auth` in its default `authorization` mode has the two fight over the
+ * same header, which is a misconfiguration rather than a supported setup.
+ */
+export class BearerTokenInjectMiddleware implements ClientMiddleware {
+  readonly name = "bearer-token-inject";
+
+  constructor(private readonly options: BearerTokenInjectOptions) {}
+
+  apply(headers: Headers, ctx: ClientMiddlewareContext): void {
+    for (const rule of this.options.rules) {
+      if (!ctx.pathname.startsWith(rule.pathPrefix)) continue;
+      headers.set("authorization", rule.scheme ? `${rule.scheme} ${rule.token}` : rule.token);
+    }
+  }
+}

--- a/src/middleware/builtin/bearer-token-inject/middleware.ts
+++ b/src/middleware/builtin/bearer-token-inject/middleware.ts
@@ -1,3 +1,4 @@
+import type { HeaderClaim } from "@/middleware/header-claims.ts";
 import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
 
 /**
@@ -58,9 +59,17 @@ export interface BearerTokenInjectOptions {
  */
 export class BearerTokenInjectMiddleware implements ClientMiddleware {
   readonly name = "bearer-token-inject";
-  readonly ownedHeaders = ["authorization"] as const;
+  readonly headerClaims: readonly HeaderClaim[];
 
-  constructor(private readonly options: BearerTokenInjectOptions) {}
+  constructor(private readonly options: BearerTokenInjectOptions) {
+    // Claimed only where the rules reach: on every other path the proxy
+    // supplies nothing, and deleting the caller's header there would break a
+    // request this middleware has no opinion about.
+    this.headerClaims = options.rules.map((r) => ({
+      header: "authorization",
+      pathPrefix: r.pathPrefix,
+    }));
+  }
 
   apply(headers: Headers, ctx: ClientMiddlewareContext): void {
     for (const rule of this.options.rules) {

--- a/src/middleware/builtin/bearer-token-inject/middleware.ts
+++ b/src/middleware/builtin/bearer-token-inject/middleware.ts
@@ -50,13 +50,15 @@ export interface BearerTokenInjectOptions {
  *
  * Only ever sets its header, never deletes: the client's own `Authorization`
  * is discarded before the pipeline runs (see `forwardRequest`), so this
- * middleware's position in the chain does not change the outcome. The one
- * ordering constraint left is a self-inflicted one — running this alongside
- * `iap-auth` in its default `authorization` mode has the two fight over the
- * same header, which is a misconfiguration rather than a supported setup.
+ * middleware's position in the chain does not change the outcome. Running it
+ * alongside `iap-auth` in its default `authorization` mode would have the two
+ * fight over one header; both declare it in `ownedHeaders`, so that
+ * combination is refused when the chain is built rather than deciding a
+ * runtime 401 by declaration order.
  */
 export class BearerTokenInjectMiddleware implements ClientMiddleware {
   readonly name = "bearer-token-inject";
+  readonly ownedHeaders = ["authorization"] as const;
 
   constructor(private readonly options: BearerTokenInjectOptions) {}
 

--- a/src/middleware/builtin/bearer-token-inject/middleware.ts
+++ b/src/middleware/builtin/bearer-token-inject/middleware.ts
@@ -53,7 +53,7 @@ export interface BearerTokenInjectOptions {
  * is discarded before the pipeline runs (see `forwardRequest`), so this
  * middleware's position in the chain does not change the outcome. Running it
  * alongside `iap-auth` in its default `authorization` mode would have the two
- * fight over one header; both declare it in `ownedHeaders`, so that
+ * fight over one header; both declare it in `headerClaims`, so that
  * combination is refused when the chain is built rather than deciding a
  * runtime 401 by declaration order.
  */

--- a/src/middleware/builtin/iap-auth/factory.ts
+++ b/src/middleware/builtin/iap-auth/factory.ts
@@ -37,6 +37,23 @@ const optionsSchema = z.object({
   tokenEnvVar: z.string().optional(),
   /** Inline token value when tokenSourceKind=static (tests only). */
   staticToken: z.string().optional(),
+  /**
+   * Header the id_token is written to.
+   *
+   * Default `authorization` — the historical behavior, kept so enabling this
+   * middleware never changes an existing deployment. Switch to
+   * `proxy-authorization` when the upstream application also wants
+   * `Authorization` for itself: IAP accepts the id_token there and then passes
+   * `Authorization` through to the backend unread. One env var flips it, and
+   * one env var flips it back if the gateway turns out not to honour it.
+   */
+  headerName: z
+    .union([z.literal("authorization"), z.literal("proxy-authorization")], {
+      message:
+        "iap-auth: headerName must be authorization or proxy-authorization " +
+        "(set N8N_IAP_AUTH_HEADER_NAME / --iap-auth-header-name)",
+    })
+    .default("authorization"),
   /** Cache TTL in ms (metadata source). Default 50 min — id_tokens live ~1h. */
   cacheTtlMs: z
     .number()
@@ -119,6 +136,9 @@ function fromEnv(env: NodeJS.ProcessEnv): Partial<IapAuthRawOptions> {
     out.tokenSourceKind = env.N8N_IAP_AUTH_TOKEN_SOURCE as IapAuthRawOptions["tokenSourceKind"];
   }
   if (env.N8N_IAP_AUTH_TOKEN_ENV_VAR) out.tokenEnvVar = env.N8N_IAP_AUTH_TOKEN_ENV_VAR;
+  if (env.N8N_IAP_AUTH_HEADER_NAME) {
+    out.headerName = env.N8N_IAP_AUTH_HEADER_NAME.toLowerCase() as IapAuthRawOptions["headerName"];
+  }
   if (env.N8N_IAP_AUTH_CACHE_TTL_MS) {
     out.cacheTtlMs = Number.parseInt(env.N8N_IAP_AUTH_CACHE_TTL_MS, 10);
   }
@@ -149,6 +169,8 @@ function fromCLI(opts: Record<string, unknown>): Partial<IapAuthRawOptions> {
     out.tokenSourceKind = s("iapAuthTokenSource") as IapAuthRawOptions["tokenSourceKind"];
   }
   if (s("iapAuthTokenEnvVar")) out.tokenEnvVar = s("iapAuthTokenEnvVar");
+  const headerName = s("iapAuthHeaderName");
+  if (headerName) out.headerName = headerName.toLowerCase() as IapAuthRawOptions["headerName"];
   const ttl = n("iapAuthCacheTtlMs");
   if (ttl !== undefined) out.cacheTtlMs = ttl;
   const t = n("iapAuthTimeoutMs");
@@ -170,7 +192,11 @@ export const iapAuthFactory: ClientMiddlewareFactory<IapAuthRawOptions> = {
   build(merged) {
     const parsed = optionsSchema.parse(merged);
     const tokenSource = buildTokenSource(parsed);
-    return new IapAuthMiddleware({ audience: parsed.audience, tokenSource });
+    return new IapAuthMiddleware({
+      audience: parsed.audience,
+      tokenSource,
+      headerName: parsed.headerName,
+    });
   },
 };
 

--- a/src/middleware/builtin/iap-auth/middleware.ts
+++ b/src/middleware/builtin/iap-auth/middleware.ts
@@ -39,8 +39,11 @@ export interface IapAuthOptions {
  */
 export class IapAuthMiddleware implements ClientMiddleware {
   readonly name = "iap-auth";
+  readonly ownedHeaders: readonly string[];
 
-  constructor(private readonly options: IapAuthOptions) {}
+  constructor(private readonly options: IapAuthOptions) {
+    this.ownedHeaders = [options.headerName ?? "authorization"];
+  }
 
   async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
     const token = await this.options.tokenSource.getToken(this.options.audience);

--- a/src/middleware/builtin/iap-auth/middleware.ts
+++ b/src/middleware/builtin/iap-auth/middleware.ts
@@ -1,26 +1,41 @@
 import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
 import type { TokenSource } from "./token-source.ts";
 
+/**
+ * Header the minted id_token is written to.
+ *
+ * `authorization` is the default and the historical behavior. IAP also accepts
+ * the id_token in `Proxy-Authorization`, and when it does it forwards
+ * `Authorization` to the backend untouched
+ * (https://docs.cloud.google.com/iap/docs/authentication-howto). That is the
+ * only way an application-layer bearer token can reach an IAP-protected
+ * upstream, because IAP consumes the `Authorization` it authenticates with.
+ */
+export type IapAuthHeaderName = "authorization" | "proxy-authorization";
+
 export interface IapAuthOptions {
   /** OAuth2 client_id of the IAP-protected upstream — becomes the `aud` claim. */
   audience: string;
   /** Token source. Defaults to GCE metadata server in the factory. */
   tokenSource: TokenSource;
+  /** Where to write the id_token. Defaults to `authorization`. */
+  headerName?: IapAuthHeaderName;
 }
 
 /**
  * Client middleware that mints a Google-signed id_token for an IAP-protected
- * upstream and attaches it as `Authorization: Bearer <token>`.
+ * upstream and attaches it as `<headerName>: Bearer <token>`.
  *
- * Always replaces any incoming `Authorization` — the client-side token (used
- * to authenticate against the proxy's *own* IAP layer, IAP#1) has a different
- * `aud` than the upstream's IAP (IAP#2), so passing it through would result
- * in audience-mismatch 401s at the second hop.
+ * This middleware only ever *adds* its own header. Discarding whatever the
+ * client brought in `Authorization` is the proxy's job and happens before the
+ * pipeline runs (see `forwardRequest`), which keeps the result independent of
+ * where this middleware sits in the chain.
  *
- * The previous `Authorization` value is dropped before the new one is set.
- * If you need the user's identity to reach the upstream, configure IAP#1 to
- * inject `X-Goog-Authenticated-User-Email` (which is a separate header and
- * isn't touched here).
+ * When `headerName` is `proxy-authorization`, `Authorization` is left entirely
+ * alone so a later middleware can put an application-layer token there. If you
+ * need the user's identity to reach the upstream, configure the proxy's own IAP
+ * to inject `X-Goog-Authenticated-User-Email` (a separate header, never touched
+ * here).
  */
 export class IapAuthMiddleware implements ClientMiddleware {
   readonly name = "iap-auth";
@@ -29,7 +44,6 @@ export class IapAuthMiddleware implements ClientMiddleware {
 
   async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {
     const token = await this.options.tokenSource.getToken(this.options.audience);
-    headers.delete("authorization");
-    headers.set("authorization", `Bearer ${token}`);
+    headers.set(this.options.headerName ?? "authorization", `Bearer ${token}`);
   }
 }

--- a/src/middleware/builtin/iap-auth/middleware.ts
+++ b/src/middleware/builtin/iap-auth/middleware.ts
@@ -1,3 +1,4 @@
+import type { HeaderClaim } from "@/middleware/header-claims.ts";
 import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
 import type { TokenSource } from "./token-source.ts";
 
@@ -39,10 +40,11 @@ export interface IapAuthOptions {
  */
 export class IapAuthMiddleware implements ClientMiddleware {
   readonly name = "iap-auth";
-  readonly ownedHeaders: readonly string[];
+  /** Written on every upstream call, so the claim carries no path scope. */
+  readonly headerClaims: readonly HeaderClaim[];
 
   constructor(private readonly options: IapAuthOptions) {
-    this.ownedHeaders = [options.headerName ?? "authorization"];
+    this.headerClaims = [{ header: options.headerName ?? "authorization" }];
   }
 
   async apply(headers: Headers, _ctx: ClientMiddlewareContext): Promise<void> {

--- a/src/middleware/builtin/webhook-token-inject/factory.ts
+++ b/src/middleware/builtin/webhook-token-inject/factory.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { sanitizeHeaderValue } from "@/middleware/header-value.ts";
 import type { ClientMiddlewareFactory } from "@/middleware/types.ts";
 import { WebhookTokenInjectMiddleware } from "./middleware.ts";
 
@@ -126,7 +127,10 @@ function resolveTokens(
     return {
       pathPrefix: rule.pathPrefix,
       header: rule.header,
-      token: token as string,
+      token: sanitizeHeaderValue(
+        token as string,
+        `webhook-token-inject: rule for ${rule.pathPrefix}`,
+      ),
       conflictPolicy: rule.conflictPolicy,
     };
   });

--- a/src/middleware/builtin/webhook-token-inject/middleware.ts
+++ b/src/middleware/builtin/webhook-token-inject/middleware.ts
@@ -62,8 +62,22 @@ export interface WebhookTokenInjectOptions {
  */
 export class WebhookTokenInjectMiddleware implements ClientMiddleware {
   readonly name = "webhook-token-inject";
+  readonly ownedHeaders: readonly string[];
 
-  constructor(private readonly options: WebhookTokenInjectOptions) {}
+  constructor(private readonly options: WebhookTokenInjectOptions) {
+    // Only the "replace" rules claim their header — those are the ones that
+    // make the proxy the single holder of that value. A "set-if-absent" rule
+    // says the opposite by design: the caller's own value wins, so it neither
+    // conflicts with another writer nor licenses discarding what the caller
+    // sent.
+    this.ownedHeaders = [
+      ...new Set(
+        options.rules
+          .filter((r) => r.conflictPolicy === "replace")
+          .map((r) => r.header.toLowerCase()),
+      ),
+    ];
+  }
 
   apply(headers: Headers, ctx: ClientMiddlewareContext): void {
     for (const rule of this.options.rules) {

--- a/src/middleware/builtin/webhook-token-inject/middleware.ts
+++ b/src/middleware/builtin/webhook-token-inject/middleware.ts
@@ -30,7 +30,7 @@ export interface WebhookTokenRule {
    *
    * One caveat for a rule whose `header` is `Authorization`: when the chain
    * also contains a middleware that claims the credential headers (see
-   * `ownedHeaders`), the caller's value is already gone by the time this runs,
+   * `headerClaims`), the caller's value is already gone by the time this runs,
    * so "set-if-absent" behaves like "replace". Webhook tokens normally live in
    * their own header, where this does not arise.
    */

--- a/src/middleware/builtin/webhook-token-inject/middleware.ts
+++ b/src/middleware/builtin/webhook-token-inject/middleware.ts
@@ -1,3 +1,4 @@
+import type { HeaderClaim } from "@/middleware/header-claims.ts";
 import type { ClientMiddleware, ClientMiddlewareContext } from "@/middleware/types.ts";
 
 /**
@@ -62,21 +63,17 @@ export interface WebhookTokenInjectOptions {
  */
 export class WebhookTokenInjectMiddleware implements ClientMiddleware {
   readonly name = "webhook-token-inject";
-  readonly ownedHeaders: readonly string[];
+  readonly headerClaims: readonly HeaderClaim[];
 
   constructor(private readonly options: WebhookTokenInjectOptions) {
-    // Only the "replace" rules claim their header — those are the ones that
-    // make the proxy the single holder of that value. A "set-if-absent" rule
-    // says the opposite by design: the caller's own value wins, so it neither
-    // conflicts with another writer nor licenses discarding what the caller
-    // sent.
-    this.ownedHeaders = [
-      ...new Set(
-        options.rules
-          .filter((r) => r.conflictPolicy === "replace")
-          .map((r) => r.header.toLowerCase()),
-      ),
-    ];
+    // Only the "replace" rules claim, and only over their own prefix. Those are
+    // the ones that make the proxy the single holder of that value; a
+    // "set-if-absent" rule says the opposite by design — the caller's value
+    // wins — so it neither conflicts with another writer nor licenses
+    // discarding what the caller sent.
+    this.headerClaims = options.rules
+      .filter((r) => r.conflictPolicy === "replace")
+      .map((r) => ({ header: r.header, pathPrefix: r.pathPrefix }));
   }
 
   apply(headers: Headers, ctx: ClientMiddlewareContext): void {

--- a/src/middleware/builtin/webhook-token-inject/middleware.ts
+++ b/src/middleware/builtin/webhook-token-inject/middleware.ts
@@ -26,6 +26,12 @@ export interface WebhookTokenRule {
    *   - "set-if-absent": leave it intact. Default — a caller that still brings
    *     its own token keeps working while a deployment migrates.
    *   - "replace": overwrite, making the proxy the single token holder.
+   *
+   * One caveat for a rule whose `header` is `Authorization`: when the chain
+   * also contains a middleware that claims the credential headers (see
+   * `ownedHeaders`), the caller's value is already gone by the time this runs,
+   * so "set-if-absent" behaves like "replace". Webhook tokens normally live in
+   * their own header, where this does not arise.
    */
   conflictPolicy: "replace" | "set-if-absent";
 }

--- a/src/middleware/client-registry.ts
+++ b/src/middleware/client-registry.ts
@@ -63,7 +63,36 @@ export function buildClientMiddlewares(input: BuildClientMiddlewaresInput): Clie
     );
     built.push(factory.build(merged));
   }
+  assertNoHeaderConflict(built);
   return built;
+}
+
+/**
+ * Refuses a chain in which two middlewares claim the same header.
+ *
+ * Both would write it and the later one would win, so the chain's declaration
+ * order — a deployment detail nothing else depends on — would silently decide
+ * which credential reaches the upstream. The failure that produces is a 401
+ * from a service that never sees the header it wanted; failing at startup with
+ * both names in hand costs an operator minutes instead of hours.
+ */
+function assertNoHeaderConflict(chain: ClientMiddleware[]): void {
+  const claimedBy = new Map<string, string>();
+  for (const mw of chain) {
+    for (const header of mw.ownedHeaders ?? []) {
+      const key = header.toLowerCase();
+      const owner = claimedBy.get(key);
+      if (owner) {
+        throw new Error(
+          `Client middlewares "${owner}" and "${mw.name}" both write the ` +
+            `"${key}" header, so which one reaches the upstream would depend on ` +
+            "chain order. Configure them onto different headers " +
+            "(e.g. N8N_IAP_AUTH_HEADER_NAME=proxy-authorization) or drop one.",
+        );
+      }
+      claimedBy.set(key, mw.name);
+    }
+  }
 }
 
 function mergeOptions(

--- a/src/middleware/client-registry.ts
+++ b/src/middleware/client-registry.ts
@@ -1,3 +1,4 @@
+import { claimsCollide, type HeaderClaim } from "./header-claims.ts";
 import type { ClientMiddleware, ClientMiddlewareFactory } from "./types.ts";
 
 /**
@@ -68,29 +69,35 @@ export function buildClientMiddlewares(input: BuildClientMiddlewaresInput): Clie
 }
 
 /**
- * Refuses a chain in which two middlewares claim the same header.
+ * Refuses a chain in which two middlewares claim one header on paths that can
+ * overlap.
  *
  * Both would write it and the later one would win, so the chain's declaration
  * order — a deployment detail nothing else depends on — would silently decide
  * which credential reaches the upstream. The failure that produces is a 401
  * from a service that never sees the header it wanted; failing at startup with
  * both names in hand costs an operator minutes instead of hours.
+ *
+ * Claims whose prefixes cannot both match one request are left alone: two
+ * middlewares writing `Authorization` on `/webhook/a/` and `/mcp-server/` never
+ * meet, and rejecting that would block a legitimate deployment.
  */
 function assertNoHeaderConflict(chain: ClientMiddleware[]): void {
-  const claimedBy = new Map<string, string>();
+  const seen: { claim: HeaderClaim; owner: string }[] = [];
   for (const mw of chain) {
-    for (const header of mw.ownedHeaders ?? []) {
-      const key = header.toLowerCase();
-      const owner = claimedBy.get(key);
-      if (owner) {
+    for (const claim of mw.headerClaims ?? []) {
+      const clash = seen.find((s) => s.owner !== mw.name && claimsCollide(s.claim, claim));
+      if (clash) {
+        const where = claim.pathPrefix ? ` on paths under "${claim.pathPrefix}"` : "";
         throw new Error(
-          `Client middlewares "${owner}" and "${mw.name}" both write the ` +
-            `"${key}" header, so which one reaches the upstream would depend on ` +
-            "chain order. Configure them onto different headers " +
-            "(e.g. N8N_IAP_AUTH_HEADER_NAME=proxy-authorization) or drop one.",
+          `Client middlewares "${clash.owner}" and "${mw.name}" both write the ` +
+            `"${claim.header.toLowerCase()}" header${where}, so which one reaches ` +
+            "the upstream would depend on chain order. Configure them onto " +
+            "different headers (e.g. N8N_IAP_AUTH_HEADER_NAME=proxy-authorization), " +
+            "scope them to non-overlapping paths, or drop one.",
         );
       }
-      claimedBy.set(key, mw.name);
+      seen.push({ claim, owner: mw.name });
     }
   }
 }

--- a/src/middleware/client-wiring.ts
+++ b/src/middleware/client-wiring.ts
@@ -1,4 +1,5 @@
 import { apiKeyInjectFactory } from "./builtin/api-key-inject/factory.ts";
+import { bearerTokenInjectFactory } from "./builtin/bearer-token-inject/factory.ts";
 import { iapAuthFactory } from "./builtin/iap-auth/factory.ts";
 import { impersonatorTokenFactory } from "./builtin/impersonator-token/factory.ts";
 import { webhookTokenInjectFactory } from "./builtin/webhook-token-inject/factory.ts";
@@ -15,6 +16,7 @@ export function registerClientBuiltins(): void {
   registerClientFactory(apiKeyInjectFactory);
   registerClientFactory(impersonatorTokenFactory);
   registerClientFactory(webhookTokenInjectFactory);
+  registerClientFactory(bearerTokenInjectFactory);
 }
 
 /**

--- a/src/middleware/header-claims.ts
+++ b/src/middleware/header-claims.ts
@@ -1,0 +1,46 @@
+/**
+ * Which headers a client middleware supplies, and where.
+ *
+ * A claim says "the proxy provides this header's value on these paths; what the
+ * caller sent for it is not the upstream's business". Two things read claims:
+ * the registry refuses a chain in which two middlewares claim one header on
+ * overlapping paths (the outcome would otherwise depend on chain order), and
+ * `forwardRequest` discards the caller's `Authorization` on the paths where the
+ * chain has claimed a credential header.
+ *
+ * Scope matters in both directions. Claiming globally what is really a
+ * path-scoped injection would delete the caller's credential on paths the proxy
+ * supplies nothing for; treating a path-scoped claim as global would also
+ * reject configurations whose prefixes cannot collide.
+ */
+export interface HeaderClaim {
+  /** Header name. Compared case-insensitively. */
+  header: string;
+  /**
+   * Path prefix the claim covers. Absent means every path — the shape of a
+   * middleware that writes its header on all upstream calls.
+   */
+  pathPrefix?: string;
+}
+
+function sameHeader(a: HeaderClaim, b: HeaderClaim): boolean {
+  return a.header.toLowerCase() === b.header.toLowerCase();
+}
+
+/**
+ * Whether two claims can ever apply to one request.
+ *
+ * Prefixes overlap when either covers everything or one is a prefix of the
+ * other — `/webhook/` and `/webhook/a/` collide, `/webhook/a/` and
+ * `/mcp-server/` cannot.
+ */
+export function claimsCollide(a: HeaderClaim, b: HeaderClaim): boolean {
+  if (!sameHeader(a, b)) return false;
+  if (a.pathPrefix === undefined || b.pathPrefix === undefined) return true;
+  return a.pathPrefix.startsWith(b.pathPrefix) || b.pathPrefix.startsWith(a.pathPrefix);
+}
+
+/** Whether a claim applies to a concrete request path. */
+export function claimCoversPath(claim: HeaderClaim, pathname: string): boolean {
+  return claim.pathPrefix === undefined || pathname.startsWith(claim.pathPrefix);
+}

--- a/src/middleware/header-value.ts
+++ b/src/middleware/header-value.ts
@@ -1,0 +1,46 @@
+/**
+ * Validation for secrets that are about to become HTTP header values.
+ *
+ * A token mounted from a file — the usual shape for a secret-store volume —
+ * arrives with a trailing newline more often than not. `Headers.set` rejects
+ * that, and it does so inside the client pipeline: every matching request turns
+ * into a 502 carrying an "Invalid header value" message, far from the config
+ * that caused it. Middlewares that resolve secrets at build time run them
+ * through here so the same mistake stops the proxy at startup instead.
+ */
+
+/** CR, LF, NUL and the rest of the C0/DEL range a header value may not carry. */
+function hasControlCharacter(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * Trims surrounding whitespace and rejects what remains if it cannot be sent.
+ *
+ * Trimming rather than rejecting: a trailing newline is an artifact of how the
+ * secret was delivered, never part of the credential, and failing on it would
+ * make every file-mounted secret a support ticket. Embedded control characters
+ * are a different matter — they mean the value is not the secret anyone
+ * intended, and header injection is the interesting failure mode.
+ *
+ * @param context what to name in the error, e.g.
+ *   `bearer-token-inject: rule for /mcp-server/`
+ */
+export function sanitizeHeaderValue(raw: string, context: string): string {
+  const value = raw.trim();
+  if (!value) {
+    throw new Error(`${context}: token is empty (after trimming surrounding whitespace)`);
+  }
+  if (hasControlCharacter(value)) {
+    throw new Error(
+      `${context}: token contains a character that cannot appear in an HTTP ` +
+        "header value (a line break or control character). Check how the secret " +
+        "is mounted — surrounding whitespace is trimmed, embedded breaks are not.",
+    );
+  }
+  return value;
+}

--- a/src/middleware/header-value.ts
+++ b/src/middleware/header-value.ts
@@ -9,11 +9,23 @@
  * through here so the same mistake stops the proxy at startup instead.
  */
 
-/** CR, LF, NUL and the rest of the C0/DEL range a header value may not carry. */
-function hasControlCharacter(value: string): boolean {
+/**
+ * Whether a character cannot survive `Headers.set`.
+ *
+ * Two classes, and the second is the one that actually bites. Control
+ * characters (C0 and DEL) are the header-injection concern. But a header value
+ * is Latin-1, so anything above U+00FF — a smart quote or a full-width
+ * character pasted into a secret — is what the runtime rejects outright; a
+ * trailing newline it merely trims. Same rule `headerSafe()` documents in
+ * `src/proxy/server.ts`.
+ */
+function isUnsendable(code: number): boolean {
+  return code < 0x20 || code === 0x7f || code > 0xff;
+}
+
+function hasUnsendableCharacter(value: string): boolean {
   for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code < 0x20 || code === 0x7f) return true;
+    if (isUnsendable(value.charCodeAt(i))) return true;
   }
   return false;
 }
@@ -23,9 +35,8 @@ function hasControlCharacter(value: string): boolean {
  *
  * Trimming rather than rejecting: a trailing newline is an artifact of how the
  * secret was delivered, never part of the credential, and failing on it would
- * make every file-mounted secret a support ticket. Embedded control characters
- * are a different matter — they mean the value is not the secret anyone
- * intended, and header injection is the interesting failure mode.
+ * make every file-mounted secret a support ticket. What is left over is a
+ * different matter — it means the value is not the secret anyone intended.
  *
  * @param context what to name in the error, e.g.
  *   `bearer-token-inject: rule for /mcp-server/`
@@ -35,11 +46,12 @@ export function sanitizeHeaderValue(raw: string, context: string): string {
   if (!value) {
     throw new Error(`${context}: token is empty (after trimming surrounding whitespace)`);
   }
-  if (hasControlCharacter(value)) {
+  if (hasUnsendableCharacter(value)) {
     throw new Error(
       `${context}: token contains a character that cannot appear in an HTTP ` +
-        "header value (a line break or control character). Check how the secret " +
-        "is mounted — surrounding whitespace is trimmed, embedded breaks are not.",
+        "header value (a line break, a control character, or a non-Latin-1 " +
+        "character such as a smart quote). Check how the secret is mounted — " +
+        "surrounding whitespace is trimmed, anything else is not.",
     );
   }
   return value;

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,5 +1,6 @@
 import type { Workflow } from "@/api/types.ts";
 import type { Violation } from "@/lint/rules/violation.ts";
+import type { HeaderClaim } from "./header-claims.ts";
 
 /** Where the pipeline is running. Middlewares can adapt to context. */
 export type PipelineMode = "proxy" | "apply" | "single";
@@ -226,22 +227,14 @@ export interface ClientMiddlewareContext {
 export interface ClientMiddleware {
   readonly name: string;
   /**
-   * Headers this middleware claims as the proxy's own, lowercase.
+   * Headers this middleware supplies, and on which paths. See `HeaderClaim`.
    *
-   * Declaring one means "the proxy supplies this header's value; whatever the
-   * caller sent for it is not the upstream's business". Two things read it:
-   * the registry rejects a chain where two middlewares claim the same header
-   * (which would make the outcome depend on chain order), and `forwardRequest`
-   * discards the caller's `Authorization` when — and only when — something in
-   * the chain has claimed the credential headers. A chain that claims none
-   * (say, `api-key-inject` alone) leaves the caller's headers alone, which is
-   * what a proxy fronting webhook nodes with header or basic auth needs.
-   *
-   * Path-scoped middlewares still claim: `bearer-token-inject` owns
-   * `Authorization` wherever its rules reach, and the caller's value must not
-   * survive on the paths it does not.
+   * A middleware that only reads, or that defers to a value the caller brought,
+   * claims nothing — a chain claiming no credential header leaves the caller's
+   * `Authorization` alone, which is what a proxy fronting webhook nodes with
+   * header or basic auth needs.
    */
-  readonly ownedHeaders?: readonly string[];
+  readonly headerClaims?: readonly HeaderClaim[];
   /**
    * Mutate `headers` in place. The proxy has already stripped hop-by-hop
    * headers, so callers can freely add/remove without re-checking that

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -226,6 +226,23 @@ export interface ClientMiddlewareContext {
 export interface ClientMiddleware {
   readonly name: string;
   /**
+   * Headers this middleware claims as the proxy's own, lowercase.
+   *
+   * Declaring one means "the proxy supplies this header's value; whatever the
+   * caller sent for it is not the upstream's business". Two things read it:
+   * the registry rejects a chain where two middlewares claim the same header
+   * (which would make the outcome depend on chain order), and `forwardRequest`
+   * discards the caller's `Authorization` when — and only when — something in
+   * the chain has claimed the credential headers. A chain that claims none
+   * (say, `api-key-inject` alone) leaves the caller's headers alone, which is
+   * what a proxy fronting webhook nodes with header or basic auth needs.
+   *
+   * Path-scoped middlewares still claim: `bearer-token-inject` owns
+   * `Authorization` wherever its rules reach, and the caller's value must not
+   * survive on the paths it does not.
+   */
+  readonly ownedHeaders?: readonly string[];
+  /**
    * Mutate `headers` in place. The proxy has already stripped hop-by-hop
    * headers, so callers can freely add/remove without re-checking that
    * surface.

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -9,10 +9,12 @@
  * recomputes it from the actual body, and so are the proxy's own control
  * headers (see `@/api/headers.ts`), which n8n has no use for.
  *
- * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) by default — the
- * client is expected to supply them and the upstream needs them to
- * authenticate. Client middlewares (see `ClientMiddleware`) can rewrite or
- * replace these after the strip step but before fetch.
+ * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) when forwarding
+ * transparently — the client is expected to supply them and the upstream needs
+ * them to authenticate. Once a client-middleware chain is configured, the
+ * client's `Authorization` is dropped instead (the proxy, not the caller, then
+ * holds upstream credentials); client middlewares (see `ClientMiddleware`) run
+ * after that and can set whatever the upstream expects.
  *
  * On the way back, `Content-Encoding` (and the now-stale `Content-Length`) are
  * dropped from the upstream response — see `normalizeResponseEncoding`.
@@ -124,6 +126,26 @@ export async function forwardRequest(
 
   const clientMiddlewares = options?.clientMiddlewares ?? [];
   if (clientMiddlewares.length > 0) {
+    // The client's `Authorization` addresses *this* hop, not the upstream, so
+    // it is dropped for the same reason hop-by-hop headers are — and before the
+    // pipeline, so a middleware that sets it still wins.
+    //
+    // Two reasons it must not travel on. It is a credential for reaching the
+    // proxy and stays replayable until it expires, so letting it land in the
+    // upstream's logs leaks the right to call this proxy. And where the proxy
+    // fronts an IAP-protected backend, the client's token carries a different
+    // `aud` than the backend's IAP expects, so forwarding it only produces
+    // audience-mismatch 401s at the second hop.
+    //
+    // Doing this here rather than inside a middleware keeps the outcome
+    // independent of chain order: middlewares only ever add.
+    //
+    // Scoped to "a chain is configured" on purpose. A proxy running no client
+    // middleware is a transparent forwarder whose callers may legitimately be
+    // authenticating to n8n itself (webhook nodes with header or basic auth,
+    // say); nothing in front of it consumed that header, so nothing here should
+    // discard it.
+    headers.delete("authorization");
     await runClientPipeline(clientMiddlewares, headers, {
       request: req,
       method: req.method,

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -9,12 +9,13 @@
  * recomputes it from the actual body, and so are the proxy's own control
  * headers (see `@/api/headers.ts`), which n8n has no use for.
  *
- * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) when forwarding
- * transparently — the client is expected to supply them and the upstream needs
- * them to authenticate. Once a client-middleware chain is configured, the
- * client's `Authorization` is dropped instead (the proxy, not the caller, then
- * holds upstream credentials); client middlewares (see `ClientMiddleware`) run
- * after that and can set whatever the upstream expects.
+ * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) by default — the
+ * client is expected to supply them and the upstream needs them to
+ * authenticate. The exception is a chain containing a middleware that claims
+ * the credential headers (see `ownedHeaders`): there the proxy holds the
+ * upstream credentials, so the client's `Authorization` is dropped before the
+ * chain runs. Client middlewares (see `ClientMiddleware`) execute after the
+ * strip step and before fetch.
  *
  * On the way back, `Content-Encoding` (and the now-stale `Content-Length`) are
  * dropped from the upstream response — see `normalizeResponseEncoding`.
@@ -98,6 +99,25 @@ function normalizeResponseEncoding(response: Response): Response {
   });
 }
 
+/**
+ * Headers that carry the credential for one hop of the chain. When a
+ * middleware claims either of them, the proxy — not the caller — is the one
+ * holding upstream credentials, and the caller's `Authorization` is dropped.
+ */
+const CREDENTIAL_HEADERS = new Set(["authorization", "proxy-authorization"]);
+
+/**
+ * Whether anything in the chain has claimed a credential header.
+ *
+ * A chain that claims none is a transparent forwarder as far as auth goes: its
+ * callers may legitimately be authenticating to n8n itself (webhook nodes using
+ * header or basic auth), nothing in front of them consumed that header, and
+ * discarding it would break them.
+ */
+function chainOwnsCredentials(chain: ClientMiddleware[]): boolean {
+  return chain.some((m) => m.ownedHeaders?.some((h) => CREDENTIAL_HEADERS.has(h.toLowerCase())));
+}
+
 export interface ForwardOptions {
   /** Total request timeout in milliseconds; 0 disables timeout. */
   timeoutMs?: number;
@@ -126,26 +146,22 @@ export async function forwardRequest(
 
   const clientMiddlewares = options?.clientMiddlewares ?? [];
   if (clientMiddlewares.length > 0) {
-    // The client's `Authorization` addresses *this* hop, not the upstream, so
-    // it is dropped for the same reason hop-by-hop headers are — and before the
-    // pipeline, so a middleware that sets it still wins.
-    //
-    // Two reasons it must not travel on. It is a credential for reaching the
-    // proxy and stays replayable until it expires, so letting it land in the
-    // upstream's logs leaks the right to call this proxy. And where the proxy
-    // fronts an IAP-protected backend, the client's token carries a different
-    // `aud` than the backend's IAP expects, so forwarding it only produces
-    // audience-mismatch 401s at the second hop.
-    //
-    // Doing this here rather than inside a middleware keeps the outcome
-    // independent of chain order: middlewares only ever add.
-    //
-    // Scoped to "a chain is configured" on purpose. A proxy running no client
-    // middleware is a transparent forwarder whose callers may legitimately be
-    // authenticating to n8n itself (webhook nodes with header or basic auth,
-    // say); nothing in front of it consumed that header, so nothing here should
-    // discard it.
-    headers.delete("authorization");
+    if (chainOwnsCredentials(clientMiddlewares)) {
+      // The client's `Authorization` addresses *this* hop, not the upstream, so
+      // it is dropped for the same reason hop-by-hop headers are — and before
+      // the pipeline, so a middleware that sets it still wins.
+      //
+      // Two reasons it must not travel on. It is a credential for reaching the
+      // proxy and stays replayable until it expires, so letting it land in the
+      // upstream's logs leaks the right to call this proxy. And where the proxy
+      // fronts an IAP-protected backend, the client's token carries a different
+      // `aud` than the backend's IAP expects, so forwarding it only produces
+      // audience-mismatch 401s at the second hop.
+      //
+      // Doing this here rather than inside a middleware keeps the outcome
+      // independent of chain order: middlewares only ever add.
+      headers.delete("authorization");
+    }
     await runClientPipeline(clientMiddlewares, headers, {
       request: req,
       method: req.method,

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -12,7 +12,7 @@
  * Preserves auth headers (`X-N8N-API-KEY`, `Authorization`) by default — the
  * client is expected to supply them and the upstream needs them to
  * authenticate. The exception is a chain containing a middleware that claims
- * the credential headers (see `ownedHeaders`): there the proxy holds the
+ * the credential headers (see `headerClaims`): there the proxy holds the
  * upstream credentials, so the client's `Authorization` is dropped before the
  * chain runs. Client middlewares (see `ClientMiddleware`) execute after the
  * strip step and before fetch.

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -22,6 +22,7 @@
  */
 import { BASE_UPDATED_AT_HEADER } from "@/api/headers.ts";
 import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import { claimCoversPath } from "@/middleware/header-claims.ts";
 import type { ClientMiddleware } from "@/middleware/types.ts";
 
 /**
@@ -107,15 +108,21 @@ function normalizeResponseEncoding(response: Response): Response {
 const CREDENTIAL_HEADERS = new Set(["authorization", "proxy-authorization"]);
 
 /**
- * Whether anything in the chain has claimed a credential header.
+ * Whether the chain supplies a credential header for this particular path.
  *
- * A chain that claims none is a transparent forwarder as far as auth goes: its
- * callers may legitimately be authenticating to n8n itself (webhook nodes using
- * header or basic auth), nothing in front of them consumed that header, and
- * discarding it would break them.
+ * Where nothing claims one, the proxy is a transparent forwarder as far as auth
+ * goes: the caller may legitimately be authenticating to n8n itself (webhook
+ * nodes using header or basic auth), nothing in front of it consumed that
+ * header, and discarding it would break the request. The check is per-path
+ * because claims are — a rule scoped to `/mcp-server/` says nothing about what
+ * should happen to `/webhook/`.
  */
-function chainOwnsCredentials(chain: ClientMiddleware[]): boolean {
-  return chain.some((m) => m.ownedHeaders?.some((h) => CREDENTIAL_HEADERS.has(h.toLowerCase())));
+function chainSuppliesCredentials(chain: ClientMiddleware[], pathname: string): boolean {
+  return chain.some((m) =>
+    m.headerClaims?.some(
+      (c) => CREDENTIAL_HEADERS.has(c.header.toLowerCase()) && claimCoversPath(c, pathname),
+    ),
+  );
 }
 
 export interface ForwardOptions {
@@ -146,7 +153,7 @@ export async function forwardRequest(
 
   const clientMiddlewares = options?.clientMiddlewares ?? [];
   if (clientMiddlewares.length > 0) {
-    if (chainOwnsCredentials(clientMiddlewares)) {
+    if (chainSuppliesCredentials(clientMiddlewares, incomingUrl.pathname)) {
       // The client's `Authorization` addresses *this* hop, not the upstream, so
       // it is dropped for the same reason hop-by-hop headers are — and before
       // the pipeline, so a middleware that sets it still wins.

--- a/tests/cli/proxy-client-middleware-flags.test.ts
+++ b/tests/cli/proxy-client-middleware-flags.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { Command } from "commander";
+import { extractClientMiddlewareCliOpts, registerProxyCommand } from "@/cli/commands/proxy.ts";
+
+/**
+ * A standing guard over the projection that carries client-middleware flags
+ * from commander into the factories.
+ *
+ * `extractClientMiddlewareCliOpts` copies an explicit allow-list, so declaring
+ * a `--<middleware>-<option>` flag and forgetting to add it there compiles,
+ * ships, and does nothing — the proxy silently runs on defaults, and the
+ * operator's evidence is a 401 somewhere far away. Rather than list the flags
+ * again here (a list that would drift the same way), this derives them from the
+ * command itself: every declared flag whose name belongs to a client middleware
+ * must survive the projection.
+ */
+
+/** Prefixes of the client middlewares registered in `client-wiring.ts`. */
+const CLIENT_MIDDLEWARE_FLAG_PREFIXES = [
+  "--iap-auth-",
+  "--api-key-inject-",
+  "--webhook-token-inject-",
+  "--bearer-token-inject-",
+  "--impersonator-token-",
+];
+
+function camelize(long: string): string {
+  return long.replace(/^--/, "").replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function declaredClientMiddlewareFlags(): string[] {
+  const program = new Command();
+  registerProxyCommand(program);
+  const proxy = program.commands.find((c) => c.name() === "proxy");
+  if (!proxy) throw new Error("proxy command was not registered");
+  return proxy.options
+    .map((o) => o.long ?? "")
+    .filter((long) => CLIENT_MIDDLEWARE_FLAG_PREFIXES.some((p) => long.startsWith(p)));
+}
+
+describe("proxy client-middleware flags", () => {
+  test("the command declares the flags this suite is meant to guard", () => {
+    // A sanity check on the derivation itself: if the prefixes ever stop
+    // matching, every other assertion here would pass vacuously.
+    const flags = declaredClientMiddlewareFlags();
+    expect(flags.length).toBeGreaterThan(10);
+    expect(flags).toContain("--iap-auth-header-name");
+    expect(flags).toContain("--bearer-token-inject-rules");
+  });
+
+  test("every declared client-middleware flag reaches the options bag", () => {
+    const flags = declaredClientMiddlewareFlags();
+    const opts = Object.fromEntries(flags.map((f) => [camelize(f), `value-for-${f}`]));
+
+    const forwarded = extractClientMiddlewareCliOpts(opts as never);
+
+    for (const flag of flags) {
+      expect(forwarded[camelize(flag)]).toBe(`value-for-${flag}`);
+    }
+  });
+
+  test("flags the user did not pass are left out entirely", () => {
+    expect(extractClientMiddlewareCliOpts({} as never)).toEqual({});
+  });
+});

--- a/tests/middleware/builtin/bearer-token-inject/middleware.test.ts
+++ b/tests/middleware/builtin/bearer-token-inject/middleware.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import {
+  bearerTokenInjectFactory,
+  resolveBearerTokenRules,
+} from "@/middleware/builtin/bearer-token-inject/factory.ts";
+import { BearerTokenInjectMiddleware } from "@/middleware/builtin/bearer-token-inject/middleware.ts";
+import type { ClientMiddlewareContext } from "@/middleware/types.ts";
+
+function ctx(pathname: string): ClientMiddlewareContext {
+  return {
+    request: new Request(`http://proxy.local${pathname}`),
+    method: "POST",
+    pathname,
+    upstreamUrl: `http://upstream.local${pathname}`,
+  };
+}
+
+const mcpRule = { pathPrefix: "/mcp-server/", token: "mcp-secret", scheme: "Bearer" };
+
+describe("BearerTokenInjectMiddleware", () => {
+  test("injects Authorization on a matching path", () => {
+    const mw = new BearerTokenInjectMiddleware({ rules: [mcpRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/mcp-server/http"));
+    expect(headers.get("authorization")).toBe("Bearer mcp-secret");
+  });
+
+  test("leaves a non-matching path completely untouched", () => {
+    const mw = new BearerTokenInjectMiddleware({ rules: [mcpRule] });
+    const headers = new Headers({ "x-n8n-api-key": "k" });
+    mw.apply(headers, ctx("/api/v1/workflows"));
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-n8n-api-key")).toBe("k");
+  });
+
+  test("the trailing slash keeps a sibling prefix out", () => {
+    const mw = new BearerTokenInjectMiddleware({ rules: [mcpRule] });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/mcp-server-admin/http"));
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  test("never touches Proxy-Authorization, which belongs to the gateway hop", () => {
+    const mw = new BearerTokenInjectMiddleware({ rules: [mcpRule] });
+    const headers = new Headers({ "proxy-authorization": "Bearer iap-token" });
+    mw.apply(headers, ctx("/mcp-server/http"));
+    expect(headers.get("proxy-authorization")).toBe("Bearer iap-token");
+    expect(headers.get("authorization")).toBe("Bearer mcp-secret");
+  });
+
+  test("the last matching rule wins", () => {
+    const mw = new BearerTokenInjectMiddleware({
+      rules: [
+        { pathPrefix: "/mcp-server/", token: "broad", scheme: "Bearer" },
+        { pathPrefix: "/mcp-server/http", token: "narrow", scheme: "Bearer" },
+      ],
+    });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/mcp-server/http"));
+    expect(headers.get("authorization")).toBe("Bearer narrow");
+  });
+
+  test("an empty scheme writes the raw value", () => {
+    const mw = new BearerTokenInjectMiddleware({
+      rules: [{ pathPrefix: "/mcp-server/", token: "raw-value", scheme: "" }],
+    });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/mcp-server/http"));
+    expect(headers.get("authorization")).toBe("raw-value");
+  });
+});
+
+describe("bearerTokenInjectFactory", () => {
+  test("rejects an empty rule set rather than injecting nothing silently", () => {
+    expect(() => bearerTokenInjectFactory.build({ rules: [] })).toThrow(/at least one rule/);
+  });
+
+  test("rejects a rule with both token and tokenEnvVar", () => {
+    expect(() =>
+      bearerTokenInjectFactory.build({
+        rules: [{ pathPrefix: "/mcp-server/", token: "a", tokenEnvVar: "B" }],
+      }),
+    ).toThrow(/exactly one of token \/ tokenEnvVar/);
+  });
+
+  test("rejects a rule with neither token nor tokenEnvVar", () => {
+    expect(() =>
+      bearerTokenInjectFactory.build({ rules: [{ pathPrefix: "/mcp-server/" }] }),
+    ).toThrow(/exactly one of token \/ tokenEnvVar/);
+  });
+
+  test("rejects a pathPrefix that is not a path", () => {
+    expect(() =>
+      bearerTokenInjectFactory.build({ rules: [{ pathPrefix: "mcp-server", token: "a" }] }),
+    ).toThrow(/must start with/);
+  });
+
+  test("scheme defaults to Bearer", () => {
+    const mw = bearerTokenInjectFactory.build({
+      rules: [{ pathPrefix: "/mcp-server/", token: "t" }],
+    });
+    const headers = new Headers();
+    mw.apply(headers, ctx("/mcp-server/http"));
+    expect(headers.get("authorization")).toBe("Bearer t");
+  });
+
+  test("loadFromEnv parses the rule JSON", () => {
+    const partial = bearerTokenInjectFactory.loadFromEnv({
+      N8N_BEARER_TOKEN_INJECT_RULES: '[{"pathPrefix":"/mcp-server/","tokenEnvVar":"MCP_TOKEN"}]',
+    });
+    expect(partial.rules).toHaveLength(1);
+    expect(partial.rules?.[0]?.pathPrefix).toBe("/mcp-server/");
+  });
+
+  test("loadFromEnv reports malformed JSON against the env var name", () => {
+    expect(() =>
+      bearerTokenInjectFactory.loadFromEnv({ N8N_BEARER_TOKEN_INJECT_RULES: "{not json" }),
+    ).toThrow(/N8N_BEARER_TOKEN_INJECT_RULES is not valid JSON/);
+  });
+
+  test("loadFromEnv rejects a non-array payload", () => {
+    expect(() =>
+      bearerTokenInjectFactory.loadFromEnv({ N8N_BEARER_TOKEN_INJECT_RULES: '{"a":1}' }),
+    ).toThrow(/must be a JSON array/);
+  });
+
+  test("loadFromCLI parses the rule JSON", () => {
+    const partial = bearerTokenInjectFactory.loadFromCLI({
+      bearerTokenInjectRules: '[{"pathPrefix":"/mcp-server/","token":"t"}]',
+    });
+    expect(partial.rules).toHaveLength(1);
+  });
+
+  test("resolveBearerTokenRules reads the token out of the environment", () => {
+    const resolved = resolveBearerTokenRules(
+      [{ pathPrefix: "/mcp-server/", tokenEnvVar: "MCP_TOKEN", scheme: "Bearer" }],
+      { MCP_TOKEN: "from-env" },
+    );
+    expect(resolved[0]?.token).toBe("from-env");
+  });
+
+  test("an unset tokenEnvVar fails loudly instead of injecting nothing", () => {
+    expect(() =>
+      resolveBearerTokenRules(
+        [{ pathPrefix: "/mcp-server/", tokenEnvVar: "MISSING_TOKEN", scheme: "Bearer" }],
+        {},
+      ),
+    ).toThrow(/MISSING_TOKEN.*unset or empty/);
+  });
+});

--- a/tests/middleware/builtin/bearer-token-inject/middleware.test.ts
+++ b/tests/middleware/builtin/bearer-token-inject/middleware.test.ts
@@ -139,6 +139,23 @@ describe("bearerTokenInjectFactory", () => {
     expect(resolved[0]?.token).toBe("from-env");
   });
 
+  test("a secret mounted with a trailing newline is trimmed, not left to 502", () => {
+    const resolved = resolveBearerTokenRules(
+      [{ pathPrefix: "/mcp-server/", tokenEnvVar: "MCP_TOKEN", scheme: "Bearer" }],
+      { MCP_TOKEN: "from-file\n" },
+    );
+    expect(resolved[0]?.token).toBe("from-file");
+  });
+
+  test("a token carrying a line break fails at startup", () => {
+    expect(() =>
+      resolveBearerTokenRules(
+        [{ pathPrefix: "/mcp-server/", tokenEnvVar: "MCP_TOKEN", scheme: "Bearer" }],
+        { MCP_TOKEN: "abc\ndef" },
+      ),
+    ).toThrow(/rule for \/mcp-server\/: token contains a character/);
+  });
+
   test("an unset tokenEnvVar fails loudly instead of injecting nothing", () => {
     expect(() =>
       resolveBearerTokenRules(

--- a/tests/middleware/builtin/iap-auth/middleware.test.ts
+++ b/tests/middleware/builtin/iap-auth/middleware.test.ts
@@ -21,7 +21,7 @@ describe("IapAuthMiddleware", () => {
     expect(headers.get("authorization")).toBe("Bearer tok-1");
   });
 
-  test("replaces an incoming Authorization header (the IAP#1 audience would mismatch IAP#2)", async () => {
+  test("overwrites whatever Authorization already held (default header mode)", async () => {
     const mw = new IapAuthMiddleware({
       audience: "aud",
       tokenSource: new StaticTokenSource("fresh-token"),
@@ -46,6 +46,31 @@ describe("IapAuthMiddleware", () => {
     const mw = new IapAuthMiddleware({ audience: "https://example.com/iap", tokenSource: src });
     await mw.apply(new Headers(), baseCtx);
     expect(seenAud).toBe("https://example.com/iap");
+  });
+
+  test("headerName=proxy-authorization writes there and leaves Authorization alone", async () => {
+    const mw = new IapAuthMiddleware({
+      audience: "aud",
+      tokenSource: new StaticTokenSource("iap-token"),
+      headerName: "proxy-authorization",
+    });
+    // An application-layer token another middleware already placed. IAP reads
+    // Proxy-Authorization and forwards this one to the backend unread.
+    const headers = new Headers({ authorization: "Bearer app-layer-token" });
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("proxy-authorization")).toBe("Bearer iap-token");
+    expect(headers.get("authorization")).toBe("Bearer app-layer-token");
+  });
+
+  test("the default mode leaves Proxy-Authorization alone (regression)", async () => {
+    const mw = new IapAuthMiddleware({
+      audience: "aud",
+      tokenSource: new StaticTokenSource("iap-token"),
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer iap-token");
+    expect(headers.get("proxy-authorization")).toBeNull();
   });
 
   test("propagates token-source errors", async () => {
@@ -103,6 +128,56 @@ describe("iapAuthFactory", () => {
     const headers = new Headers();
     await mw.apply(headers, baseCtx);
     expect(headers.get("authorization")).toBe("Bearer fixed-token");
+  });
+
+  test("headerName defaults to authorization when nothing configures it", async () => {
+    const mw = iapAuthFactory.build({
+      audience: "a",
+      tokenSourceKind: "static",
+      staticToken: "t",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("authorization")).toBe("Bearer t");
+    expect(headers.get("proxy-authorization")).toBeNull();
+  });
+
+  test("headerName comes through env, case-insensitively", async () => {
+    const partial = iapAuthFactory.loadFromEnv({
+      N8N_IAP_AUTH_AUDIENCE: "a",
+      N8N_IAP_AUTH_HEADER_NAME: "Proxy-Authorization",
+    });
+    expect(partial.headerName).toBe("proxy-authorization");
+    const mw = iapAuthFactory.build({
+      ...partial,
+      tokenSourceKind: "static",
+      staticToken: "t",
+    });
+    const headers = new Headers();
+    await mw.apply(headers, baseCtx);
+    expect(headers.get("proxy-authorization")).toBe("Bearer t");
+  });
+
+  test("headerName comes through the CLI", () => {
+    const partial = iapAuthFactory.loadFromCLI({
+      iapAuthAudience: "a",
+      iapAuthHeaderName: "proxy-authorization",
+    });
+    expect(partial.headerName).toBe("proxy-authorization");
+  });
+
+  test("rejects a header name that is neither of the two supported ones", () => {
+    expect(
+      () =>
+        iapAuthFactory.build({
+          audience: "a",
+          tokenSourceKind: "static",
+          staticToken: "t",
+          headerName: "x-custom-auth",
+        }),
+      // The message names the setting, so an operator flipping this one env var
+      // learns what to fix without reading the source.
+    ).toThrow(/headerName must be authorization or proxy-authorization/);
   });
 
   test("loadFromEnv picks up impersonation settings", () => {

--- a/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
+++ b/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
@@ -29,6 +29,30 @@ const testRule = {
   conflictPolicy: "set-if-absent" as const,
 };
 
+describe("WebhookTokenInjectMiddleware ownedHeaders", () => {
+  test("a replace rule claims its header, so a second writer is detectable", () => {
+    const mw = new WebhookTokenInjectMiddleware({
+      rules: [{ ...agentRule, header: "Authorization", conflictPolicy: "replace" }],
+    });
+    expect(mw.ownedHeaders).toEqual(["authorization"]);
+  });
+
+  test("a set-if-absent rule claims nothing — it defers to the caller by design", () => {
+    const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule, testRule] });
+    expect(mw.ownedHeaders).toEqual([]);
+  });
+
+  test("two replace rules on one header claim it once", () => {
+    const mw = new WebhookTokenInjectMiddleware({
+      rules: [
+        { ...agentRule, conflictPolicy: "replace" },
+        { ...agentRule, pathPrefix: "/webhook/agent/sub/", conflictPolicy: "replace" },
+      ],
+    });
+    expect(mw.ownedHeaders).toEqual(["x-agent-token"]);
+  });
+});
+
 describe("WebhookTokenInjectMiddleware", () => {
   test("injects the token on a path under the rule's prefix", () => {
     const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule] });

--- a/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
+++ b/tests/middleware/builtin/webhook-token-inject/middleware.test.ts
@@ -29,27 +29,17 @@ const testRule = {
   conflictPolicy: "set-if-absent" as const,
 };
 
-describe("WebhookTokenInjectMiddleware ownedHeaders", () => {
-  test("a replace rule claims its header, so a second writer is detectable", () => {
+describe("WebhookTokenInjectMiddleware headerClaims", () => {
+  test("a replace rule claims its header over its own prefix only", () => {
     const mw = new WebhookTokenInjectMiddleware({
       rules: [{ ...agentRule, header: "Authorization", conflictPolicy: "replace" }],
     });
-    expect(mw.ownedHeaders).toEqual(["authorization"]);
+    expect(mw.headerClaims).toEqual([{ header: "Authorization", pathPrefix: "/webhook/agent/" }]);
   });
 
   test("a set-if-absent rule claims nothing — it defers to the caller by design", () => {
     const mw = new WebhookTokenInjectMiddleware({ rules: [agentRule, testRule] });
-    expect(mw.ownedHeaders).toEqual([]);
-  });
-
-  test("two replace rules on one header claim it once", () => {
-    const mw = new WebhookTokenInjectMiddleware({
-      rules: [
-        { ...agentRule, conflictPolicy: "replace" },
-        { ...agentRule, pathPrefix: "/webhook/agent/sub/", conflictPolicy: "replace" },
-      ],
-    });
-    expect(mw.ownedHeaders).toEqual(["x-agent-token"]);
+    expect(mw.headerClaims).toEqual([]);
   });
 });
 

--- a/tests/middleware/client-registry.test.ts
+++ b/tests/middleware/client-registry.test.ts
@@ -90,6 +90,32 @@ describe("buildClientMiddlewares", () => {
     });
   });
 
+  test("two middlewares claiming one header are refused, naming both", () => {
+    const owner = (name: string, header: string): ClientMiddlewareFactory<FakeOptions> => ({
+      name,
+      loadFromEnv: () => ({}),
+      loadFromCLI: () => ({}),
+      build: () => ({ name, ownedHeaders: [header], apply: () => {} }),
+    });
+    registerClientFactory(owner("first", "Authorization"));
+    registerClientFactory(owner("second", "authorization"));
+    expect(() => buildClientMiddlewares({ enabled: ["first", "second"] })).toThrow(
+      /"first" and "second" both write the "authorization" header/,
+    );
+  });
+
+  test("claims on different headers coexist", () => {
+    const owner = (name: string, header: string): ClientMiddlewareFactory<FakeOptions> => ({
+      name,
+      loadFromEnv: () => ({}),
+      loadFromCLI: () => ({}),
+      build: () => ({ name, ownedHeaders: [header], apply: () => {} }),
+    });
+    registerClientFactory(owner("gate", "proxy-authorization"));
+    registerClientFactory(owner("app", "authorization"));
+    expect(buildClientMiddlewares({ enabled: ["gate", "app"] })).toHaveLength(2);
+  });
+
   test("preserves middleware order", () => {
     registerClientFactory(fakeFactory("a"));
     registerClientFactory(fakeFactory("b"));

--- a/tests/middleware/client-registry.test.ts
+++ b/tests/middleware/client-registry.test.ts
@@ -90,30 +90,51 @@ describe("buildClientMiddlewares", () => {
     });
   });
 
+  const claimer = (
+    name: string,
+    header: string,
+    pathPrefix?: string,
+  ): ClientMiddlewareFactory<FakeOptions> => ({
+    name,
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: () => ({ name, headerClaims: [{ header, pathPrefix }], apply: () => {} }),
+  });
+
   test("two middlewares claiming one header are refused, naming both", () => {
-    const owner = (name: string, header: string): ClientMiddlewareFactory<FakeOptions> => ({
-      name,
-      loadFromEnv: () => ({}),
-      loadFromCLI: () => ({}),
-      build: () => ({ name, ownedHeaders: [header], apply: () => {} }),
-    });
-    registerClientFactory(owner("first", "Authorization"));
-    registerClientFactory(owner("second", "authorization"));
+    registerClientFactory(claimer("first", "Authorization"));
+    registerClientFactory(claimer("second", "authorization"));
     expect(() => buildClientMiddlewares({ enabled: ["first", "second"] })).toThrow(
       /"first" and "second" both write the "authorization" header/,
     );
   });
 
   test("claims on different headers coexist", () => {
-    const owner = (name: string, header: string): ClientMiddlewareFactory<FakeOptions> => ({
-      name,
-      loadFromEnv: () => ({}),
-      loadFromCLI: () => ({}),
-      build: () => ({ name, ownedHeaders: [header], apply: () => {} }),
-    });
-    registerClientFactory(owner("gate", "proxy-authorization"));
-    registerClientFactory(owner("app", "authorization"));
+    registerClientFactory(claimer("gate", "proxy-authorization"));
+    registerClientFactory(claimer("app", "authorization"));
     expect(buildClientMiddlewares({ enabled: ["gate", "app"] })).toHaveLength(2);
+  });
+
+  test("one header claimed over disjoint prefixes is allowed", () => {
+    registerClientFactory(claimer("hooks", "authorization", "/webhook/a/"));
+    registerClientFactory(claimer("mcp", "authorization", "/mcp-server/"));
+    expect(buildClientMiddlewares({ enabled: ["hooks", "mcp"] })).toHaveLength(2);
+  });
+
+  test("a nested prefix still collides, and the message says where", () => {
+    registerClientFactory(claimer("broad", "authorization", "/webhook/"));
+    registerClientFactory(claimer("narrow", "authorization", "/webhook/a/"));
+    expect(() => buildClientMiddlewares({ enabled: ["broad", "narrow"] })).toThrow(
+      /both write the "authorization" header on paths under "\/webhook\/a\/"/,
+    );
+  });
+
+  test("an unscoped claim collides with every scoped one", () => {
+    registerClientFactory(claimer("everywhere", "authorization"));
+    registerClientFactory(claimer("scoped", "authorization", "/mcp-server/"));
+    expect(() => buildClientMiddlewares({ enabled: ["everywhere", "scoped"] })).toThrow(
+      /both write the "authorization" header/,
+    );
   });
 
   test("preserves middleware order", () => {

--- a/tests/middleware/header-value.test.ts
+++ b/tests/middleware/header-value.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeHeaderValue } from "@/middleware/header-value.ts";
+
+describe("sanitizeHeaderValue", () => {
+  test("passes an ordinary token through untouched", () => {
+    expect(sanitizeHeaderValue("n8n_api_abc123", "ctx")).toBe("n8n_api_abc123");
+  });
+
+  test("trims the trailing newline a file-mounted secret arrives with", () => {
+    // Left to reach `Headers.set`, this becomes a 502 on every matching request
+    // with the real cause nowhere in sight.
+    expect(sanitizeHeaderValue("token-value\n", "ctx")).toBe("token-value");
+    expect(sanitizeHeaderValue("  token-value\r\n", "ctx")).toBe("token-value");
+  });
+
+  test("rejects an embedded line break, naming the context", () => {
+    expect(() =>
+      sanitizeHeaderValue("good\nX-Evil: yes", "bearer-token-inject: rule for /a/"),
+    ).toThrow(/bearer-token-inject: rule for \/a\/: token contains a character/);
+  });
+
+  test("rejects other control characters", () => {
+    expect(() => sanitizeHeaderValue(`tok${String.fromCharCode(0)}en`, "ctx")).toThrow(
+      /cannot appear in an HTTP/,
+    );
+  });
+
+  test("keeps interior spaces — scheme-and-value is a legal header", () => {
+    expect(sanitizeHeaderValue("Basic dXNlcjpwYXNz", "ctx")).toBe("Basic dXNlcjpwYXNz");
+  });
+
+  test("rejects a value that is nothing but whitespace", () => {
+    expect(() => sanitizeHeaderValue("   \n", "ctx")).toThrow(/token is empty/);
+  });
+});

--- a/tests/middleware/header-value.test.ts
+++ b/tests/middleware/header-value.test.ts
@@ -25,6 +25,13 @@ describe("sanitizeHeaderValue", () => {
     );
   });
 
+  test("rejects a non-Latin-1 character, which is what Headers.set actually refuses", () => {
+    // The failure mode a trailing newline does *not* produce: Bun trims that,
+    // but a smart quote pasted into a secret makes every request throw.
+    expect(() => sanitizeHeaderValue("Bearer “token”", "ctx")).toThrow(/smart quote/);
+    expect(() => sanitizeHeaderValue("トークン", "ctx")).toThrow(/cannot appear in an HTTP/);
+  });
+
   test("keeps interior spaces — scheme-and-value is a legal header", () => {
     expect(sanitizeHeaderValue("Basic dXNlcjpwYXNz", "ctx")).toBe("Basic dXNlcjpwYXNz");
   });

--- a/tests/proxy/proxy.mcp-passthrough.test.ts
+++ b/tests/proxy/proxy.mcp-passthrough.test.ts
@@ -170,8 +170,9 @@ describe("proxy: MCP header split", () => {
   });
 });
 
-describe("proxy: transparent forwarding without a client-middleware chain", () => {
-  test("keeps the caller's Authorization — nothing in front of it consumed one", async () => {
+describe("proxy: chains that claim no credential header", () => {
+  function startWithout(chain: string[]): void {
+    registerClientFactory(apiKeyInjectFactory);
     proxy = startProxy({
       listen: "127.0.0.1:0",
       upstream: `http://127.0.0.1:${upstream.port}`,
@@ -179,13 +180,58 @@ describe("proxy: transparent forwarding without a client-middleware chain", () =
       disableRules: [],
       logFormat: "json",
       allowDuplicates: true,
-      clientMiddlewares: [],
+      clientMiddlewares: chain,
+      clientMiddlewareCliOptions: { apiKeyInjectKeyEnvVar: "TEST_N8N_API_KEY" },
     });
+  }
+
+  test("no chain at all keeps the caller's Authorization", async () => {
+    startWithout([]);
     await fetch(`http://127.0.0.1:${proxy.port}/webhook/basic-auth-node`, {
       method: "POST",
       headers: { authorization: "Basic dXNlcjpwYXNz" },
       body: "{}",
     });
     expect(upstream.captured[0]!.headers.authorization).toBe("Basic dXNlcjpwYXNz");
+  });
+
+  test("api-key-inject alone keeps it too — it never claimed that header", async () => {
+    // Regression guard for deployments that proxy webhook URLs whose nodes use
+    // header or basic auth: dropping Authorization for them would turn every
+    // such webhook into a 401 on upgrade.
+    startWithout(["api-key-inject"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/basic-auth-node`, {
+      method: "POST",
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+      body: "{}",
+    });
+    const cap = upstream.captured[0]!;
+    expect(cap.headers.authorization).toBe("Basic dXNlcjpwYXNz");
+    expect(cap.headers["x-n8n-api-key"]).toBe("api-key-value");
+  });
+});
+
+describe("proxy: chains that would fight over one header", () => {
+  test("iap-auth in its default mode plus bearer-token-inject is refused at startup", () => {
+    registerClientFactory(iapAuthFactory);
+    registerClientFactory(bearerTokenInjectFactory);
+    expect(() =>
+      startProxy({
+        listen: "127.0.0.1:0",
+        upstream: `http://127.0.0.1:${upstream.port}`,
+        enforce: "off",
+        disableRules: [],
+        logFormat: "json",
+        allowDuplicates: true,
+        clientMiddlewares: ["bearer-token-inject", "iap-auth"],
+        clientMiddlewareCliOptions: {
+          iapAuthAudience: "https://example.com/gateway",
+          iapAuthTokenSource: "env",
+          iapAuthTokenEnvVar: "TEST_IAP_ID_TOKEN",
+          // headerName left at its default, so both want `authorization`.
+          bearerTokenInjectRules: MCP_RULES,
+        },
+      }),
+    ).toThrow(/both write the "authorization" header/);
   });
 });

--- a/tests/proxy/proxy.mcp-passthrough.test.ts
+++ b/tests/proxy/proxy.mcp-passthrough.test.ts
@@ -195,6 +195,37 @@ describe("proxy: chains that claim no credential header", () => {
     expect(upstream.captured[0]!.headers.authorization).toBe("Basic dXNlcjpwYXNz");
   });
 
+  test("a path-scoped claim leaves Authorization alone off its own paths", async () => {
+    // bearer-token-inject claims `/mcp-server/` and nothing else. A webhook node
+    // authenticating on Authorization lives outside that scope, and the proxy
+    // supplies nothing there, so the caller's credential has to survive.
+    registerClientFactory(bearerTokenInjectFactory);
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: ["bearer-token-inject"],
+      clientMiddlewareCliOptions: { bearerTokenInjectRules: MCP_RULES },
+    });
+
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/basic-auth-node`, {
+      method: "POST",
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+      body: "{}",
+    });
+    expect(upstream.captured[0]!.headers.authorization).toBe("Basic dXNlcjpwYXNz");
+
+    await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
+      method: "POST",
+      headers: { authorization: "Bearer caller-token-for-this-hop" },
+      body: "{}",
+    });
+    expect(upstream.captured[1]!.headers.authorization).toBe("Bearer mcp-secret");
+  });
+
   test("api-key-inject alone keeps it too — it never claimed that header", async () => {
     // Regression guard for deployments that proxy webhook URLs whose nodes use
     // header or basic auth: dropping Authorization for them would turn every

--- a/tests/proxy/proxy.mcp-passthrough.test.ts
+++ b/tests/proxy/proxy.mcp-passthrough.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { apiKeyInjectFactory } from "@/middleware/builtin/api-key-inject/factory.ts";
+import { bearerTokenInjectFactory } from "@/middleware/builtin/bearer-token-inject/factory.ts";
+import { iapAuthFactory } from "@/middleware/builtin/iap-auth/factory.ts";
+import { registerClientFactory, resetClientRegistry } from "@/middleware/client-registry.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+/**
+ * End-to-end cover for the header split that lets an application-layer bearer
+ * token survive a gateway that authenticates with `Authorization` itself.
+ *
+ * The gateway (Google IAP) accepts its id_token in `Proxy-Authorization` and
+ * then forwards `Authorization` to the backend unread, so:
+ *   Proxy-Authorization → gateway,  Authorization → the application.
+ *
+ * These tests assert the shape of the request that leaves the proxy — including
+ * that a token the *caller* put in `Authorization` never reaches the upstream,
+ * whatever order the chain is configured in.
+ */
+
+interface Captured {
+  pathname: string;
+  headers: Record<string, string>;
+}
+
+function startMockUpstream(): {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: Captured[];
+} {
+  const captured: Captured[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ pathname: url.pathname, headers });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { server, port: server.port!, captured };
+}
+
+const MCP_RULES = JSON.stringify([{ pathPrefix: "/mcp-server/", token: "mcp-secret" }]);
+
+let upstream: ReturnType<typeof startMockUpstream>;
+let proxy: ProxyHandle;
+
+function start(chain: string[]): void {
+  registerClientFactory(iapAuthFactory);
+  registerClientFactory(apiKeyInjectFactory);
+  registerClientFactory(bearerTokenInjectFactory);
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    clientMiddlewares: chain,
+    clientMiddlewareCliOptions: {
+      iapAuthAudience: "https://example.com/gateway",
+      iapAuthTokenSource: "env",
+      iapAuthTokenEnvVar: "TEST_IAP_ID_TOKEN",
+      iapAuthHeaderName: "proxy-authorization",
+      apiKeyInjectKeyEnvVar: "TEST_N8N_API_KEY",
+      bearerTokenInjectRules: MCP_RULES,
+    },
+  });
+}
+
+beforeEach(() => {
+  resetClientRegistry();
+  upstream = startMockUpstream();
+  process.env.TEST_N8N_API_KEY = "api-key-value";
+  process.env.TEST_IAP_ID_TOKEN = "iap-id-token";
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  await upstream.server.stop(true);
+  resetClientRegistry();
+  delete process.env.TEST_N8N_API_KEY;
+  delete process.env.TEST_IAP_ID_TOKEN;
+});
+
+describe("proxy: MCP header split", () => {
+  test("an MCP call arrives with the gateway token and the app token on separate headers", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(200);
+    const cap = upstream.captured[0]!;
+    expect(cap.pathname).toBe("/mcp-server/http");
+    expect(cap.headers.authorization).toBe("Bearer mcp-secret");
+    expect(cap.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+  });
+
+  test("the chain order does not change the result", async () => {
+    start(["bearer-token-inject", "api-key-inject", "iap-auth"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
+      method: "POST",
+      body: "{}",
+    });
+    const cap = upstream.captured[0]!;
+    expect(cap.headers.authorization).toBe("Bearer mcp-secret");
+    expect(cap.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+  });
+
+  test("a token the caller brought in Authorization never reaches the upstream", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
+      method: "POST",
+      headers: { authorization: "Bearer caller-token-for-this-hop" },
+      body: "{}",
+    });
+    expect(upstream.captured[0]!.headers.authorization).toBe("Bearer mcp-secret");
+  });
+
+  test("a caller's Authorization is dropped even on paths no injection rule covers", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, {
+      method: "GET",
+      headers: { authorization: "Bearer caller-token-for-this-hop" },
+    });
+    const cap = upstream.captured[0]!;
+    // Nothing set it on this path, and the caller's value was discarded.
+    expect(cap.headers.authorization).toBeUndefined();
+    expect(cap.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+    expect(cap.headers["x-n8n-api-key"]).toBe("api-key-value");
+  });
+
+  test("a Proxy-Authorization the caller brought is stripped, not forwarded", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
+      method: "POST",
+      headers: { "proxy-authorization": "Bearer smuggled-gateway-token" },
+      body: "{}",
+    });
+    // Hop-by-hop strip runs before the pipeline, so only the proxy's own token
+    // survives — a caller cannot ride its own credential past the gateway.
+    expect(upstream.captured[0]!.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+  });
+
+  test("the REST API surface still works while the split is on", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`, { method: "GET" });
+    expect(res.status).toBe(200);
+    const cap = upstream.captured[0]!;
+    // The public API authenticates on X-N8N-API-KEY and never reads
+    // Authorization, so freeing that header up costs it nothing.
+    expect(cap.headers["x-n8n-api-key"]).toBe("api-key-value");
+    expect(cap.headers.authorization).toBeUndefined();
+  });
+
+  test("the MCP token stays off every other path", async () => {
+    start(["iap-auth", "api-key-inject", "bearer-token-inject"]);
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/anything`, { method: "POST", body: "{}" });
+    expect(upstream.captured[0]!.headers.authorization).toBeUndefined();
+  });
+});
+
+describe("proxy: transparent forwarding without a client-middleware chain", () => {
+  test("keeps the caller's Authorization — nothing in front of it consumed one", async () => {
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      clientMiddlewares: [],
+    });
+    await fetch(`http://127.0.0.1:${proxy.port}/webhook/basic-auth-node`, {
+      method: "POST",
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+      body: "{}",
+    });
+    expect(upstream.captured[0]!.headers.authorization).toBe("Basic dXNlcjpwYXNz");
+  });
+});


### PR DESCRIPTION
## What

n8n's instance-level MCP server (`POST /mcp-server/http`) authenticates with
`Authorization: Bearer <token>`. Behind Google IAP that header is already taken —
IAP authenticates with `Authorization`, consumes it, and never passes it to the
backend, so the application answers:

```
HTTP/2 401
www-authenticate: Bearer realm="n8n MCP Server"
{"message":"Unauthorized: Authorization header not sent"}
```

IAP documents the way out: a valid id_token in `Proxy-Authorization` authorizes
the request, and `Authorization` is then forwarded to the backend unread
([docs](https://docs.cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header)).
This PR makes the proxy able to use that split.

| Header | Carries | Consumed by |
| --- | --- | --- |
| `Proxy-Authorization` | the gateway id_token | IAP |
| `Authorization` | the application token | n8n |

## Changes

- **`iap-auth` gains `headerName`** — `authorization` (default, unchanged) or
  `proxy-authorization`. Env `N8N_IAP_AUTH_HEADER_NAME`, CLI
  `--iap-auth-header-name`. Deployment-wide rather than path-scoped: the public
  API authenticates on `X-N8N-API-KEY` and never reads `Authorization`, so
  freeing that header up costs it nothing, and one setting is easier to reason
  about — and to revert — than a per-path rule.
- **New `bearer-token-inject` client middleware** — puts a path-scoped
  application token in `Authorization`, following `webhook-token-inject`'s
  design (`tokenEnvVar` preferred over a literal, unresolvable references fail
  at startup). Paths no rule covers get nothing. Env
  `N8N_BEARER_TOKEN_INJECT_RULES`, CLI `--bearer-token-inject-rules`.
- **The caller's `Authorization` is stripped outside the pipeline.** It used to
  be `iap-auth` that dropped it; with `iap-auth` writing elsewhere that drop
  would have vanished and the caller's token would have travelled to n8n. It is
  a credential for the *proxy* hop, replayable until it expires, so it must not
  land in the upstream's logs — and behind a second IAP it would carry the wrong
  `aud` anyway. Moving it out of the pipeline also makes the outcome independent
  of chain order: middlewares now only ever add.
- **Middlewares declare the headers they supply, and on which paths**
  (`headerClaims`, `src/middleware/header-claims.ts`). Two uses. The strip above
  happens only where the chain actually supplies a credential header for the
  request at hand, so a chain that claims none (`api-key-inject` alone) — or a
  path outside a scoped rule's reach — keeps forwarding `Authorization` exactly
  as before. And the registry refuses a chain where two middlewares claim one
  header on prefixes that can overlap, turning "`iap-auth` in its default mode
  alongside `bearer-token-inject`" from a runtime 401 decided by declaration
  order into a startup error naming both; disjoint prefixes are left alone.
- **Secrets are validated when they are resolved, not when they are sent.** A
  token mounted from a file carries a trailing newline, `Headers.set` rejects
  it, and every matching request became a 502 whose message named nothing
  useful. Surrounding whitespace is now trimmed and embedded control characters
  fail at startup, for `bearer-token-inject`, `webhook-token-inject` and
  `api-key-inject` alike.
- `Proxy-Authorization` stays on the hop-by-hop strip list, so a caller cannot
  smuggle its own gateway token through.
- README section explaining the split with the IAP doc as the source, plus the
  env/CLI names a deployment needs.
- Version 2.10.1 → 2.11.0.

### Backward compatibility

Default behavior is byte-for-byte unchanged: `iap-auth` still writes
`Authorization` unless told otherwise, and the switch reverts by unsetting one
env var. Anything that claims no credential header for a given request — a
chain of `api-key-inject` alone, no chain at all, a path outside a scoped rule
— keeps forwarding the caller's `Authorization`, so transparent setups whose
webhook nodes use header or basic auth are unaffected. The drop applies exactly
where the proxy has declared itself the holder of that header, which for an
`iap-auth` chain is the same set of requests as before this PR.

**One upgrade note for the release.** The startup conflict check can refuse a
chain that boots today: `iap-auth` in its default mode alongside either a
`webhook-token-inject` rule writing `Authorization` with
`conflictPolicy: replace`, or `api-key-inject` pointed at `Authorization`. Those
configurations were already broken — the two writers clobbered each other and
the loser's absence showed up as a 401 from whichever service wanted it — but
the symptom moves from a runtime 401 to a proxy that will not start. The fix is
in the error message: give the two different headers (typically
`N8N_IAP_AUTH_HEADER_NAME=proxy-authorization`), scope them to non-overlapping
paths, or drop one.

## Security note

`/mcp-server/` is transparently forwarded and so never passes through the
server-middleware chain, and unlike a webhook token the credential being
attached there is a general-purpose instance credential. The README says
explicitly that this setup assumes an authenticating ingress (IAP or
equivalent) in front of the proxy.

## Tests

`tests/middleware/builtin/bearer-token-inject/middleware.test.ts` (new),
`tests/proxy/proxy.mcp-passthrough.test.ts` (new), and additions to
`tests/middleware/builtin/iap-auth/middleware.test.ts`:

- `proxy-authorization` mode writes there and leaves `Authorization` alone;
  default mode writes `Authorization` and leaves `Proxy-Authorization` alone
  (regression)
- `headerName` resolves from env (case-insensitively) and CLI; an unsupported
  value is rejected with a message naming the setting
- `bearer-token-inject` touches nothing outside its prefix, trailing-slash
  scoping, last-matching-rule-wins, `tokenEnvVar` resolution and its
  fail-loudly-when-unset behavior, malformed/non-array rule JSON
- end-to-end: both headers arrive correctly on `/mcp-server/http`, **with the
  same result when the chain order is reversed**
- end-to-end: a caller-supplied `Authorization` never reaches the upstream, on
  covered and uncovered paths alike
- end-to-end: a caller-supplied `Proxy-Authorization` is stripped, not forwarded
- end-to-end: the REST API surface still authenticates on `X-N8N-API-KEY` while
  the split is on
- end-to-end: a proxy with no client-middleware chain — and one running
  `api-key-inject` alone — still forwards `Authorization` untouched
- a chain whose middlewares fight over one header is refused at startup, naming
  both and saying where; different headers, and one header over disjoint
  prefixes, coexist; a nested prefix still collides
- a path-scoped claim leaves `Authorization` alone off its own paths
- `headerClaims` reflects `replace` rules only, scoped to their own prefix
- a trailing newline on a mounted secret is trimmed; an embedded line break
  fails at startup instead of 502ing every request
- **a guard over the CLI→factory projection**: the flag list is derived from the
  command itself, so a newly declared client-middleware flag that is not
  forwarded fails the suite instead of silently doing nothing

## Quality gates

`make quality-gate` (generate-schemas / typecheck / lint / third-party-licenses
/ test) green — 1401 pass, 0 fail. `make build` + `make size-check` green.

## Not verified here

Whether IAP accepts `Proxy-Authorization` in this deployment, and whether n8n's
MCP server takes an ordinary API key as its bearer token, both need a real
gateway and real credentials. Both are reverted by unsetting
`N8N_IAP_AUTH_HEADER_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GWxTSPRDtMxdDLngkUVUJ
