### PR TITLE
feat(mcp): gate on the trigger n8n will actually enter, and say which one it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ n8n's `Available in MCP` toggle is per-workflow and anyone with edit rights can 
 | `namePattern` | `string` | Regular expression the workflow name must match |
 | `mcpTags` | `string[]` | Tags that mean "meant for MCP" even when the setting is off |
 | `requireSetting` | `boolean` | When true, a workflow carrying an `mcpTags` tag must also have `settings.availableInMCP` — otherwise the tag promises access n8n refuses |
+| `entryPathPattern` | `string` | `*`-glob the [entry trigger's](#the-entry-trigger) path must match. Pass the same glob the proxy runs with, so CI and the gate agree. The message names the node that would actually fire, which node order otherwise hides |
 
 ```json
 {
@@ -345,8 +346,8 @@ n8n's `Available in MCP` toggle is per-workflow and anyone with edit rights can 
     "mcp-exposure": ["error", {
       "mcpTags": ["mcp"],
       "requireTags": ["mcp"],
-      "namePattern": "^\\[mcp\\] ",
-      "requireSetting": true
+      "requireSetting": true,
+      "entryPathPattern": "__mcp__/*"
     }]
   }
 }
@@ -1083,26 +1084,49 @@ That is a reasonable product default and a poor blast radius. The MCP gate puts 
 ```bash
 n8n-cli proxy \
   --upstream https://n8n.example.com \
+  --client-middleware api-key-inject \
+  --api-key-inject-key-env-var N8N_API_KEY \
   --mcp-enforce error \
   --mcp-allow-tools 'search_workflows,get_workflow_details,execute_workflow' \
-  --mcp-workflow-tags mcp
+  --mcp-workflow-tags mcp \
+  --mcp-entry-path-pattern '__mcp__/*'
 ```
 
-Three things happen, and only the first is cosmetic:
+> **The gate needs its own credential for the public API.** Deciding whether a workflow is in scope means reading `/api/v1/workflows`, and an MCP client authenticates to the *MCP* endpoint — nothing on its request carries an `X-N8N-API-KEY`. So the egress chain has to supply one, unscoped (`api-key-inject`), or every workflow-scoped call is refused with "could not verify whether that workflow is available over MCP". A 401 on that lookup says so explicitly in the log.
 
-1. **`tools/list` is filtered** — a withheld tool never reaches the model's context.
-2. **`tools/call` on a withheld tool is refused at the proxy**, and never reaches n8n. Hiding a tool an agent can still call is theatre; the refusal comes back as a JSON-RPC `Unknown tool` error.
-3. **`tools/call` on a tool that names a workflow is refused unless that workflow carries the tags you named.** The proxy resolves tags against the n8n API (cached for `--mcp-cache-ttl-ms`). The refusal comes back as an MCP tool result with `isError: true`, so the agent is told *why* rather than seeing a transport failure.
+**A workflow is never a tool here.** Under instance-level MCP the tools are verbs — `search_workflows`, `execute_workflow`, `update_workflow` — and a workflow is an *argument* to one. So the gate has two independent axes: which verbs a client gets, and which workflows those verbs may name.
+
+Four things happen, and only the first is cosmetic:
+
+1. **`tools/list` is filtered** — a withheld verb never reaches the model's context.
+2. **`tools/call` on a withheld verb is refused at the proxy**, and never reaches n8n. Hiding a tool an agent can still call is theatre; the refusal comes back as a JSON-RPC `Unknown tool` error.
+3. **`tools/call` naming a workflow outside the scope is refused**, with an MCP tool result carrying `isError: true` and the reason — which tag is missing, or which trigger n8n would have entered it through. The agent is told *why* rather than seeing a transport failure.
+4. **`search_workflows` is narrowed rather than refused.** Its `tags` argument is an AND, the same semantics as the policy, so the policy's tags are merged into whatever the agent asked for. Without this an agent still sees the name and description of every workflow the token's owner can read.
 
 Everything else on the path — `initialize`, notifications, the server-to-client `GET` stream, session teardown — is forwarded untouched, and both `application/json` and `text/event-stream` (Streamable HTTP) replies are handled.
 
 | Flag | Env | Description |
 |------|-----|-------------|
 | `--mcp-enforce <level>` | `N8N_MCP_ENFORCE` | `off`, `warn`, `error`. **Required to enable the gate** — without it `/mcp-server/` is forwarded unfiltered, so upgrading changes nothing |
-| `--mcp-allow-tools <list>` | `N8N_MCP_ALLOW_TOOLS` | Comma-separated `*`-globs; only these tools are visible and callable. Empty means all |
+| `--mcp-allow-tools <list>` | `N8N_MCP_ALLOW_TOOLS` | Comma-separated `*`-globs; only these **verbs** are visible and callable. Empty means all |
 | `--mcp-deny-tools <list>` | `N8N_MCP_DENY_TOOLS` | Globs to withhold, applied after the allowlist |
-| `--mcp-workflow-tags <tags>` | `N8N_MCP_WORKFLOW_TAGS` | A reachable workflow must carry **all** of these tags |
-| `--mcp-cache-ttl-ms <ms>` | `N8N_MCP_CACHE_TTL_MS` | Workflow-tag cache lifetime (default `60000`) |
+| `--mcp-workflow-tags <tags>` | `N8N_MCP_WORKFLOW_TAGS` | A reachable workflow must carry **all** of these tags. Also narrows `search_workflows` |
+| `--mcp-entry-path-pattern <glob>` | `N8N_MCP_ENTRY_PATH_PATTERN` | A reachable workflow's **entry trigger** must declare a path matching this glob (see below) |
+| `--mcp-cache-ttl-ms <ms>` | `N8N_MCP_CACHE_TTL_MS` | Workflow-facts cache lifetime (default `60000`) |
+
+### The entry trigger
+
+`execute_workflow` does not let the caller choose a trigger. n8n maps the supplied input onto **the first non-disabled Schedule / Webhook / Form / Chat node in the workflow's `nodes` array** and starts there — array order decides, and its own source calls the multi-trigger case unsupported. Node order is invisible in a diff, so a workflow can be exposed exactly as intended and still be entered through a test hook, or through a nightly Schedule.
+
+`--mcp-entry-path-pattern` gates on the path *that* trigger declares. It lets a repository mark "this workflow has an interface meant for agents" in the workflow itself, while the proxy stays agnostic about which trigger type was used to build it:
+
+- A **Schedule** trigger carries no path, so a cron job cannot opt itself in by accident.
+- A webhook or form node that never had a path set carries none either — n8n falls back to the node's `webhookId`. Declaring the path is what opts a workflow in, so the rule fails closed.
+- Matching happens against the *first* supported trigger, not any of them, precisely so that this and n8n agree about which node runs.
+
+The matching mirrors n8n's `findMcpSupportedTrigger`. That is a coupling: if n8n adds a supported trigger type, a workflow whose new-type trigger sorts earlier is entered somewhere this release does not predict. The list lives in one place (`src/common/mcp.ts`) and is worth revisiting on an n8n upgrade. The [`mcp-exposure`](#mcp-exposure) lint rule takes the same glob, so CI and the gate cannot disagree.
+
+> **`fmt` re-derives node order from position.** `n8n-cli fmt` writes nodes sorted by canvas position (left to right, then top to bottom), so on a formatted workflow the entry is whichever matching trigger sits leftmost — not whichever appears first in the file you edited. It also recomputes those positions with a graph layout, which places every trigger in the same column and orders them by a heuristic you do not control. Two ways out: keep the agent-facing trigger's path unique so the lint rule catches any drift on the next PR, or keep MCP-exposed definitions in a format `fmt` does not touch (`.ts`, where node order is explicit). `fmt` does not know about this glob today.
 
 **Rollout:** `--mcp-enforce warn` logs every decision and changes nothing — the tool list is *not* filtered in warn mode either, because a client that never sees a tool cannot exercise it and the log you are rolling out against would stay empty.
 
@@ -1116,7 +1140,7 @@ Everything else on the path — `initialize`, notifications, the server-to-clien
 
 > Tool names differ between n8n's documentation and its implementation — the docs call them `list_tags`, `get_execution` and `search_executions`, the server registers `list_workflow_tags`, `get_workflow_execution` and `search_workflow_executions`. Build `--mcp-allow-tools` from a real `tools/list` against your instance, not from the docs; a misspelt entry silently withholds a tool you meant to allow.
 
-**What it does not do:** `search_workflows` results are forwarded verbatim, so an agent can still *see* a preview — name, description — of every workflow the connecting identity can read, even ones it may not fetch or run. Withhold `search_workflows` itself if that listing is the problem.
+**What it does not do:** with `--mcp-workflow-tags` set, `search_workflows` is narrowed to those tags — but an **entry-path-only** policy has no equivalent argument upstream, so the listing stays wide: an agent still sees the name and description of every workflow the connecting identity can read. Pair the path rule with a tag, or withhold `search_workflows` itself, if that listing is the problem.
 
 > As with every other check here, this is an enforcement boundary only if direct access to n8n is blocked at the network level. A client that can reach `/mcp-server/` on the instance itself bypasses the proxy.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/apply/threeway/detector.ts
+++ b/src/apply/threeway/detector.ts
@@ -34,6 +34,21 @@ export class ThreeWayDetector {
     const baseToLocal = this.compareWorkflows(local, base);
     const baseToRemote = this.compareWorkflows(remote, base);
 
+    // `description` is judged on the base→local edge only, and never on
+    // base→remote.
+    //
+    // `remote` comes from the n8n API while `base` is the definition at the git
+    // base ref, so comparing them symmetrically means "this file predates
+    // description support and someone wrote one in the UI" reads as a remote
+    // change — and, paired with any local edit, as a conflict needing --force.
+    // Nothing is at risk there: apply never sends a description the local file
+    // does not declare (see `compare` in ../differ.ts), so a UI-authored one
+    // cannot be clobbered and has nothing to conflict with.
+    if (this.localChangedDescription(local, base)) {
+      baseToLocal.changedFields.push("description");
+      baseToLocal.hasChanges = true;
+    }
+
     if (!baseToLocal.hasChanges && !baseToRemote.hasChanges) {
       return {
         type: "skip",
@@ -80,21 +95,24 @@ export class ThreeWayDetector {
     };
   }
 
+  /**
+   * Whether the author changed the description in the definition itself.
+   *
+   * A local file with no `description` key is not claiming the description is
+   * empty — it is not managing the field, which is every definition written
+   * before n8n-cli could carry one. Same rule as the 2-way `compare`.
+   */
+  private localChangedDescription(local: Workflow, base: Workflow): boolean {
+    if (local.description === undefined) return false;
+    return local.description !== (base.description ?? "");
+  }
+
   /** Compares two workflows and returns a DiffVector. */
   private compareWorkflows(a: Workflow, b: Workflow): DiffVector {
     const diff: DiffVector = { hasChanges: false, changedFields: [] };
 
     if (a.name !== b.name) {
       diff.changedFields.push("name");
-      diff.hasChanges = true;
-    }
-
-    // Symmetric here, unlike `compare()`: this runs over base/local/remote
-    // revisions of the same definition, so "absent on one side" really does
-    // mean the field changed between two states rather than "this file does
-    // not manage the field".
-    if ((a.description ?? "") !== (b.description ?? "")) {
-      diff.changedFields.push("description");
       diff.hasChanges = true;
     }
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -218,7 +218,16 @@ export function registerProxyCommand(program: Command): void {
     .option(
       "--mcp-workflow-tags <tags>",
       "Only workflows carrying ALL of these tags may be reached by a workflow-scoped tool call " +
-        "(AND condition). env: N8N_MCP_WORKFLOW_TAGS",
+        "(AND condition). Also narrows search_workflows, which n8n otherwise answers with every " +
+        "workflow the token's owner can read. env: N8N_MCP_WORKFLOW_TAGS",
+    )
+    .option(
+      "--mcp-entry-path-pattern <glob>",
+      "Only workflows whose entry trigger declares a path matching this glob may be reached " +
+        '(e.g. "__mcp__/*"). The entry trigger is the one n8n would actually fire: the first ' +
+        "non-disabled Schedule/Webhook/Form/Chat node in the workflow. A trigger with no path — " +
+        "a Schedule, or a webhook that never had one set — matches nothing, so declaring the " +
+        "path is what opts a workflow in. env: N8N_MCP_ENTRY_PATH_PATTERN",
     )
     .option(
       "--mcp-cache-ttl-ms <ms>",

--- a/src/common/mcp.ts
+++ b/src/common/mcp.ts
@@ -1,0 +1,90 @@
+/**
+ * How n8n picks the trigger it enters a workflow through over MCP, and the
+ * glob used to write policy about it.
+ *
+ * Shared because the proxy gate and the `mcp-exposure` lint rule must agree
+ * exactly: CI passing and the gate refusing the same workflow would be worse
+ * than either check alone. One definition, two callers.
+ */
+
+/**
+ * Trigger node types n8n will start an MCP execution from.
+ *
+ * A mirror of `findMcpSupportedTrigger` in n8n
+ * (`packages/cli/src/modules/mcp/mcp.utils.ts`). Manual triggers are omitted:
+ * n8n accepts them only for `executionMode: "manual"`, and resolving a
+ * different entry than a production run would use is worse than resolving none.
+ *
+ * **This is a coupling.** If n8n adds a supported trigger type, a workflow
+ * whose new-type trigger sorts earlier is entered somewhere this release does
+ * not predict. It lives here, in one place, to be revisited on n8n upgrades.
+ */
+export const MCP_ENTRY_TRIGGER_TYPES: readonly string[] = [
+  "n8n-nodes-base.scheduleTrigger",
+  "n8n-nodes-base.webhook",
+  "n8n-nodes-base.formTrigger",
+  "@n8n/n8n-nodes-langchain.chatTrigger",
+];
+
+/** The trigger n8n would start an MCP execution from. */
+export interface EntryTrigger {
+  name: string;
+  type: string;
+  /**
+   * `parameters.path`, when the node carries one.
+   *
+   * Schedule triggers never do. A webhook or form node that never had one set
+   * does not either — n8n falls back to the node's `webhookId`, a UUID that no
+   * path convention should be written against.
+   */
+  path?: string;
+}
+
+/** The shape this needs from a node; deliberately looser than `Node`. */
+export interface EntryTriggerNode {
+  name?: unknown;
+  type?: unknown;
+  disabled?: unknown;
+  parameters?: { path?: unknown } | null;
+}
+
+/**
+ * Resolves the trigger n8n would fire, using n8n's own rule: the first
+ * non-disabled node of a supported type, **in array order**.
+ *
+ * Array order is not incidental — it is the entire mechanism, and it is stable:
+ * n8n stores `nodes` as JSON and nothing in its save path reorders it, so the
+ * order a definition is written in is the order this sees.
+ */
+export function findEntryTrigger(
+  nodes: readonly EntryTriggerNode[] | undefined,
+): EntryTrigger | null {
+  for (const node of nodes ?? []) {
+    if (node.disabled === true) continue;
+    if (typeof node.type !== "string" || !MCP_ENTRY_TRIGGER_TYPES.includes(node.type)) continue;
+    const path = node.parameters?.path;
+    return {
+      name: typeof node.name === "string" ? node.name : "",
+      type: node.type,
+      ...(typeof path === "string" && path !== "" ? { path } : {}),
+    };
+  }
+  return null;
+}
+
+/**
+ * Matches a `*`-glob against a value.
+ *
+ * Deliberately not a regex from the operator: these patterns are matched
+ * against names and paths that arrive from upstream, and a config typo
+ * producing a catastrophically backtracking pattern would be a denial of
+ * service on whatever is doing the matching.
+ */
+export function globMatch(pattern: string, value: string): boolean {
+  const escaped = pattern.split("*").map(escapeRegex).join(".*");
+  return new RegExp(`^${escaped}$`).test(value);
+}
+
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lint/rules/mcp-exposure.ts
+++ b/src/lint/rules/mcp-exposure.ts
@@ -1,4 +1,5 @@
 import type { Workflow } from "@/api/types.ts";
+import { findEntryTrigger, globMatch } from "@/common/mcp.ts";
 import { readStringArray } from "./mcp-tool-description.ts";
 import type { Rule } from "./rule.ts";
 import type { Violation } from "./violation.ts";
@@ -45,6 +46,11 @@ function hasAnyTag(workflow: Workflow, tags: string[]): boolean {
  *   - `requireSetting`: when true, a workflow carrying an `mcpTags` tag must
  *     also have `settings.availableInMCP` set — otherwise the tag promises an
  *     agent access that n8n refuses.
+ *   - `entryPathPattern`: a `*`-glob the *entry trigger's* path must match.
+ *     The entry trigger is the one n8n would actually fire — the first
+ *     non-disabled Schedule/Webhook/Form/Chat node, in array order. Pass the
+ *     same glob the proxy runs with (`--mcp-entry-path-pattern`) so CI and the
+ *     gate cannot disagree about which workflows are reachable.
  */
 export const mcpExposureRule: Rule = {
   name: "mcp-exposure",
@@ -61,11 +67,19 @@ export const mcpExposureRule: Rule = {
     const requireTags = readStringArray(options?.requireTags);
     const namePattern = typeof options?.namePattern === "string" ? options.namePattern : undefined;
     const requireSetting = options?.requireSetting === true;
+    const entryPathPattern =
+      typeof options?.entryPathPattern === "string" && options.entryPathPattern !== ""
+        ? options.entryPathPattern
+        : undefined;
 
     if (!isMcpExposed(workflow, mcpTags)) return [];
 
     const violations: Violation[] = [];
     const present = new Set((workflow.tags ?? []).map((t) => t.name));
+
+    if (entryPathPattern !== undefined) {
+      violations.push(...checkEntryPath(workflow, entryPathPattern));
+    }
 
     for (const tag of requireTags) {
       if (!present.has(tag)) {
@@ -111,3 +125,63 @@ export const mcpExposureRule: Rule = {
     return violations;
   },
 };
+
+/**
+ * Checks the trigger n8n would actually enter this workflow through.
+ *
+ * The failure this catches is not a missing feature but a silent one: n8n picks
+ * the *first* supported trigger in `nodes` order and gives the caller no way to
+ * choose, so a workflow can be perfectly exposed and still be entered somewhere
+ * nobody intended — through a test hook, or through a nightly Schedule. Node
+ * order is invisible in review, which is why a machine has to say it out loud.
+ *
+ * Messages name the node, because "which one fires" is the question an author
+ * cannot otherwise answer without reading the whole definition.
+ */
+function checkEntryPath(workflow: Workflow, pattern: string): Violation[] {
+  const entry = findEntryTrigger(workflow.nodes);
+
+  if (entry === null) {
+    return [
+      {
+        rule: "mcp-exposure",
+        severity: "warning",
+        message:
+          "Workflow is exposed over MCP but has no trigger n8n can enter it through " +
+          "(only Schedule, Webhook, Form and Chat triggers count), so execute_workflow fails.",
+      },
+    ];
+  }
+
+  if (entry.path === undefined) {
+    return [
+      {
+        rule: "mcp-exposure",
+        severity: "warning",
+        message:
+          `MCP enters this workflow through "${entry.name}" (${entry.type}), which declares no path, ` +
+          `so it cannot match the agent-facing convention /${pattern}/. A Schedule trigger never ` +
+          "carries one — if an agent should not be able to fire this workflow on demand, take it " +
+          "out of MCP instead.",
+      },
+    ];
+  }
+
+  if (!globMatch(pattern, entry.path)) {
+    return [
+      {
+        rule: "mcp-exposure",
+        severity: "warning",
+        message:
+          `MCP enters this workflow through "${entry.name}" (path "${entry.path}"), which is outside ` +
+          `the agent-facing convention /${pattern}/. n8n fires the FIRST supported trigger in node ` +
+          "order, so give the agent-facing trigger a matching path and put it first — note that " +
+          "`n8n-cli fmt` re-derives node order from canvas position (left to right, then top to " +
+          "bottom), so on a workflow that gets formatted the entry is whichever matching trigger " +
+          "sits leftmost.",
+      },
+    ];
+  }
+
+  return [];
+}

--- a/src/proxy/mcp/config.ts
+++ b/src/proxy/mcp/config.ts
@@ -28,8 +28,23 @@ export interface McpCliOptions {
   mcpAllowTools?: string;
   mcpDenyTools?: string;
   mcpWorkflowTags?: string;
+  mcpEntryPathPattern?: string;
   mcpCacheTtlMs?: string;
 }
+
+/**
+ * Options that state a *policy* — what an agent may reach.
+ *
+ * `--mcp-cache-ttl-ms` is deliberately absent: it tunes how often a lookup is
+ * repeated, and someone who set only that has expressed no belief about what
+ * is exposed. Refusing to start over it would be noise.
+ */
+const POLICY_OPTIONS: ReadonlyArray<{ cli: keyof McpCliOptions; env: string }> = [
+  { cli: "mcpAllowTools", env: "N8N_MCP_ALLOW_TOOLS" },
+  { cli: "mcpDenyTools", env: "N8N_MCP_DENY_TOOLS" },
+  { cli: "mcpWorkflowTags", env: "N8N_MCP_WORKFLOW_TAGS" },
+  { cli: "mcpEntryPathPattern", env: "N8N_MCP_ENTRY_PATH_PATTERN" },
+];
 
 /**
  * Builds the gate settings, or returns null when the operator asked for no gate.
@@ -43,7 +58,22 @@ export function parseMcpSettings(
   env: NodeJS.ProcessEnv,
 ): McpGateSettings | null {
   const enforceRaw = opts.mcpEnforce ?? env.N8N_MCP_ENFORCE;
-  if (!enforceRaw) return null;
+  if (!enforceRaw) {
+    // Off by default is right, but silently discarding a policy someone wrote
+    // is not: the deployment would forward `/mcp-server/` unfiltered while its
+    // configuration says otherwise, and nothing in the startup line would
+    // contradict the belief that the gate is on.
+    const orphans = POLICY_OPTIONS.filter(
+      ({ cli, env: name }) => opts[cli] !== undefined || env[name] !== undefined,
+    ).map(({ env: name }) => name);
+    if (orphans.length > 0) {
+      throw new Error(
+        `MCP policy is configured (${orphans.join(", ")}) but --mcp-enforce / N8N_MCP_ENFORCE is not set, ` +
+          "so the gate would be off and the policy ignored. Set it to off, warn or error.",
+      );
+    }
+    return null;
+  }
 
   return {
     enforce: parseEnforce(enforceRaw),
@@ -51,6 +81,7 @@ export function parseMcpSettings(
       allowTools: parseList(opts.mcpAllowTools ?? env.N8N_MCP_ALLOW_TOOLS),
       denyTools: parseList(opts.mcpDenyTools ?? env.N8N_MCP_DENY_TOOLS),
       workflowTags: parseList(opts.mcpWorkflowTags ?? env.N8N_MCP_WORKFLOW_TAGS),
+      ...parseEntryPathPattern(opts.mcpEntryPathPattern ?? env.N8N_MCP_ENTRY_PATH_PATTERN),
     },
     cacheTtlMs: parseTtl(opts.mcpCacheTtlMs ?? env.N8N_MCP_CACHE_TTL_MS),
   };
@@ -67,6 +98,16 @@ function parseList(value: string | undefined): string[] {
     .split(",")
     .map((v) => v.trim())
     .filter((v) => v !== "");
+}
+
+/**
+ * A `*`-glob, not a regex — the same shape as the tool patterns, and for the
+ * same reason: an operator typo must not become a backtracking hazard on a
+ * value that arrives from upstream.
+ */
+function parseEntryPathPattern(value: string | undefined): { entryPathPattern?: string } {
+  if (!value || value.trim() === "") return {};
+  return { entryPathPattern: value.trim() };
 }
 
 function parseTtl(value: string | undefined): number {

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -37,7 +37,7 @@ import {
   scanForWorkflowIds,
   targetWorkflowId,
 } from "./policy.ts";
-import type { AllowedWorkflowIndex } from "./workflow-index.ts";
+import { type AllowedWorkflowIndex, explainRefusal } from "./workflow-index.ts";
 
 export interface McpGateDeps {
   upstream: string;
@@ -99,6 +99,17 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
     if (refusal) refusals.push(refusal);
   }
 
+  // Narrow a discovery call rather than refusing it. `search_workflows` takes a
+  // `tags` filter with AND semantics — the same semantics as the policy — so
+  // adding the policy's tags to whatever the agent asked for can only shrink
+  // the result. Without this the agent still sees the name and description of
+  // every workflow the token's owner can read, which is the one part of the
+  // listing surface n8n gives no way to close.
+  const narrowedJSON =
+    refusals.length === 0 && deps.enforce === "error"
+      ? narrowSearchArguments(parsed, deps.policy)
+      : null;
+
   // Under `warn` the decision is logged and the call still goes through, which
   // is how an operator finds out what a policy would break before it does.
   if (refusals.length > 0 && deps.enforce === "error") {
@@ -118,7 +129,7 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
     return jsonRpcResponse(refusals, parsed.isBatch);
   }
 
-  const response = await forward(req, rawJSON, pathname, deps);
+  const response = await forward(req, narrowedJSON ?? rawJSON, pathname, deps);
 
   // Only a tools/list reply needs rewriting, and only when the policy actually
   // withholds something. Everything else streams back untouched.
@@ -130,6 +141,39 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
   if (!listsTools || !filtersTools(deps.policy) || deps.enforce !== "error") return response;
 
   return filterToolsListResponse(response, deps, pathname);
+}
+
+/**
+ * Adds the policy's tags to a `search_workflows` call, or returns null when
+ * there is nothing to add.
+ *
+ * Only tags: the entry-path rule has no equivalent argument upstream, so a
+ * path-only policy still leaves the listing wide. Say so in the README rather
+ * than pretending otherwise.
+ */
+function narrowSearchArguments(
+  parsed: { messages: JsonRpcMessage[]; isBatch: boolean },
+  policy: McpPolicy,
+): string | null {
+  if (policy.workflowTags.length === 0) return null;
+
+  let changed = false;
+  const messages = parsed.messages.map((message) => {
+    if (toolCallName(message) !== "search_workflows") return message;
+    const args = toolCallArguments(message);
+    const asked = Array.isArray(args.tags)
+      ? args.tags.filter((t): t is string => typeof t === "string")
+      : [];
+    const merged = [...new Set([...asked, ...policy.workflowTags])];
+    if (merged.length === asked.length) return message;
+    changed = true;
+    return {
+      ...message,
+      params: { ...message.params, arguments: { ...args, tags: merged } },
+    };
+  });
+
+  return changed ? encodeReply(messages, parsed.isBatch) : null;
 }
 
 /** Whether the policy can withhold any tool at all. */
@@ -189,16 +233,24 @@ async function refuse(
   // Every workflow id anywhere in the arguments, not just the one the table
   // pointed at — so a parameter this release named wrong, or a tool it has
   // never heard of, cannot carry a forbidden id past the check.
-  const mentioned = scanForWorkflowIds(args, sets.known);
+  const mentioned = scanForWorkflowIds(args, new Set(sets.facts.keys()));
   if (target !== undefined) mentioned.add(target);
 
   const forbidden = [...mentioned].filter((id) => !sets.allowed.has(id));
   if (forbidden.length === 0) return null;
 
-  log(deps, pathname, `workflow ${forbidden.join(", ")} is out of MCP scope`, tool);
+  // Name the reason. An agent told only "no" retries; one told the entry
+  // trigger declares no path can report something its user can act on.
+  const detail = forbidden
+    .map((id) => `${id} (${explainRefusal(deps.policy, sets.facts.get(id))})`)
+    .join("; ");
+
+  log(deps, pathname, `workflow out of MCP scope: ${detail}`, tool);
   return toolErrorResult(
     message.id,
-    `Workflow ${forbidden.join(", ")} is not available over MCP. Only workflows this instance's MCP policy covers can be reached; ask the workflow's owner to bring it under that policy.`,
+    `Not available over MCP: ${detail}. Note that every workflow id anywhere in the arguments is ` +
+      "checked, so this may name one the call merely referenced — a sub-workflow, say — rather " +
+      "than the one it targeted. Ask the owner to bring it under this instance's MCP policy.",
   );
 }
 

--- a/src/proxy/mcp/policy.ts
+++ b/src/proxy/mcp/policy.ts
@@ -1,3 +1,5 @@
+import { globMatch } from "@/common/mcp.ts";
+
 /**
  * What an MCP client is allowed to see and do through this proxy.
  *
@@ -18,6 +20,13 @@
  * `get_workflow_details` for a workflow without it, so re-checking here would
  * add a flag and no enforcement.
  */
+
+export {
+  type EntryTrigger,
+  findEntryTrigger,
+  globMatch,
+  MCP_ENTRY_TRIGGER_TYPES,
+} from "@/common/mcp.ts";
 
 /** Tools that act on one workflow, and the argument naming it. */
 export type WorkflowIdArgs = Record<string, string[]>;
@@ -53,19 +62,34 @@ export const WORKFLOW_ID_ARGS: WorkflowIdArgs = {
 
 export interface McpPolicy {
   /**
-   * Glob patterns (`*` matches any run of characters) for the tools a client may
-   * see and call. When empty every tool is allowed and only `denyTools` applies.
+   * Glob patterns (`*` matches any run of characters) for the *verbs* a client
+   * may see and call — `execute_workflow`, `update_workflow` and so on. Not the
+   * workflows: under instance-level MCP a workflow is an argument, never a tool.
+   * When empty every tool is allowed and only `denyTools` applies.
    */
   allowTools: string[];
   /** Glob patterns for tools to withhold. Applied after `allowTools`. */
   denyTools: string[];
   /** Tags a workflow must carry (all of them) to be reachable over MCP. */
   workflowTags: string[];
+  /**
+   * Glob the *entry trigger's* path must match for a workflow to be reachable.
+   *
+   * The entry trigger is the one n8n would actually fire — see
+   * {@link findEntryTrigger}. Matching on its path lets a repository declare
+   * "this workflow has an interface meant for agents" in the workflow itself,
+   * without the proxy caring which trigger type was used to build it.
+   *
+   * A trigger with no path (a Schedule trigger, or a webhook/form node that
+   * never had one set — n8n falls back to the node's `webhookId`) matches
+   * nothing, so declaring the path is what opts a workflow in.
+   */
+  entryPathPattern?: string;
 }
 
 /** True when the policy says nothing about which workflows are reachable. */
 export function hasWorkflowScope(policy: McpPolicy): boolean {
-  return policy.workflowTags.length > 0;
+  return policy.workflowTags.length > 0 || policy.entryPathPattern !== undefined;
 }
 
 /** Whether a tool name survives the allow/deny lists. */
@@ -134,26 +158,4 @@ export function scanForWorkflowIds(args: unknown, known: ReadonlySet<string>): S
 
   walk(args, 0);
   return found;
-}
-
-/**
- * Matches a `*`-glob against a name.
- *
- * Deliberately not a regex from the operator: these patterns are matched
- * against tool names that arrive from upstream, and a config typo producing a
- * catastrophically backtracking pattern would be a denial of service on the
- * gate itself.
- */
-export function globMatch(pattern: string, value: string): boolean {
-  return globRegex(pattern).test(value);
-}
-
-/** Compiles a `*`-glob to an anchored regex with every other character literal. */
-function globRegex(pattern: string): RegExp {
-  const escaped = pattern.split("*").map(escapeRegex).join(".*");
-  return new RegExp(`^${escaped}$`);
-}
-
-function escapeRegex(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/proxy/mcp/workflow-index.ts
+++ b/src/proxy/mcp/workflow-index.ts
@@ -1,15 +1,15 @@
 /**
- * Which workflows exist upstream, and which of them the MCP policy considers
- * agent-reachable.
+ * What the gate knows about the workflows upstream.
  *
- * The decision needs the workflow's tags, and those are not in the MCP call —
- * only an id is. So the gate resolves them against the n8n public API and
- * caches the answer, the way the duplicate-name check does.
+ * An MCP call carries a workflow id and nothing else, but the policy asks about
+ * tags and about which trigger n8n would fire. So the gate resolves those from
+ * the n8n public API and caches the answer, the way the duplicate-name check
+ * does.
  *
- * Both sets matter. `allowed` answers "may this call proceed?"; `known` lets the
- * gate recognise a workflow id sitting in an argument it was not expecting, so
- * a tool whose parameter names this release guessed wrong still cannot reach a
- * workflow the policy excludes.
+ * Facts are kept per workflow rather than as a bare allow/deny set. Two reasons:
+ * a refusal can then say *why* ("its entry trigger is a Schedule with no path")
+ * instead of only "no", and a new predicate becomes a config change rather than
+ * another round trip to n8n.
  *
  * The lookup goes through `forwardRequest`, not a bare fetch, because on a
  * deployment where the proxy holds the credentials (IAP id_token, shared API
@@ -21,7 +21,13 @@
 import type { Workflow } from "@/api/types.ts";
 import type { ClientMiddleware } from "@/middleware/types.ts";
 import { forwardRequest } from "../upstream.ts";
-import { hasWorkflowScope, type McpPolicy } from "./policy.ts";
+import {
+  type EntryTrigger,
+  findEntryTrigger,
+  globMatch,
+  hasWorkflowScope,
+  type McpPolicy,
+} from "./policy.ts";
 
 /** Cap on pagination, matching the duplicate-name index. */
 const MAX_PAGES = 50;
@@ -31,9 +37,20 @@ interface ListResponse {
   nextCursor?: string | null;
 }
 
+/** What the gate remembers about one workflow. */
+export interface WorkflowFacts {
+  id: string;
+  name: string;
+  description?: string;
+  tags: string[];
+  availableInMCP: boolean;
+  /** The trigger n8n would start an MCP execution from, if any. */
+  entry: EntryTrigger | null;
+}
+
 export interface WorkflowSets {
-  /** Every workflow id upstream, whatever the policy says about it. */
-  known: Set<string>;
+  /** Facts for every workflow upstream, keyed by id. */
+  facts: Map<string, WorkflowFacts>;
   /** The subset the policy lets an agent reach. */
   allowed: Set<string>;
 }
@@ -47,6 +64,32 @@ export interface WorkflowIndexDeps {
   upstream: string;
   timeoutMs?: number;
   clientMiddlewares?: ClientMiddleware[];
+}
+
+/** Why a workflow is not reachable, phrased for the agent that asked. */
+export function explainRefusal(policy: McpPolicy, facts: WorkflowFacts | undefined): string {
+  if (!facts) return "no workflow with that id is visible to this proxy";
+  const reasons: string[] = [];
+  if (policy.workflowTags.length > 0) {
+    const missing = policy.workflowTags.filter((t) => !facts.tags.includes(t));
+    if (missing.length > 0) reasons.push(`it does not carry the tag(s) ${missing.join(", ")}`);
+  }
+  if (policy.entryPathPattern !== undefined && !entryPathMatches(policy, facts)) {
+    reasons.push(
+      facts.entry === null
+        ? "it has no trigger this proxy can enter it through"
+        : facts.entry.path === undefined
+          ? `its entry trigger "${facts.entry.name}" declares no path`
+          : `its entry trigger path "${facts.entry.path}" is outside the agent-facing namespace`,
+    );
+  }
+  return reasons.length > 0 ? reasons.join("; ") : "it is outside this proxy's MCP policy";
+}
+
+function entryPathMatches(policy: McpPolicy, facts: WorkflowFacts): boolean {
+  if (policy.entryPathPattern === undefined) return true;
+  if (!facts.entry?.path) return false;
+  return globMatch(policy.entryPathPattern, facts.entry.path);
 }
 
 export class AllowedWorkflowIndex {
@@ -95,7 +138,7 @@ export class AllowedWorkflowIndex {
   }
 
   /**
-   * The upstream workflow sets.
+   * The upstream workflow facts.
    *
    * Throws when the upstream cannot be read. The gate turns that into a refusal
    * — this class refuses to answer "allowed" from a list it never managed to
@@ -103,7 +146,7 @@ export class AllowedWorkflowIndex {
    */
   async sets(): Promise<WorkflowSets> {
     if (!hasWorkflowScope(this.policy)) {
-      return { known: new Set(), allowed: new Set() };
+      return { facts: new Map(), allowed: new Set() };
     }
 
     const now = performance.now();
@@ -127,15 +170,18 @@ export class AllowedWorkflowIndex {
   }
 
   private async fetchSets(): Promise<WorkflowSets> {
-    const known = new Set<string>();
+    const facts = new Map<string, WorkflowFacts>();
     const allowed = new Set<string>();
 
     let cursor: string | undefined;
     for (let page = 0; page < MAX_PAGES; page++) {
-      const url = new URL(`${this.deps.upstream}/api/v1/workflows`);
+      // Only the path and query are read from this URL — `forwardRequest`
+      // prepends the upstream base itself. Building it from `upstream` would
+      // double any base path an operator put in `--upstream`.
+      const url = new URL("/api/v1/workflows", "http://mcp-gate.invalid");
       url.searchParams.set("limit", "100");
-      // Only tags are read from the response. Pinned data can be the largest
-      // part of a workflow and is never looked at here.
+      // Only tags and trigger nodes are read from the response. Pinned data can
+      // be the largest part of a workflow and is never looked at here.
       url.searchParams.set("excludePinnedData", "true");
       if (cursor) url.searchParams.set("cursor", cursor);
 
@@ -149,27 +195,49 @@ export class AllowedWorkflowIndex {
         { timeoutMs: this.deps.timeoutMs, clientMiddlewares: this.deps.clientMiddlewares },
       );
       if (!response.ok) {
-        throw new Error(`upstream returned HTTP ${response.status} listing workflows`);
+        // 401/403 here is nearly always a missing credential rather than a
+        // broken n8n: an MCP client authenticates to the MCP endpoint, so
+        // nothing on the request carries an X-N8N-API-KEY unless the egress
+        // chain supplies one. Say that, because the symptom otherwise is every
+        // workflow-scoped call being refused with no clue why.
+        const hint =
+          response.status === 401 || response.status === 403
+            ? " — the MCP gate reads the workflow list under the proxy's own credentials," +
+              " so the client-middleware chain must supply one for /api/v1 (api-key-inject)"
+            : "";
+        throw new Error(`upstream returned HTTP ${response.status} listing workflows${hint}`);
       }
 
       const body = (await response.json()) as ListResponse;
       for (const workflow of body.data ?? []) {
         if (!workflow.id) continue;
-        known.add(workflow.id);
-        if (this.matches(workflow)) allowed.add(workflow.id);
+        const f = toFacts(workflow);
+        facts.set(f.id, f);
+        if (this.matches(f)) allowed.add(f.id);
       }
 
       cursor = body.nextCursor ?? undefined;
       if (!cursor) break;
     }
 
-    return { known, allowed };
+    return { facts, allowed };
   }
 
-  private matches(workflow: Workflow): boolean {
+  private matches(facts: WorkflowFacts): boolean {
     // The whole list is fetched rather than filtered with `?tags=`: n8n's tag
     // filter is an OR on some versions, and this has to be an AND.
-    const present = new Set((workflow.tags ?? []).map((t) => t.name));
-    return this.policy.workflowTags.every((t) => present.has(t));
+    if (!this.policy.workflowTags.every((t) => facts.tags.includes(t))) return false;
+    return entryPathMatches(this.policy, facts);
   }
+}
+
+function toFacts(workflow: Workflow): WorkflowFacts {
+  return {
+    id: workflow.id ?? "",
+    name: workflow.name ?? "",
+    ...(workflow.description ? { description: workflow.description } : {}),
+    tags: (workflow.tags ?? []).map((t) => t.name),
+    availableInMCP: workflow.settings?.availableInMCP === true,
+    entry: findEntryTrigger(workflow.nodes),
+  };
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -131,7 +131,11 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   // Start resolving which workflows the policy covers now rather than inside
   // the first tool call. Not awaited, and not part of the readiness pass
   // below: a slow n8n must not hold the container back — see `prefetch()`.
-  mcp?.index.prefetch();
+  //
+  // Skipped at `off`, where no request will read the result: paginating every
+  // workflow at startup — and logging a credential failure for it — is a poor
+  // way to honour "this gate is turned off".
+  if (mcp && mcp.enforce !== "off") mcp.index.prefetch();
 
   // Run prepare() up front so identity-resolution / config-load failures
   // surface at startup rather than on the first request. We also track the

--- a/tests/cli/proxy-flags-documented.test.ts
+++ b/tests/cli/proxy-flags-documented.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { Command } from "commander";
+import { registerProxyCommand } from "@/cli/commands/proxy.ts";
+
+/**
+ * The README and the flags have to describe the same proxy.
+ *
+ * This is not hypothetical tidiness. Twice while the MCP gate was being built,
+ * options were renamed or deleted and the README kept documenting them — and a
+ * documented flag that no longer exists is worse than an undocumented one,
+ * because an operator copies it into a deployment and the process dies at
+ * startup with "unknown option". The reverse costs less but hides the very
+ * controls the feature exists to offer.
+ *
+ * Scope is deliberately the `--mcp-*` family rather than every proxy flag:
+ * that is the surface under active change, and a check nobody can satisfy gets
+ * deleted rather than fixed.
+ */
+
+const PREFIX = "--mcp-";
+
+function declaredFlags(): Set<string> {
+  const program = new Command();
+  registerProxyCommand(program);
+  const proxy = program.commands.find((c) => c.name() === "proxy");
+  if (!proxy) throw new Error("the proxy command is not registered");
+  return new Set(proxy.options.map((o) => o.long ?? "").filter((long) => long.startsWith(PREFIX)));
+}
+
+function documentedFlags(): Set<string> {
+  const readme = fs.readFileSync(path.join(process.cwd(), "README.md"), "utf-8");
+  // Flags appear as `--mcp-foo` or `--mcp-foo <arg>`; take the name only.
+  //
+  // The whole README is scanned, so naming a removed flag anywhere — including
+  // in prose explaining why it was removed — fails this. That is the intent:
+  // a reader copies what they see, and there is no rendering that makes
+  // "this flag no longer exists" safe to paste into a deployment.
+  const found = readme.match(/--mcp-[a-z0-9-]+/g) ?? [];
+  return new Set(found);
+}
+
+describe("proxy --mcp-* flags and the README", () => {
+  test("every documented flag exists", () => {
+    const declared = declaredFlags();
+    const stale = [...documentedFlags()].filter((f) => !declared.has(f));
+    expect(stale).toEqual([]);
+  });
+
+  test("every flag is documented", () => {
+    const documented = documentedFlags();
+    const undocumented = [...declaredFlags()].filter((f) => !documented.has(f));
+    expect(undocumented).toEqual([]);
+  });
+
+  test("each flag names the environment variable it can be set from", () => {
+    // The gate is configured by env in every deployment that runs it — a flag
+    // whose env var is undocumented is unreachable there.
+    const program = new Command();
+    registerProxyCommand(program);
+    const proxy = program.commands.find((c) => c.name() === "proxy");
+    const missing = (proxy?.options ?? [])
+      .filter((o) => (o.long ?? "").startsWith(PREFIX))
+      .filter((o) => !/env: N8N_MCP_[A-Z_]+/.test(o.description))
+      .map((o) => o.long);
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/formats/description.test.ts
+++ b/tests/formats/description.test.ts
@@ -100,4 +100,27 @@ describe("workflow description: diffing", () => {
     expect(result.type).toBe("update");
     expect(result.baseToLocal?.changedFields).toContain("description");
   });
+
+  test("a description written in the n8n UI does not turn an unrelated edit into a conflict", () => {
+    // `remote` comes from the API, `base` from the git base ref. Every
+    // definition written before description support lacks the key, so
+    // comparing the two symmetrically made "someone typed a description in the
+    // UI" read as a remote change — and, paired with any local edit, as a
+    // conflict needing --force. Nothing is at risk: apply never sends a
+    // description the local file does not declare.
+    const detector = new ThreeWayDetector();
+    const local = { ...base, name: "renamed locally" };
+    const remote = { ...base, description: "written in the n8n UI" };
+
+    const result = detector.detect(base, local, remote);
+
+    expect(result.type).toBe("update");
+    expect(result.baseToRemote?.changedFields ?? []).not.toContain("description");
+  });
+
+  test("a genuine divergence is still a conflict", () => {
+    const detector = new ThreeWayDetector();
+    const result = detector.detect(base, { ...base, name: "local" }, { ...base, name: "remote" });
+    expect(result.type).toBe("conflict");
+  });
 });

--- a/tests/lint/rules/mcp-exposure.test.ts
+++ b/tests/lint/rules/mcp-exposure.test.ts
@@ -86,6 +86,86 @@ describe("mcp-exposure rule", () => {
     expect(violations[0]?.message).toContain("availableInMCP");
   });
 
+  describe("entryPathPattern", () => {
+    const webhook = (name: string, path?: string, disabled = false) => ({
+      id: `n-${name}`,
+      name,
+      type: "n8n-nodes-base.webhook",
+      typeVersion: 2,
+      position: [0, 0] as [number, number],
+      parameters: path === undefined ? {} : { path },
+      ...(disabled ? { disabled: true } : {}),
+    });
+    const exposed = (nodes: Workflow["nodes"]) =>
+      makeWorkflow({ nodes, settings: { availableInMCP: true } });
+    const OPT = { entryPathPattern: "__mcp__/*" };
+
+    test("passes when the first supported trigger is the agent-facing one", () => {
+      const wf = exposed([
+        webhook("[MCP] entry", "__mcp__/lookup"),
+        webhook("[CLI Test]", "__cli-test__/u"),
+      ]);
+      expect(mcpExposureRule.check(wf, "", OPT)).toEqual([]);
+    });
+
+    test("flags the case the whole rule exists for: the test hook is first", () => {
+      // Same two nodes, opposite order. Nothing else about the workflow differs,
+      // and nothing in a diff would show it — which is why this is checked.
+      const wf = exposed([
+        webhook("[CLI Test]", "__cli-test__/u"),
+        webhook("[MCP] entry", "__mcp__/lookup"),
+      ]);
+      const violations = mcpExposureRule.check(wf, "", OPT);
+      expect(violations.length).toBe(1);
+      expect(violations[0]?.message).toContain('"[CLI Test]"');
+      expect(violations[0]?.message).toContain("__cli-test__/u");
+    });
+
+    test("a Schedule entry is reported as having no path, with the way out named", () => {
+      const wf = exposed([
+        {
+          id: "s",
+          name: "Every night",
+          type: "n8n-nodes-base.scheduleTrigger",
+          typeVersion: 1,
+          position: [0, 0],
+          parameters: {},
+        },
+      ]);
+      const violations = mcpExposureRule.check(wf, "", OPT);
+      expect(violations[0]?.message).toContain("declares no path");
+      expect(violations[0]?.message).toContain("take it out of MCP");
+    });
+
+    test("a workflow n8n cannot enter at all is called out separately", () => {
+      const wf = exposed([
+        {
+          id: "sub",
+          name: "Called by another workflow",
+          type: "n8n-nodes-base.executeWorkflowTrigger",
+          typeVersion: 1,
+          position: [0, 0],
+          parameters: {},
+        },
+      ]);
+      expect(mcpExposureRule.check(wf, "", OPT)[0]?.message).toContain("no trigger n8n can enter");
+    });
+
+    test("a disabled trigger does not count as the entry", () => {
+      const wf = exposed([
+        webhook("[MCP] disabled", "__mcp__/lookup", true),
+        webhook("[CLI Test]", "__cli-test__/u"),
+      ]);
+      expect(mcpExposureRule.check(wf, "", OPT)[0]?.message).toContain('"[CLI Test]"');
+    });
+
+    test("the check is off unless the pattern is configured", () => {
+      const wf = exposed([webhook("[CLI Test]", "__cli-test__/u")]);
+      expect(mcpExposureRule.check(wf, "")).toEqual([]);
+      expect(mcpExposureRule.check(wf, "", { entryPathPattern: "" })).toEqual([]);
+    });
+  });
+
   test("requireSetting is satisfied once the setting is on", () => {
     const wf = makeWorkflow({ tags: [{ name: "mcp" }], settings: { availableInMCP: true } });
     expect(mcpExposureRule.check(wf, "", { mcpTags: ["mcp"], requireSetting: true })).toEqual([]);

--- a/tests/proxy/mcp-config.test.ts
+++ b/tests/proxy/mcp-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { parseMcpSettings } from "@/proxy/mcp/config.ts";
 import {
+  findEntryTrigger,
   globMatch,
   hasWorkflowScope,
   isToolAllowed,
@@ -110,17 +111,96 @@ describe("scanForWorkflowIds", () => {
   });
 });
 
+describe("findEntryTrigger", () => {
+  const node = (name: string, type: string, extra: Record<string, unknown> = {}) => ({
+    name,
+    type,
+    ...extra,
+  });
+
+  test("takes the first supported trigger in array order, like n8n does", () => {
+    const entry = findEntryTrigger([
+      node("Set", "n8n-nodes-base.set"),
+      node("A", "n8n-nodes-base.webhook", { parameters: { path: "__mcp__/a" } }),
+      node("B", "n8n-nodes-base.formTrigger", { parameters: { path: "__mcp__/b" } }),
+    ]);
+    expect(entry?.name).toBe("A");
+    expect(entry?.path).toBe("__mcp__/a");
+  });
+
+  test("skips disabled triggers, like n8n does", () => {
+    const entry = findEntryTrigger([
+      node("Off", "n8n-nodes-base.webhook", { disabled: true, parameters: { path: "off" } }),
+      node("On", "n8n-nodes-base.webhook", { parameters: { path: "on" } }),
+    ]);
+    expect(entry?.name).toBe("On");
+  });
+
+  test("a Schedule trigger is an entry, but carries no path", () => {
+    const entry = findEntryTrigger([node("Nightly", "n8n-nodes-base.scheduleTrigger")]);
+    expect(entry?.type).toBe("n8n-nodes-base.scheduleTrigger");
+    expect(entry?.path).toBeUndefined();
+  });
+
+  test("a webhook that never had a path set carries none either", () => {
+    // n8n falls back to the node's webhookId for the URL, which is a UUID and
+    // deliberately not something a path convention should match.
+    const entry = findEntryTrigger([
+      node("W", "n8n-nodes-base.webhook", { parameters: {}, webhookId: "uuid" }),
+    ]);
+    expect(entry?.path).toBeUndefined();
+  });
+
+  test("ignores node types n8n will not enter a workflow through", () => {
+    expect(
+      findEntryTrigger([
+        node("Sub", "n8n-nodes-base.executeWorkflowTrigger"),
+        node("Manual", "n8n-nodes-base.manualTrigger"),
+      ]),
+    ).toBeNull();
+  });
+
+  test("no nodes at all is not an entry", () => {
+    expect(findEntryTrigger([])).toBeNull();
+    expect(findEntryTrigger(undefined)).toBeNull();
+  });
+});
+
 describe("hasWorkflowScope", () => {
   test("false until a tag scopes workflows", () => {
     expect(hasWorkflowScope(policy())).toBe(false);
     expect(hasWorkflowScope(policy({ denyTools: ["*"] }))).toBe(false);
     expect(hasWorkflowScope(policy({ workflowTags: ["mcp"] }))).toBe(true);
+    expect(hasWorkflowScope(policy({ entryPathPattern: "__mcp__/*" }))).toBe(true);
   });
 });
 
 describe("parseMcpSettings", () => {
-  test("no gate unless enforcement is asked for", () => {
-    expect(parseMcpSettings({ mcpAllowTools: "search_workflows" }, NO_ENV)).toBeNull();
+  test("no gate, and no complaint, when nothing was configured", () => {
+    expect(parseMcpSettings({}, NO_ENV)).toBeNull();
+  });
+
+  test("a policy written without an enforce level is refused, not ignored", () => {
+    // The dangerous shape: the deployment says "only these tools, only these
+    // workflows" and forwards /mcp-server/ unfiltered, with nothing in the
+    // startup line to contradict the belief that the gate is on.
+    expect(() => parseMcpSettings({ mcpAllowTools: "search_workflows" }, NO_ENV)).toThrow(
+      /N8N_MCP_ALLOW_TOOLS.*--mcp-enforce/s,
+    );
+    expect(() =>
+      parseMcpSettings({}, { N8N_MCP_WORKFLOW_TAGS: "mcp" } as NodeJS.ProcessEnv),
+    ).toThrow(/N8N_MCP_WORKFLOW_TAGS/);
+  });
+
+  test("the cache TTL alone is not a policy, so it does not block startup", () => {
+    // It tunes how often a lookup repeats. Someone who set only that has
+    // expressed no belief about what is exposed.
+    expect(parseMcpSettings({ mcpCacheTtlMs: "5000" }, NO_ENV)).toBeNull();
+  });
+
+  test("enforce=off is a real answer, and silences that check", () => {
+    const settings = parseMcpSettings({ mcpEnforce: "off", mcpWorkflowTags: "mcp" }, NO_ENV);
+    expect(settings?.enforce).toBe("off");
   });
 
   test("reads the whole policy off the flags", () => {
@@ -130,6 +210,7 @@ describe("parseMcpSettings", () => {
         mcpAllowTools: "search_workflows, execute_workflow",
         mcpDenyTools: "*credential*",
         mcpWorkflowTags: "mcp,prod",
+        mcpEntryPathPattern: "__mcp__/*",
         mcpCacheTtlMs: "5000",
       },
       NO_ENV,
@@ -139,6 +220,7 @@ describe("parseMcpSettings", () => {
     expect(settings?.policy.allowTools).toEqual(["search_workflows", "execute_workflow"]);
     expect(settings?.policy.denyTools).toEqual(["*credential*"]);
     expect(settings?.policy.workflowTags).toEqual(["mcp", "prod"]);
+    expect(settings?.policy.entryPathPattern).toBe("__mcp__/*");
     expect(settings?.cacheTtlMs).toBe(5000);
   });
 
@@ -151,6 +233,20 @@ describe("parseMcpSettings", () => {
     expect(settings?.enforce).toBe("warn");
     expect(settings?.policy.workflowTags).toEqual(["mcp"]);
     expect(settings?.cacheTtlMs).toBe(60_000);
+  });
+
+  test("an unset entry-path pattern stays absent rather than becoming an empty glob", () => {
+    // An empty string would match nothing, silently gating everything off.
+    const settings = parseMcpSettings({ mcpEnforce: "error", mcpEntryPathPattern: "  " }, NO_ENV);
+    expect(settings?.policy.entryPathPattern).toBeUndefined();
+  });
+
+  test("the entry-path pattern also comes from the environment", () => {
+    const settings = parseMcpSettings({}, {
+      N8N_MCP_ENFORCE: "error",
+      N8N_MCP_ENTRY_PATH_PATTERN: "__mcp__/*",
+    } as NodeJS.ProcessEnv);
+    expect(settings?.policy.entryPathPattern).toBe("__mcp__/*");
   });
 
   test("a bad value is rejected at startup, naming the flag", () => {

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -26,12 +26,32 @@ const TOOLS = [
   { name: "list_credentials", description: "List credentials" },
 ];
 
+/** A trigger node as n8n stores it. */
+const trigger = (name: string, type: string, path?: string, disabled = false) => ({
+  id: `n-${name}`,
+  name,
+  type,
+  typeVersion: 1,
+  position: [0, 0] as [number, number],
+  parameters: path === undefined ? {} : { path },
+  ...(disabled ? { disabled: true } : {}),
+});
+
+const WEBHOOK = "n8n-nodes-base.webhook";
+const FORM = "n8n-nodes-base.formTrigger";
+const SCHEDULE = "n8n-nodes-base.scheduleTrigger";
+
 const WORKFLOWS = [
   {
     id: "wf-open",
     name: "[mcp] hospital lookup",
     active: true,
-    nodes: [],
+    // The shape the convention asks for: the agent-facing entry first, the
+    // repository's test entry after it.
+    nodes: [
+      trigger("[MCP] entry", FORM, "__mcp__/hospital-lookup"),
+      trigger("[CLI Test] entry", WEBHOOK, "__cli-test__/uuid-1"),
+    ],
     connections: {},
     settings: { availableInMCP: true },
     tags: [{ id: "1", name: "mcp" }],
@@ -40,7 +60,7 @@ const WORKFLOWS = [
     id: "wf-internal",
     name: "payroll export",
     active: true,
-    nodes: [],
+    nodes: [trigger("[CLI Test] entry", WEBHOOK, "__cli-test__/uuid-2")],
     connections: {},
     settings: {},
     tags: [{ id: "2", name: "finance" }],
@@ -49,9 +69,20 @@ const WORKFLOWS = [
     id: "wf-tagged-only",
     name: "[mcp] draft tool",
     active: true,
-    nodes: [],
+    // Tagged, but its only entry is the test hook — no agent-facing path.
+    nodes: [trigger("[CLI Test] entry", WEBHOOK, "__cli-test__/uuid-3")],
     connections: {},
     settings: {},
+    tags: [{ id: "1", name: "mcp" }],
+  },
+  {
+    id: "wf-cron",
+    name: "[mcp] nightly digest",
+    active: true,
+    // Tagged and MCP-enabled, but a Schedule trigger carries no path at all.
+    nodes: [trigger("Every night", SCHEDULE)],
+    connections: {},
+    settings: { availableInMCP: true },
     tags: [{ id: "1", name: "mcp" }],
   },
 ];
@@ -349,6 +380,104 @@ describe("MCP gate: failure and enforcement modes", () => {
   });
 });
 
+describe("MCP gate: entry-trigger path scope", () => {
+  const ENTRY = { entryPathPattern: "__mcp__/*" };
+
+  async function execute(workflowId: string): Promise<Record<string, unknown>> {
+    return await call("tools/call", { name: "execute_workflow", arguments: { workflowId } });
+  }
+
+  function refusal(reply: Record<string, unknown>): string | null {
+    const result = reply.result as { isError?: boolean; content?: Array<{ text: string }> };
+    return result?.isError ? (result.content?.[0]?.text ?? "") : null;
+  }
+
+  test("a workflow whose entry declares the agent-facing path is reachable", async () => {
+    start(policy(ENTRY));
+    expect(refusal(await execute("wf-open"))).toBeNull();
+  });
+
+  test("a workflow whose only entry is the repository's test hook is not", async () => {
+    // The point of the path rule: `[CLI Test]` is a real, working webhook, so
+    // trigger *type* cannot tell it apart from an agent-facing one. The path can.
+    start(policy(ENTRY));
+    expect(refusal(await execute("wf-tagged-only"))).toContain(
+      "outside the agent-facing namespace",
+    );
+  });
+
+  test("a Schedule-only workflow falls out without being special-cased", async () => {
+    // Schedule triggers carry no path at all, so a cron job cannot opt itself
+    // in by accident — an agent firing a nightly batch on demand is exactly the
+    // surprise this avoids.
+    start(policy(ENTRY));
+    expect(refusal(await execute("wf-cron"))).toContain("declares no path");
+  });
+
+  test("the entry is the FIRST supported trigger, mirroring n8n", async () => {
+    // wf-open lists the agent entry first and the test hook second. Were the
+    // gate to scan for *any* matching trigger instead of the first one, the
+    // ordering that decides n8n's behaviour would stop mattering here — and the
+    // two would disagree.
+    start(policy({ entryPathPattern: "__cli-test__/*" }));
+    expect(refusal(await execute("wf-open"))).toContain("__mcp__/hospital-lookup");
+  });
+
+  test("tags and entry path are both required when both are configured", async () => {
+    start(policy({ workflowTags: ["finance"], entryPathPattern: "__mcp__/*" }));
+    const text = refusal(await execute("wf-open"));
+    expect(text).toContain("finance");
+  });
+
+  test("the refusal names the workflow and the reason, not just 'no'", async () => {
+    start(policy(ENTRY));
+    const text = refusal(await execute("wf-cron"));
+    expect(text).toContain("wf-cron");
+    expect(text).toContain("Every night");
+  });
+});
+
+describe("MCP gate: narrowing search_workflows", () => {
+  function sentArgs(): Record<string, unknown> | undefined {
+    const hit = upstream.captured.find((c) => c.body.includes("search_workflows"));
+    if (!hit) return undefined;
+    return JSON.parse(hit.body).params?.arguments;
+  }
+
+  test("the policy's tags are added to the agent's own filter", async () => {
+    // n8n answers search_workflows with everything the token's owner can read.
+    // Its `tags` filter is an AND, so merging the policy's tags in can only
+    // shrink the result — the one part of the listing surface that can be closed.
+    start(policy({ workflowTags: ["mcp"] }));
+    await call("tools/call", {
+      name: "search_workflows",
+      arguments: { query: "hospital", tags: ["ops"] },
+    });
+    expect(sentArgs()?.tags).toEqual(["ops", "mcp"]);
+    expect(sentArgs()?.query).toBe("hospital");
+  });
+
+  test("tags are added when the agent asked for none", async () => {
+    start(policy({ workflowTags: ["mcp"] }));
+    await call("tools/call", { name: "search_workflows", arguments: {} });
+    expect(sentArgs()?.tags).toEqual(["mcp"]);
+  });
+
+  test("a policy with no tags leaves the call alone", async () => {
+    // An entry-path policy has no equivalent argument upstream, so the listing
+    // stays wide. Better to leave it visibly untouched than to fake a filter.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    await call("tools/call", { name: "search_workflows", arguments: { query: "x" } });
+    expect(sentArgs()).toEqual({ query: "x" });
+  });
+
+  test("warn mode does not rewrite the call either", async () => {
+    start(policy({ workflowTags: ["mcp"] }), "warn");
+    await call("tools/call", { name: "search_workflows", arguments: {} });
+    expect(sentArgs()).toEqual({});
+  });
+});
+
 describe("MCP gate: startup", () => {
   async function readyz(): Promise<{ status: number; body: string }> {
     const res = await fetch(`http://127.0.0.1:${proxy.port}/readyz`);
@@ -416,6 +545,16 @@ describe("MCP gate: startup", () => {
     start(policy({ workflowTags: ["mcp"] }));
 
     expect((await waitForReady()).status).toBe(200);
+  });
+
+  test("enforce=off does not paginate the whole instance for nothing", async () => {
+    // A gate someone turned off should not walk every page of
+    // /api/v1/workflows at startup, nor log a credential failure for a lookup
+    // no request will read.
+    start(policy({ workflowTags: ["mcp"] }), "off");
+    await waitForReady();
+    await call("tools/list");
+    expect(listCalls()).toBe(0);
   });
 
   test("no workflow scope means no prefetch at all", async () => {


### PR DESCRIPTION
## The problem

n8n does not let an MCP caller choose a trigger. `execute_workflow` maps the supplied input onto the **first non-disabled Schedule/Webhook/Form/Chat node in the workflow's `nodes` array** and starts there:

```ts
// n8n: packages/cli/src/modules/mcp/mcp.utils.ts
return nodes.find((node) => triggerNodeTypes.includes(node.type) && !node.disabled);

// packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
/** LIMITATION: Does not properly support workflows with multiple triggers. */
```

Node order decides, and node order is invisible in a diff. A workflow can be exposed exactly as intended and still be entered through a test hook, or through a nightly Schedule that an agent can now fire on demand.

Trigger *type* cannot separate those. In any repository that gives every workflow a test webhook by convention, the triggers all look alike. The **path** can.

## `--mcp-entry-path-pattern`

Gates on the path that the entry trigger declares.

```bash
n8n-cli proxy --mcp-enforce error \
  --mcp-workflow-tags mcp \
  --mcp-entry-path-pattern '__mcp__/*'
```

- A **Schedule** trigger carries no path, so a scheduled job cannot opt itself in by accident.
- A webhook or form node that never had one set carries none either — n8n falls back to the `webhookId`. **Declaring the path is what opts a workflow in**, so the rule fails closed.
- Matching is against the *first* supported trigger, not any of them, precisely so this and n8n agree about which node runs.

The proxy stays agnostic about trigger type — the definitions decide whether the agent-facing entry is a Form, a Webhook or a Chat trigger. (A Form trigger is worth preferring: `get_workflow_details` renders its `formFields` as an input schema, where a webhook entry shows the agent nothing about the payload shape.)

## Three things ride along

- **Per-workflow facts instead of two id sets.** The cached index now keeps `{name, description, tags, availableInMCP, entry}`, so a refusal names the reason — which tag is missing, which node would have run — rather than only "no".
- **`search_workflows` is narrowed, not refused.** Its `tags` argument is an AND — the same semantics as the policy — so the policy's tags are merged into whatever the agent asked for. This closes the listing leak for tag policies. An entry-path-only policy has no equivalent argument upstream; the README says so rather than pretending otherwise.
- **`mcp-exposure` takes the same glob, from the same definition** (`src/common/mcp.ts`), so CI and the gate cannot disagree about which workflows are reachable.

## What this deliberately does not do

`fmt` does not hoist the entry trigger — and the lint message says so. `fmt` re-derives node order from canvas position, so advice to "move the node up in the file" would not survive the next format. Making a formatter silently change which trigger an agent reaches is worse than leaving the check advisory.

## Quality gate

`tests/cli/proxy-flags-documented.test.ts` asserts the `--mcp-*` flags and the README describe the same proxy, **in both directions**, and that every flag names its env var.

Documented-but-deleted flags were a real defect twice during this work. An operator copies one into a deployment and the process dies at startup with "unknown option"; the reverse hides the controls the feature exists to offer. The check scans the whole README, so naming a removed flag even in prose fails it — intentional, since a reader copies what they see.

## Self-review pass

A `code-review high` pass turned up six findings, all fixed. One was a regression from #66 rather than from this branch:

**`ThreeWayDetector` compared `description` symmetrically.** Its comment justified that with "this runs over base/local/remote revisions of the same definition" — false for `remote`, which comes from the n8n API while `base` comes from the git base ref. So for every definition written before description support, a description typed in the n8n UI read as a *remote* change, and paired with any local edit produced a **conflict needing `--force`** where the same apply used to return `update`. Nothing was ever at risk — apply does not send a description the local file has not declared — so the 2-way path's rule was right and the 3-way path contradicted it. Now judged on the base→local edge only, with a regression test.

The other five, all in this branch:

- **The workflow index fetched `/api/v1/workflows` with no credential of its own.** An MCP client authenticates to the *MCP* endpoint, and `bearer-token-inject` is path-scoped, so on a deployment where the proxy holds the credentials that lookup 401s and the gate fails closed into a total outage rather than a policy. The README recipe now shows `api-key-inject` and says why; a 401 there now says it too.
- That URL was built from `--upstream`, which `forwardRequest` prepends again — an upstream carrying a base path was fetched twice-prefixed.
- `prefetch()` ran at `--mcp-enforce off`, paginating the instance at startup for a result nothing reads.
- A policy configured without `--mcp-enforce` was silently discarded. Off by default is right; ignoring flags someone wrote is not. It now refuses to start.
- The out-of-scope refusal now says the named id may be one the call merely *referenced* — a sub-workflow — rather than the one it targeted.

## Coupling to be aware of

The entry resolution mirrors n8n's `findMcpSupportedTrigger`. If n8n adds a supported trigger type, a workflow whose new-type trigger sorts earlier is entered somewhere this release does not predict. The list is in one place and is worth revisiting on an n8n upgrade; it is called out in the README and in the source.

## Testing

- `tests/proxy/proxy.mcp-gate.test.ts` — entry-path scope end to end: the agent-facing entry passes, a test hook does not, a Schedule-only workflow falls out without being special-cased, the entry is the *first* trigger, tags and path AND together, and the refusal names workflow and reason. Plus `search_workflows` narrowing (merged with the agent's own tags, added when it asked for none, untouched under a path-only policy, untouched in `warn`).
- `tests/proxy/mcp-config.test.ts` — `findEntryTrigger` against array order, disabled nodes, Schedule-without-path, webhook-without-path, unsupported types; flag/env parsing; the empty-pattern case.
- `tests/lint/rules/mcp-exposure.test.ts` — the same two nodes in both orders, which is the whole point of the rule.

Local gates green: `biome check`, `tsc --noEmit`, `bun test` (1535 pass), `check-third-party-licenses`, `make build` + `size-check`.

Released as **v2.12.1**.
