### PR TITLE
feat(mcp): make what an agent can see the same set as what it can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ Four things happen, and only the first is cosmetic:
 1. **`tools/list` is filtered** — a withheld verb never reaches the model's context.
 2. **`tools/call` on a withheld verb is refused at the proxy**, and never reaches n8n. Hiding a tool an agent can still call is theatre; the refusal comes back as a JSON-RPC `Unknown tool` error.
 3. **`tools/call` naming a workflow outside the scope is refused**, with an MCP tool result carrying `isError: true` and the reason — which tag is missing, or which trigger n8n would have entered it through. The agent is told *why* rather than seeing a transport failure.
-4. **`search_workflows` is narrowed rather than refused.** Its `tags` argument is an AND, the same semantics as the policy, so the policy's tags are merged into whatever the agent asked for. Without this an agent still sees the name and description of every workflow the token's owner can read.
+4. **`search_workflows` is narrowed rather than refused**, so that what an agent can see and what it can run are the same set. Its results are filtered on the way back against the same policy that governs `tools/call` — by tag, by entry path, or both. Where the policy has tags, they are also merged into the request's own `tags` argument (an AND, the same semantics), which saves n8n from serving rows that would be dropped anyway.
 
 Everything else on the path — `initialize`, notifications, the server-to-client `GET` stream, session teardown — is forwarded untouched, and both `application/json` and `text/event-stream` (Streamable HTTP) replies are handled.
 
@@ -1140,7 +1140,7 @@ The matching mirrors n8n's `findMcpSupportedTrigger`. That is a coupling: if n8n
 
 > **Build `--mcp-allow-tools` from a real `tools/list` against your own instance.** n8n renames these tools between versions — a 2.32.5 instance serves `list_tags`, `get_execution`, `search_executions` and `prepare_test_pin_data`, where later code renames them to `list_workflow_tags`, `get_workflow_execution`, `search_workflow_executions` and `prepare_workflow_pin_data`. Neither the documentation nor a checkout of n8n's default branch tells you which set *your* server publishes. A name that does not exist costs nothing; a real tool missing from the allowlist is silently withheld, so listing both spellings is the safe move.
 
-**What it does not do:** with `--mcp-workflow-tags` set, `search_workflows` is narrowed to those tags — but an **entry-path-only** policy has no equivalent argument upstream, so the listing stays wide: an agent still sees the name and description of every workflow the connecting identity can read. Pair the path rule with a tag, or withhold `search_workflows` itself, if that listing is the problem.
+**What it does not do:** only `search_workflows` is filtered on the way back. The execution-history tools (`search_executions`, `get_execution`) report on workflows the policy does not expose, so withhold them unless that history is meant to be readable. And `count` in a filtered page is the upstream count minus what was dropped, which is exact for a single page and an estimate when n8n reports a total across pages.
 
 > As with every other check here, this is an enforcement boundary only if direct access to n8n is blocked at the network level. A client that can reach `/mcp-server/` on the instance itself bypasses the proxy.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -1,7 +1,7 @@
 /**
  * The MCP gate: an operator's policy in front of n8n's MCP endpoint.
  *
- * Three things happen here, and only the first is cosmetic:
+ * Four things happen here, and only the first is cosmetic:
  *
  *   1. `tools/list` results are filtered, so a tool the policy withholds never
  *      appears in the model's context at all.
@@ -11,6 +11,8 @@
  *      workflow matches the policy, which is the part n8n's own per-workflow
  *      toggle cannot give you: it is set in the UI, by anyone with edit rights,
  *      and never shows up in a review.
+ *   4. `search_workflows` results are filtered against that same policy, so the
+ *      set an agent can see is the set it can run.
  *
  * Everything else on the MCP path — `initialize`, `notifications/*`, the
  * server-to-client `GET` stream, session teardown — is forwarded untouched.
@@ -131,25 +133,45 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
 
   const response = await forward(req, narrowedJSON ?? rawJSON, pathname, deps);
 
-  // Only a tools/list reply needs rewriting, and only when the policy actually
-  // withholds something. Everything else streams back untouched.
-  //
-  // Under `warn` the list is left alone as well: the point of warn is to find
-  // out what the policy would break, and a client that never sees a tool cannot
-  // exercise it, so the log an operator is rolling out against would stay empty.
-  const listsTools = parsed.messages.some((m) => m.method === "tools/list");
-  if (!listsTools || !filtersTools(deps.policy) || deps.enforce !== "error") return response;
+  // Under `warn` nothing is rewritten: the point of warn is to find out what
+  // the policy would break, and a client that never sees a tool or a workflow
+  // cannot exercise it, so the log an operator is rolling out against would
+  // stay empty.
+  if (deps.enforce !== "error") return response;
 
-  return filterToolsListResponse(response, deps, pathname);
+  const tools = filtersTools(deps.policy) && parsed.messages.some((m) => m.method === "tools/list");
+  const searchIds = hasWorkflowScope(deps.policy)
+    ? searchCallIds(parsed.messages)
+    : new Set<string | number>();
+  if (!tools && searchIds.size === 0) return response;
+
+  return filterResponse(response, deps, pathname, { tools, searchIds });
+}
+
+/**
+ * Ids of the `search_workflows` calls in a request.
+ *
+ * The reply to a `tools/call` does not name the tool, and `{data, count}` is the
+ * envelope several n8n tools share — so the replies to filter are identified by
+ * the id they answer, not by their shape.
+ */
+function searchCallIds(messages: JsonRpcMessage[]): Set<string | number> {
+  const ids = new Set<string | number>();
+  for (const message of messages) {
+    if (toolCallName(message) !== "search_workflows") continue;
+    if (typeof message.id === "string" || typeof message.id === "number") ids.add(message.id);
+  }
+  return ids;
 }
 
 /**
  * Adds the policy's tags to a `search_workflows` call, or returns null when
  * there is nothing to add.
  *
- * Only tags: the entry-path rule has no equivalent argument upstream, so a
- * path-only policy still leaves the listing wide. Say so in the README rather
- * than pretending otherwise.
+ * Only tags: the entry-path rule has no equivalent argument upstream. That is
+ * why this is an optimisation and not the enforcement — narrowing the request
+ * saves n8n from serving rows that would be dropped anyway, and
+ * `filterResponse` is what actually decides the listing.
  */
 function narrowSearchArguments(
   parsed: { messages: JsonRpcMessage[]; isBatch: boolean },
@@ -255,41 +277,81 @@ async function refuse(
 }
 
 /**
- * Buffers a tools/list reply and drops the tools the policy withholds.
+ * Buffers a reply and drops what the policy withholds — tools from a
+ * `tools/list`, workflows from a `search_workflows`.
+ *
+ * The listing half is the one n8n gives no way to close. `search_workflows`
+ * returns the name and description of every workflow the token's owner can
+ * read, and its only relevant filter is `tags` — so a policy written as a path
+ * convention has nothing to push upstream, and the result has to be narrowed on
+ * the way back. Doing it here is what makes "visible" and "executable" the same
+ * set, whichever predicate the policy is written in.
  *
  * Buffering is safe here and only here: under Streamable HTTP a POST is
- * answered by a stream that closes once the reply is delivered, and a tool list
- * is a few kilobytes. The long-lived server-to-client stream is the `GET`, which
- * never reaches this function. Note that `--upstream-timeout` bounds the fetch,
- * not this read, so an upstream that opens a response and then stalls holds the
- * request open — the same exposure the rest of the proxy has when it reads a
- * body.
+ * answered by a stream that closes once the reply is delivered, and both a tool
+ * list and a page of search results are a few kilobytes. The long-lived
+ * server-to-client stream is the `GET`, which never reaches this function. Note
+ * that `--upstream-timeout` bounds the fetch, not this read, so an upstream that
+ * opens a response and then stalls holds the request open — the same exposure
+ * the rest of the proxy has when it reads a body.
  */
-async function filterToolsListResponse(
+async function filterResponse(
   response: Response,
   deps: McpGateDeps,
   pathname: string,
+  plan: { tools: boolean; searchIds: Set<string | number> },
 ): Promise<Response> {
+  // By now `refuse()` has already resolved the index for any workflow-scoped
+  // call in this request, so this is a cache read. It can still fail on a
+  // request whose only tool call is the search itself.
+  let allowed: ReadonlySet<string> | null = null;
+  if (plan.searchIds.size > 0) {
+    try {
+      allowed = (await deps.index.sets()).allowed;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      log(deps, pathname, `workflow index unavailable, withholding search results: ${reason}`);
+    }
+  }
+
   const contentType = response.headers.get("content-type");
   const body = await response.text();
 
-  let removed = 0;
+  let removedTools = 0;
+  let removedWorkflows = 0;
   const rewritten = rewriteBody(body, contentType, (message) => {
-    const tools = message.result?.tools;
-    if (!Array.isArray(tools)) return message;
-    const kept = tools.filter((tool) => {
-      const name = (tool as { name?: unknown })?.name;
-      if (typeof name !== "string") return true;
-      const allowed = isToolAllowed(deps.policy, name);
-      if (!allowed) removed++;
-      return allowed;
+    if (plan.tools && Array.isArray(message.result?.tools)) {
+      const tools = message.result.tools;
+      const kept = tools.filter((tool) => {
+        const name = (tool as { name?: unknown })?.name;
+        if (typeof name !== "string") return true;
+        const ok = isToolAllowed(deps.policy, name);
+        if (!ok) removedTools++;
+        return ok;
+      });
+      if (kept.length === tools.length) return message;
+      return { ...message, result: { ...message.result, tools: kept } };
+    }
+
+    if (message.id === undefined || message.id === null || !plan.searchIds.has(message.id)) {
+      return message;
+    }
+    if (!allowed) {
+      // Fail closed, like a refused call: an unfiltered listing is the leak
+      // this function exists to prevent.
+      return toolErrorResult(
+        message.id,
+        "This proxy could not verify which workflows are available over MCP. Try again shortly.",
+      );
+    }
+    return filterSearchResult(message, allowed, (n) => {
+      removedWorkflows += n;
     });
-    if (kept.length === tools.length) return message;
-    return { ...message, result: { ...message.result, tools: kept } };
   });
 
-  if (removed > 0) {
-    log(deps, pathname, `withheld ${removed} tool(s) from tools/list`);
+  if (removedTools > 0) log(deps, pathname, `withheld ${removedTools} tool(s) from tools/list`);
+  if (removedWorkflows > 0) {
+    log(deps, pathname, `withheld ${removedWorkflows} workflow(s) from search_workflows`);
   }
 
   const headers = new Headers(response.headers);
@@ -300,6 +362,90 @@ async function filterToolsListResponse(
     statusText: response.statusText,
     headers,
   });
+}
+
+/**
+ * Drops out-of-policy workflows from a `search_workflows` result.
+ *
+ * n8n sends the same `{data, count}` payload twice — once as `structuredContent`
+ * and once JSON-encoded in a text content block — and a client may read either.
+ * Both are rewritten, or the names filtered out of one arrive through the other.
+ */
+function filterSearchResult(
+  message: JsonRpcMessage,
+  allowed: ReadonlySet<string>,
+  count: (removed: number) => void,
+): JsonRpcMessage {
+  const result = message.result;
+  if (!result) return message;
+
+  const next: Record<string, unknown> = { ...result };
+  let changed = false;
+  let removed = 0;
+
+  const structured = filterPayload(result.structuredContent, allowed);
+  if (structured) {
+    next.structuredContent = structured.payload;
+    removed = Math.max(removed, structured.removed);
+    changed = true;
+  }
+
+  if (Array.isArray(result.content)) {
+    const content = result.content.map((block) => {
+      const text = (block as { text?: unknown })?.text;
+      if (typeof text !== "string") return block;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return block;
+      }
+      const filtered = filterPayload(parsed, allowed);
+      if (!filtered) return block;
+      removed = Math.max(removed, filtered.removed);
+      changed = true;
+      return { ...(block as object), text: JSON.stringify(filtered.payload) };
+    });
+    if (changed) next.content = content;
+  }
+
+  if (!changed) return message;
+  count(removed);
+  return { ...message, result: next };
+}
+
+/**
+ * Filters one `{data, count}` payload, or returns null when it is not one.
+ *
+ * An entry whose `id` is not an allowed workflow goes, and so does one carrying
+ * no usable id: the point is that nothing reaches the model that it could not
+ * then execute, and an entry the gate cannot identify is not identifiable at
+ * `tools/call` time either.
+ *
+ * `count` is decremented rather than recomputed. n8n reports the number of
+ * matches, which may exceed the page in hand; subtracting what was dropped is
+ * right when it is a page count and the closest honest answer when it is a
+ * total. Leaving it alone would have an agent paging after workflows it is
+ * never going to be shown.
+ */
+function filterPayload(
+  payload: unknown,
+  allowed: ReadonlySet<string>,
+): { payload: Record<string, unknown>; removed: number } | null {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+  const record = payload as Record<string, unknown>;
+  if (!Array.isArray(record.data)) return null;
+
+  const kept = record.data.filter((item) => {
+    const id = (item as { id?: unknown })?.id;
+    return typeof id === "string" && allowed.has(id);
+  });
+  const removed = record.data.length - kept.length;
+  if (removed === 0) return null;
+
+  const next: Record<string, unknown> = { ...record, data: kept };
+  if (typeof record.count === "number") next.count = Math.max(0, record.count - removed);
+  return { payload: next, removed };
 }
 
 function jsonRpcResponse(messages: JsonRpcMessage[], isBatch: boolean): Response {

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -130,6 +130,28 @@ function mcpReply(request: { id?: unknown; method?: string; params?: { name?: st
   if (request.method === "tools/list") {
     return { jsonrpc: "2.0", id: request.id, result: { tools: TOOLS } };
   }
+  if (request.params?.name === "search_workflows") {
+    // The shape a live 2.32.5 instance returns: the same {data, count} payload
+    // twice, once structured and once JSON-encoded in a text block.
+    const payload = {
+      data: WORKFLOWS.map((w) => ({
+        id: w.id,
+        name: w.name,
+        description: `what ${w.name} does`,
+        availableInMCP: (w.settings as { availableInMCP?: boolean }).availableInMCP === true,
+        tags: w.tags,
+      })),
+      count: WORKFLOWS.length,
+    };
+    return {
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+        structuredContent: payload,
+      },
+    };
+  }
   return {
     jsonrpc: "2.0",
     id: request.id,
@@ -475,6 +497,108 @@ describe("MCP gate: narrowing search_workflows", () => {
     start(policy({ workflowTags: ["mcp"] }), "warn");
     await call("tools/call", { name: "search_workflows", arguments: {} });
     expect(sentArgs()).toEqual({});
+  });
+});
+
+describe("MCP gate: filtering search_workflows results", () => {
+  /** The two channels n8n sends the same payload down, read separately. */
+  function listed(reply: Record<string, unknown>): {
+    structured: string[];
+    text: string[];
+    count: number;
+  } {
+    const result = reply.result as {
+      structuredContent?: { data?: Array<{ id: string }>; count?: number };
+      content?: Array<{ text?: string }>;
+    };
+    const text = JSON.parse(result.content?.[0]?.text ?? "{}") as {
+      data?: Array<{ id: string }>;
+      count?: number;
+    };
+    return {
+      structured: (result.structuredContent?.data ?? []).map((w) => w.id),
+      text: (text.data ?? []).map((w) => w.id),
+      count: result.structuredContent?.count ?? -1,
+    };
+  }
+
+  async function search(args: unknown = {}): Promise<Record<string, unknown>> {
+    return await call("tools/call", { name: "search_workflows", arguments: args });
+  }
+
+  test("an entry-path policy narrows the listing, with no tag involved", async () => {
+    // The listing is the half n8n cannot close: its only relevant filter is
+    // `tags`, so without this a path-based policy would let an agent read the
+    // name and description of every workflow before finding out it may run one.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    expect(listed(await search()).structured).toEqual(["wf-open"]);
+  });
+
+  test("both channels are rewritten, and they agree", async () => {
+    // Filtering one and not the other would send the names out through the
+    // channel that was left alone.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    const seen = listed(await search());
+    expect(seen.text).toEqual(seen.structured);
+  });
+
+  test("count follows the rows that were dropped", async () => {
+    // Left alone, an agent pages after workflows it will never be shown.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    expect(listed(await search()).count).toBe(1);
+  });
+
+  test("a tag policy filters the reply as well as narrowing the request", async () => {
+    // The upstream `tags` argument is an optimisation; this is the enforcement.
+    // The mock ignores the argument, so what comes back is the unfiltered list.
+    start(policy({ workflowTags: ["mcp"] }));
+    expect(listed(await search()).structured).toEqual(["wf-open", "wf-tagged-only", "wf-cron"]);
+  });
+
+  test("filtering survives SSE framing", async () => {
+    await upstream.server.stop(true);
+    upstream = startMockUpstream({ sse: true });
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    expect(listed(await search()).structured).toEqual(["wf-open"]);
+  });
+
+  test("a page where everything is out of scope comes back empty, not refilled", async () => {
+    start(policy({ entryPathPattern: "__nothing__/*" }));
+    const seen = listed(await search());
+    expect(seen.structured).toEqual([]);
+    expect(seen.count).toBe(0);
+  });
+
+  test("a tools-only policy leaves the listing alone", async () => {
+    // Nothing has been said about which workflows are reachable, so filtering
+    // the reply would be inventing a policy the operator did not write.
+    start(policy({ allowTools: ["search_workflows"] }));
+    expect(listed(await search()).structured).toHaveLength(WORKFLOWS.length);
+  });
+
+  test("warn mode returns the listing untouched", async () => {
+    start(policy({ entryPathPattern: "__mcp__/*" }), "warn");
+    expect(listed(await search()).structured).toHaveLength(WORKFLOWS.length);
+  });
+
+  test("another tool's reply is not filtered by resemblance", async () => {
+    // `{data, count}` is a shared envelope. The reply to filter is identified
+    // by the id it answers, not by looking like a search result.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    const reply = await call("tools/call", { name: "search_projects", arguments: {} });
+    const result = reply.result as { content: Array<{ text: string }> };
+    expect(result.content[0]?.text).toBe("ran search_projects");
+  });
+
+  test("an unreadable workflow list withholds the listing rather than passing it", async () => {
+    await upstream.server.stop(true);
+    upstream = startMockUpstream({ listFails: true });
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+
+    const reply = await search();
+    const result = reply.result as { isError?: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("could not verify");
   });
 });
 


### PR DESCRIPTION
Contains #68's commit as well — merge #68 first, then rebase this onto main (the `package.json` version line conflicts otherwise).

## The hole

The gate already refuses `execute_workflow` for a workflow outside the policy, by tag or by the path its entry trigger declares. **Execution control was never the gap.** `search_workflows` was.

n8n answers `search_workflows` with the id, name and description of every workflow the connecting identity can read. Its only relevant filter is `tags`, so a policy written as a path convention — `--mcp-entry-path-pattern '__mcp__/*'` — had nothing to push upstream. The agent read the whole catalogue, picked something, and only then learned it was not allowed to run it.

Two costs: the names and descriptions themselves, and an agent that keeps trying doors that are locked.

## The fix

Filter the reply against the same policy that governs `tools/call`. The facts needed (id, tags, entry trigger) are already in the index the gate keeps, so no new fetch.

Tag push-down (`narrowSearchArguments`) stays, demoted to what it always was — an optimisation that saves n8n from serving rows that would be dropped anyway.

```
--mcp-entry-path-pattern '__mcp__/*'    # now closes both listing and execution
```

Tags become optional. Before this, a path-only policy needed a tag bolted on to close the listing.

## Details that decide correctness

- **Both channels are rewritten.** n8n sends the same `{data, count}` payload twice — as `structuredContent` and JSON-encoded in a text content block — and a client may read either. Filtering one leaks the names through the other. n8n 2.32.5 returns exactly that; the mock now reproduces the shape.
- **Replies are matched by the id they answer, not by shape.** A `tools/call` reply does not name its tool, and `{data, count}` is an envelope several n8n tools share, so shape-sniffing would filter the wrong results. `tools/list` gets away with it; this cannot.
- **`count` is decremented by what was dropped.** Exact for a single page, the closest honest answer when n8n reports a total. Left alone, an agent pages after workflows it will never be shown.
- **Fails closed.** If the workflow index is unreadable the listing is withheld with an `isError` result, matching how a workflow-scoped `tools/call` behaves — an unfiltered listing is the leak this exists to prevent.
- **An entry with no usable id is dropped**, not kept: what the model sees must be what it could execute.
- **`warn` leaves everything alone**, like the rest of the gate.

## Known limits, stated in the README

`search_executions` / `get_execution` report on workflows the policy does not expose. Withhold them via `--mcp-deny-tools` unless that history is meant to be readable. Filtering them would need per-execution workflow resolution and is not in this change.

## Tests

11 new cases in `tests/proxy/proxy.mcp-gate.test.ts`: both channels agree, count follows, SSE framing, an all-dropped page comes back empty rather than refilled, a tools-only policy is left alone, warn is untouched, another tool's `{data, count}` reply is not filtered by resemblance, and an unreadable index withholds.

Full suite green (1545 pass), biome and tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiJorhtfyncc8W1ii1MHXU
