### PR TITLE
feat(mcp): publish a small get_workflow_entry beside n8n's own tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,24 @@ The matching mirrors n8n's `findMcpSupportedTrigger`. That is a coupling: if n8n
 
 > **`fmt` re-derives node order from position.** `n8n-cli fmt` writes nodes sorted by canvas position (left to right, then top to bottom), so on a formatted workflow the entry is whichever matching trigger sits leftmost — not whichever appears first in the file you edited. It also recomputes those positions with a graph layout, which places every trigger in the same column and orders them by a heuristic you do not control. Two ways out: keep the agent-facing trigger's path unique so the lint rule catches any drift on the next PR, or keep MCP-exposed definitions in a format `fmt` does not touch (`.ts`, where node order is explicit). `fmt` does not know about this glob today.
 
+### `get_workflow_entry` — a tool the proxy adds
+
+`execute_workflow`'s own description tells the model to call `get_workflow_details` first, and it has to: `inputs` is a union discriminated by trigger type (`chat` / `form` / `webhook`), nothing in `search_workflows` says which one a workflow takes, and picking wrong makes n8n execute with empty data rather than fail. So that lookup runs before every execution — and n8n answers it with the whole workflow definition. Measured against a live instance, one workflow came back as **116 KB**, of which a caller that only runs workflows reads three fields.
+
+Name `get_workflow_entry` in `--mcp-allow-tools` and the gate publishes a small tool of its own beside n8n's:
+
+```json
+{ "id": "...", "name": "...", "description": "...", "tags": [],
+  "entry": { "name": "[MCP] entry", "type": "n8n-nodes-base.formTrigger",
+             "path": "__mcp__/...", "parameters": { "formFields": {} } } }
+```
+
+`entry` is resolved exactly as reachability is, so the trigger reported is the node n8n would start from, and its `parameters` carry what building `inputs` needs — a form trigger's `formFields`, a webhook's `httpMethod`.
+
+**It adds, it does not rewrite.** n8n's `get_workflow_details` keeps behaving exactly as n8n serves it; an operator who wants only the small one leaves the large one out of the allowlist. Nothing here makes this proxy responsible for a response shape it does not own. It also costs no upstream call — the gate already holds these facts, because resolving the entry trigger is how it decides reachability. The same scope applies: a workflow outside the policy is refused with the reason, not described.
+
+It must be named in `--mcp-allow-tools` rather than merely permitted by an empty one, so upgrading the proxy never adds a tool to a client's list on its own.
+
 **Rollout:** `--mcp-enforce warn` logs every decision and changes nothing — the tool list is *not* filtered in warn mode either, because a client that never sees a tool cannot exercise it and the log you are rolling out against would stay empty.
 
 **Fail-closed.** A tool call whose workflow cannot be resolved — because the upstream list is unreadable — is refused, as is a workflow-scoped call that names no workflow. There is no switch to open those: a gate that opens during an outage is not a gate, and `warn` already covers "measure, don't block".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.12.4",
+  "version": "2.13.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/common/mcp.ts
+++ b/src/common/mcp.ts
@@ -38,6 +38,14 @@ export interface EntryTrigger {
    * path convention should be written against.
    */
   path?: string;
+  /**
+   * The trigger's own parameters, as n8n stores them.
+   *
+   * Carried so a caller can be told what to send without reading the workflow:
+   * a Form trigger's `formFields` and a Webhook's `httpMethod` both live here,
+   * and they are what `execute_workflow`'s `inputs` argument has to match.
+   */
+  parameters?: Record<string, unknown>;
 }
 
 /** The shape this needs from a node; deliberately looser than `Node`. */
@@ -63,10 +71,14 @@ export function findEntryTrigger(
     if (node.disabled === true) continue;
     if (typeof node.type !== "string" || !MCP_ENTRY_TRIGGER_TYPES.includes(node.type)) continue;
     const path = node.parameters?.path;
+    const parameters = node.parameters;
     return {
       name: typeof node.name === "string" ? node.name : "",
       type: node.type,
       ...(typeof path === "string" && path !== "" ? { path } : {}),
+      ...(typeof parameters === "object" && parameters !== null
+        ? { parameters: parameters as Record<string, unknown> }
+        : {}),
     };
   }
   return null;

--- a/src/proxy/mcp/entry-tool.ts
+++ b/src/proxy/mcp/entry-tool.ts
@@ -1,0 +1,89 @@
+/**
+ * `get_workflow_entry` — a small tool the proxy answers itself.
+ *
+ * n8n's `execute_workflow` tells the model to call `get_workflow_details`
+ * first, and it has to: `inputs` is a union discriminated by trigger type
+ * (`chat` / `form` / `webhook`), nothing in `search_workflows` says which one a
+ * workflow takes, and picking wrong makes n8n execute with empty data rather
+ * than fail. So that lookup happens before every execution — and n8n answers it
+ * with the whole workflow. Measured against a live instance: 116 KB, of which a
+ * caller that only runs workflows reads three fields.
+ *
+ * This is the additive answer to that. Rather than rewriting n8n's reply — which
+ * would make this proxy responsible for a shape it does not own, forever — the
+ * gate publishes its own tool beside it. n8n's `get_workflow_details` keeps
+ * working exactly as it does; an operator who wants only the small one simply
+ * leaves the large one out of `--mcp-allow-tools`.
+ *
+ * It costs no upstream call: the gate already holds these facts, because it has
+ * to resolve the entry trigger to decide reachability at all.
+ */
+
+import type { JsonRpcMessage } from "./jsonrpc.ts";
+import { isToolAllowed, type McpPolicy } from "./policy.ts";
+import type { WorkflowFacts } from "./workflow-index.ts";
+
+export const ENTRY_TOOL_NAME = "get_workflow_entry";
+
+/**
+ * Whether this deployment publishes the tool.
+ *
+ * It has to be named in `--mcp-allow-tools`, not merely allowed by an empty
+ * list: a tool appearing in `tools/list` because someone upgraded the proxy is
+ * a surprise, and the gate's rule everywhere else is that an upgrade changes
+ * nothing until the configuration says so.
+ */
+export function publishesEntryTool(policy: McpPolicy): boolean {
+  return policy.allowTools.length > 0 && isToolAllowed(policy, ENTRY_TOOL_NAME);
+}
+
+export const ENTRY_TOOL_DEFINITION = {
+  name: ENTRY_TOOL_NAME,
+  description:
+    "Get what you need to call execute_workflow on a workflow: its description, and the " +
+    "trigger n8n would actually enter it through — the type decides which shape of `inputs` " +
+    "to build, and the trigger's own parameters carry the details (a form trigger's " +
+    "formFields, a webhook's httpMethod). Use this instead of get_workflow_details, which " +
+    "returns the entire workflow definition and is far larger than this task needs.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      workflowId: { type: "string", description: "The ID of the workflow to describe" },
+    },
+    required: ["workflowId"],
+    additionalProperties: false,
+    $schema: "http://json-schema.org/draft-07/schema#",
+  },
+} as const;
+
+/** The payload for one workflow. */
+export function entryPayload(facts: WorkflowFacts): Record<string, unknown> {
+  return {
+    id: facts.id,
+    name: facts.name,
+    ...(facts.description === undefined ? {} : { description: facts.description }),
+    tags: facts.tags,
+    entry:
+      facts.entry === null
+        ? null
+        : {
+            name: facts.entry.name,
+            type: facts.entry.type,
+            ...(facts.entry.path === undefined ? {} : { path: facts.entry.path }),
+            parameters: facts.entry.parameters ?? {},
+          },
+  };
+}
+
+/** Builds the reply, in both channels, the way n8n builds its own. */
+export function entryToolResult(id: JsonRpcMessage["id"], facts: WorkflowFacts): JsonRpcMessage {
+  const payload = entryPayload(facts);
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    result: {
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+      structuredContent: payload,
+    },
+  };
+}

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -22,6 +22,12 @@ import type { EnforceLevel } from "../config.ts";
 import type { Logger } from "../logging.ts";
 import { forwardRequest } from "../upstream.ts";
 import {
+  ENTRY_TOOL_DEFINITION,
+  ENTRY_TOOL_NAME,
+  entryToolResult,
+  publishesEntryTool,
+} from "./entry-tool.ts";
+import {
   encodeReply,
   INVALID_PARAMS,
   type JsonRpcMessage,
@@ -39,7 +45,7 @@ import {
   scanForWorkflowIds,
   targetWorkflowId,
 } from "./policy.ts";
-import { type AllowedWorkflowIndex, explainRefusal } from "./workflow-index.ts";
+import { type AllowedWorkflowIndex, explainRefusal, type WorkflowFacts } from "./workflow-index.ts";
 
 export interface McpGateDeps {
   upstream: string;
@@ -95,6 +101,14 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
     return forward(req, rawJSON, pathname, deps);
   }
 
+  // Answered here, never forwarded: n8n has no such tool. Before the refusal
+  // pass, because the same workflow scope decides both and this needs the facts
+  // rather than a yes/no.
+  if (deps.enforce === "error" && publishesEntryTool(deps.policy)) {
+    const answered = await answerEntryTool(parsed, pathname, deps);
+    if (answered) return answered;
+  }
+
   const refusals: JsonRpcMessage[] = [];
   for (const message of parsed.messages) {
     const refusal = await refuse(message, pathname, deps);
@@ -139,13 +153,66 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
   // stay empty.
   if (deps.enforce !== "error") return response;
 
-  const tools = filtersTools(deps.policy) && parsed.messages.some((m) => m.method === "tools/list");
+  const listsTools = parsed.messages.some((m) => m.method === "tools/list");
+  const tools = listsTools && (filtersTools(deps.policy) || publishesEntryTool(deps.policy));
   const searchIds = hasWorkflowScope(deps.policy)
     ? searchCallIds(parsed.messages)
     : new Set<string | number>();
   if (!tools && searchIds.size === 0) return response;
 
   return filterResponse(response, deps, pathname, { tools, searchIds });
+}
+
+/**
+ * Answers `get_workflow_entry` without going upstream, or returns null when the
+ * request does not call it.
+ *
+ * A batch that mixes it with other calls is not split — the other half would
+ * still have to be forwarded and the two recombined, for a case no MCP client
+ * produces. Those fall through, and n8n rejects the unknown tool on its own
+ * terms, which is at least an honest answer.
+ */
+async function answerEntryTool(
+  parsed: { messages: JsonRpcMessage[]; isBatch: boolean },
+  pathname: string,
+  deps: McpGateDeps,
+): Promise<Response | null> {
+  if (!parsed.messages.every((m) => toolCallName(m) === ENTRY_TOOL_NAME)) return null;
+
+  let sets: Awaited<ReturnType<typeof deps.index.sets>>;
+  try {
+    sets = await deps.index.sets();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log(deps, pathname, `workflow index unavailable: ${reason}`, ENTRY_TOOL_NAME);
+    return jsonRpcResponse(
+      parsed.messages.map((m) =>
+        toolErrorResult(
+          m.id,
+          "This proxy could not verify whether that workflow is available over MCP. Try again shortly.",
+        ),
+      ),
+      parsed.isBatch,
+    );
+  }
+
+  const replies = parsed.messages.map((message) => {
+    const id = toolCallArguments(message).workflowId;
+    if (typeof id !== "string" || id === "") {
+      return toolErrorResult(message.id, `${ENTRY_TOOL_NAME} requires a workflowId.`);
+    }
+    if (!sets.allowed.has(id)) {
+      log(deps, pathname, `workflow out of MCP scope: ${id}`, ENTRY_TOOL_NAME);
+      return toolErrorResult(
+        message.id,
+        `Not available over MCP: ${id} (${explainRefusal(deps.policy, sets.facts.get(id))}).`,
+      );
+    }
+    // `allowed` is built from `facts`, so the lookup cannot miss.
+    return entryToolResult(message.id, sets.facts.get(id) as WorkflowFacts);
+  });
+
+  return jsonRpcResponse(replies, parsed.isBatch);
 }
 
 /**
@@ -329,8 +396,11 @@ async function filterResponse(
         if (!ok) removedTools++;
         return ok;
       });
-      if (kept.length === tools.length) return message;
-      return { ...message, result: { ...message.result, tools: kept } };
+      // Published beside n8n's own, never in place of one: this proxy adds a
+      // tool, it does not reshape what n8n serves.
+      const published = publishesEntryTool(deps.policy) ? [...kept, ENTRY_TOOL_DEFINITION] : kept;
+      if (published.length === tools.length) return message;
+      return { ...message, result: { ...message.result, tools: published } };
     }
 
     if (message.id === undefined || message.id === null || !plan.searchIds.has(message.id)) {

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -622,6 +622,114 @@ describe("MCP gate: filtering search_workflows results", () => {
   });
 });
 
+describe("MCP gate: get_workflow_entry", () => {
+  const ALLOW = ["search_workflows", "execute_workflow", "get_workflow_entry"];
+
+  async function entry(workflowId: string): Promise<Record<string, unknown>> {
+    return await call("tools/call", {
+      name: "get_workflow_entry",
+      arguments: { workflowId },
+    });
+  }
+
+  function payload(reply: Record<string, unknown>): Record<string, unknown> {
+    const result = reply.result as {
+      structuredContent?: Record<string, unknown>;
+      content?: Array<{ text?: string }>;
+    };
+    return result.structuredContent ?? {};
+  }
+
+  test("is published beside n8n's own tools, not in place of one", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    expect(toolNames(await call("tools/list"))).toEqual([
+      "search_workflows",
+      "execute_workflow",
+      "get_workflow_entry",
+    ]);
+  });
+
+  test("names the trigger n8n would enter the workflow through", async () => {
+    // wf-open lists the agent entry first and the test hook second. Which one
+    // is reported decides which shape of `inputs` the caller builds.
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    const seen = payload(await entry("wf-open")) as {
+      entry?: { name?: string; type?: string; path?: string; parameters?: unknown };
+    };
+    expect(seen.entry?.name).toBe("[MCP] entry");
+    expect(seen.entry?.type).toBe(FORM);
+    expect(seen.entry?.path).toBe("__mcp__/hospital-lookup");
+    expect(seen.entry?.parameters).toBeDefined();
+  });
+
+  test("answers without going upstream at all", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    await entry("wf-open");
+    expect(upstream.captured.some((c) => c.pathname === "/mcp-server/http")).toBe(false);
+  });
+
+  test("both channels carry the same payload, the way n8n builds its own", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    const result = (await entry("wf-open")).result as {
+      structuredContent: unknown;
+      content: Array<{ text: string }>;
+    };
+    expect(JSON.parse(result.content[0]!.text)).toEqual(result.structuredContent);
+  });
+
+  test("a workflow outside the policy is refused, with the reason", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    const result = (await entry("wf-tagged-only")).result as {
+      isError?: boolean;
+      content: Array<{ text: string }>;
+    };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("outside the agent-facing namespace");
+  });
+
+  test("a call naming no workflow is refused", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    const reply = await call("tools/call", { name: "get_workflow_entry", arguments: {} });
+    expect((reply.result as { isError?: boolean }).isError).toBe(true);
+  });
+
+  test("an unreadable workflow list refuses rather than answers", async () => {
+    await upstream.server.stop(true);
+    upstream = startMockUpstream({ listFails: true });
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    expect((await entry("wf-open")).result).toMatchObject({ isError: true });
+  });
+
+  test("it has to be named in the allowlist, not merely permitted by an empty one", async () => {
+    // An upgrade must not add a tool to someone's tools/list on its own.
+    start(policy({ entryPathPattern: "__mcp__/*" }));
+    expect(toolNames(await call("tools/list"))).not.toContain("get_workflow_entry");
+  });
+
+  test("warn does not publish it", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }), "warn");
+    expect(toolNames(await call("tools/list"))).not.toContain("get_workflow_entry");
+  });
+
+  test("n8n's own get_workflow_details is untouched when it is allowed too", async () => {
+    // The point of adding a tool rather than rewriting a reply: the large one
+    // still works, exactly as n8n serves it.
+    start(
+      policy({
+        allowTools: [...ALLOW, "get_workflow_details"],
+        entryPathPattern: "__mcp__/*",
+      }),
+    );
+    const reply = await call("tools/call", {
+      name: "get_workflow_details",
+      arguments: { workflowId: "wf-open" },
+    });
+    expect((reply.result as { content: Array<{ text: string }> }).content[0]?.text).toBe(
+      "ran get_workflow_details",
+    );
+  });
+});
+
 describe("MCP gate: startup", () => {
   async function readyz(): Promise<{ status: number; body: string }> {
     const res = await fetch(`http://127.0.0.1:${proxy.port}/readyz`);


### PR DESCRIPTION
## Why

`execute_workflow`'s own tool description tells the model to call `get_workflow_details` first — and it has to. `inputs` is a union discriminated by trigger type:

```
{type: "chat",    chatInput: ...}
{type: "form",    formData: {...}}
{type: "webhook", webhookData: {...}}
```

Nothing in `search_workflows` says which one a workflow takes, and picking wrong makes n8n execute with **empty data rather than fail**. So the lookup runs before every execution.

n8n answers it with the entire workflow definition — every node's parameters, plus a second copy under `activeVersion`. Measured against a live instance: **116 KB** for one workflow, of which a caller that only runs workflows reads three fields.

## What this adds

Name `get_workflow_entry` in `--mcp-allow-tools` and the gate publishes its own tool beside n8n's:

```json
{ "id": "...", "name": "...", "description": "...", "tags": [],
  "entry": { "name": "[MCP] entry", "type": "n8n-nodes-base.formTrigger",
             "path": "__mcp__/...", "parameters": { "formFields": {} } } }
```

`entry` is resolved by the same code that decides reachability, so the trigger reported is the node n8n would actually start from — not a guess, and not "here are three triggers, good luck", which is what n8n's own `triggerInfo` gives. Its `parameters` carry what building `inputs` needs: a form trigger's `formFields`, a webhook's `httpMethod`.

## Why a new tool instead of trimming the old one

I built the trimming version first and did not ship it. Filtering *what* a client may reach is access control and belongs in a proxy. Rewriting the *shape* of a response is a different claim — that we know better than n8n what a client needs — and it has two costs that do not go away:

- Every future n8n change to that response is ours to keep working.
- A keep-list silently withholds anything n8n adds later. A new field describing expected input is exactly what would be lost that way, and the loss would look like n8n not sending it.

Adding a tool has neither. `get_workflow_details` keeps behaving exactly as n8n serves it; an operator who wants only the small one leaves the large one out of the allowlist.

## Cost

No upstream call. Resolving the entry trigger is already how the gate decides reachability, so the facts are in the index it maintains.

## Scope and safety

- The same workflow scope applies: a workflow outside the policy is refused with the reason, not described.
- An unreadable workflow index refuses rather than answers, like every other workflow-scoped path.
- `warn` does not publish it, consistent with `warn` not filtering.
- It must be **named** in `--mcp-allow-tools`, not merely permitted by an empty list, so upgrading the proxy never adds a tool to a client's list on its own.

## Tests

11 new cases: published beside n8n's tools rather than replacing one, names the first supported trigger, answers without touching upstream, both channels agree, out-of-scope refused with the reason, no workflowId refused, unreadable index refuses, absent unless named, not published under warn, and `get_workflow_details` still passes through untouched when it is allowed too.

Full suite green (1556 pass), biome and tsc clean.