### PR TITLE
fix(mcp): carry the description get_workflow_entry promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,9 @@ Name `get_workflow_entry` in `--mcp-allow-tools` and the gate publishes a small 
 
 `entry` is resolved exactly as reachability is, so the trigger reported is the node n8n would start from, and its `parameters` carry what building `inputs` needs — a form trigger's `formFields`, a webhook's `httpMethod`.
 
-**It adds, it does not rewrite.** n8n's `get_workflow_details` keeps behaving exactly as n8n serves it; an operator who wants only the small one leaves the large one out of the allowlist. Nothing here makes this proxy responsible for a response shape it does not own. It also costs no upstream call — the gate already holds these facts, because resolving the entry trigger is how it decides reachability. The same scope applies: a workflow outside the policy is refused with the reason, not described.
+The description costs one `GET /api/v1/workflows/{id}`, once per workflow per cache lifetime, and only for a workflow the policy already allows: n8n's workflow *listing* — which is what the gate's index is built from — omits `description` entirely, and only the per-workflow read carries it. If that read fails the tool still answers, without the description: the trigger information is the part a caller cannot get anywhere else.
+
+**It adds, it does not rewrite.** n8n's `get_workflow_details` keeps behaving exactly as n8n serves it; an operator who wants only the small one leaves the large one out of the allowlist. Nothing here makes this proxy responsible for a response shape it does not own. The trigger half costs no upstream call at all — resolving the entry trigger is already how the gate decides reachability. The same scope applies: a workflow outside the policy is refused with the reason, not described.
 
 It must be named in `--mcp-allow-tools` rather than merely permitted by an empty one, so upgrading the proxy never adds a tool to a client's list on its own.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/proxy/mcp/entry-tool.ts
+++ b/src/proxy/mcp/entry-tool.ts
@@ -15,8 +15,11 @@
  * working exactly as it does; an operator who wants only the small one simply
  * leaves the large one out of `--mcp-allow-tools`.
  *
- * It costs no upstream call: the gate already holds these facts, because it has
- * to resolve the entry trigger to decide reachability at all.
+ * The trigger half costs no upstream call: the gate already holds it, because
+ * it has to resolve the entry trigger to decide reachability at all. The
+ * description costs one per-workflow read, once per cache lifetime — n8n's
+ * workflow listing does not carry descriptions, only the single-workflow
+ * endpoint does.
  */
 
 import type { JsonRpcMessage } from "./jsonrpc.ts";

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -196,21 +196,27 @@ async function answerEntryTool(
     );
   }
 
-  const replies = parsed.messages.map((message) => {
-    const id = toolCallArguments(message).workflowId;
-    if (typeof id !== "string" || id === "") {
-      return toolErrorResult(message.id, `${ENTRY_TOOL_NAME} requires a workflowId.`);
-    }
-    if (!sets.allowed.has(id)) {
-      log(deps, pathname, `workflow out of MCP scope: ${id}`, ENTRY_TOOL_NAME);
-      return toolErrorResult(
-        message.id,
-        `Not available over MCP: ${id} (${explainRefusal(deps.policy, sets.facts.get(id))}).`,
-      );
-    }
-    // `allowed` is built from `facts`, so the lookup cannot miss.
-    return entryToolResult(message.id, sets.facts.get(id) as WorkflowFacts);
-  });
+  const replies = await Promise.all(
+    parsed.messages.map(async (message) => {
+      const id = toolCallArguments(message).workflowId;
+      if (typeof id !== "string" || id === "") {
+        return toolErrorResult(message.id, `${ENTRY_TOOL_NAME} requires a workflowId.`);
+      }
+      if (!sets.allowed.has(id)) {
+        log(deps, pathname, `workflow out of MCP scope: ${id}`, ENTRY_TOOL_NAME);
+        return toolErrorResult(
+          message.id,
+          `Not available over MCP: ${id} (${explainRefusal(deps.policy, sets.facts.get(id))}).`,
+        );
+      }
+      // `allowed` is built from `facts`, so the lookup cannot miss.
+      const facts = sets.facts.get(id) as WorkflowFacts;
+      // Only now, and only for a workflow the policy already allows: the
+      // listing the index is built from carries no descriptions.
+      await deps.index.fillDescription(facts);
+      return entryToolResult(message.id, facts);
+    }),
+  );
 
   return jsonRpcResponse(replies, parsed.isBatch);
 }

--- a/src/proxy/mcp/workflow-index.ts
+++ b/src/proxy/mcp/workflow-index.ts
@@ -41,7 +41,14 @@ interface ListResponse {
 export interface WorkflowFacts {
   id: string;
   name: string;
+  /**
+   * Absent until {@link AllowedWorkflowIndex.fillDescription} asks for it: the
+   * workflow listing does not carry descriptions, only the per-workflow read
+   * does.
+   */
   description?: string;
+  /** Whether the per-workflow read has been attempted, successful or not. */
+  descriptionFetched?: boolean;
   tags: string[];
   availableInMCP: boolean;
   /** The trigger n8n would start an MCP execution from, if any. */
@@ -167,6 +174,49 @@ export class AllowedWorkflowIndex {
         this.inFlight = null;
       });
     return this.inFlight;
+  }
+
+  /**
+   * Fills in a workflow's description, which the listing does not carry.
+   *
+   * Measured against a live 2.32.5 instance: `GET /api/v1/workflows` answers
+   * without a `description` field at all, while `GET /api/v1/workflows/{id}`
+   * has it. So the index cannot know descriptions, and anything that needs one
+   * has to ask per workflow — which is fine as long as it is only asked for a
+   * workflow the policy already allows.
+   *
+   * Best effort. A workflow described without its description is still worth
+   * returning; failing the whole call over it would trade the useful half for
+   * nothing. Resolves once per workflow per cache lifetime, because the result
+   * is written back onto the cached facts.
+   */
+  async fillDescription(facts: WorkflowFacts): Promise<void> {
+    if (facts.description !== undefined || facts.descriptionFetched) return;
+    facts.descriptionFetched = true;
+
+    try {
+      const url = new URL(
+        `/api/v1/workflows/${encodeURIComponent(facts.id)}`,
+        "http://mcp-gate.invalid",
+      );
+      url.searchParams.set("excludePinnedData", "true");
+      const { response } = await forwardRequest(
+        new Request(url.toString(), {
+          method: "GET",
+          headers: new Headers({ accept: "application/json" }),
+        }),
+        this.deps.upstream,
+        undefined,
+        { timeoutMs: this.deps.timeoutMs, clientMiddlewares: this.deps.clientMiddlewares },
+      );
+      if (!response.ok) return;
+      const body = (await response.json()) as { description?: unknown };
+      if (typeof body.description === "string" && body.description !== "") {
+        facts.description = body.description;
+      }
+    } catch {
+      // Left without a description; see above.
+    }
   }
 
   private async fetchSets(): Promise<WorkflowSets> {

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -89,7 +89,7 @@ const WORKFLOWS = [
 
 /** Mock n8n: the MCP endpoint plus enough of the public API to build an index. */
 function startMockUpstream(
-  options: { sse?: boolean; listFails?: boolean; inflatedCount?: number } = {},
+  options: { sse?: boolean; listFails?: boolean; readFails?: boolean; inflatedCount?: number } = {},
 ): {
   server: ReturnType<typeof Bun.serve>;
   port: number;
@@ -105,7 +105,18 @@ function startMockUpstream(
 
       if (url.pathname === "/api/v1/workflows") {
         if (options.listFails) return new Response("nope", { status: 503 });
+        // Deliberately without `description`: a live 2.32.5 instance omits the
+        // field from the listing entirely, and only the per-workflow read has
+        // it. An index built from this cannot know descriptions.
         return Response.json({ data: WORKFLOWS, nextCursor: null });
+      }
+
+      if (url.pathname.startsWith("/api/v1/workflows/")) {
+        if (options.readFails) return new Response("nope", { status: 503 });
+        const id = url.pathname.slice("/api/v1/workflows/".length);
+        const workflow = WORKFLOWS.find((w) => w.id === id);
+        if (!workflow) return new Response("not found", { status: 404 });
+        return Response.json({ ...workflow, description: `what ${workflow.name} does` });
       }
 
       let request: { id?: unknown; method?: string; params?: { name?: string } } = {};
@@ -662,10 +673,44 @@ describe("MCP gate: get_workflow_entry", () => {
     expect(seen.entry?.parameters).toBeDefined();
   });
 
-  test("answers without going upstream at all", async () => {
+  test("never touches n8n's MCP endpoint", async () => {
     start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
     await entry("wf-open");
     expect(upstream.captured.some((c) => c.pathname === "/mcp-server/http")).toBe(false);
+  });
+
+  test("carries the description, which the listing does not have", async () => {
+    // The whole promise of this tool is description + entry. n8n's workflow
+    // listing omits `description` entirely — only the per-workflow read has it
+    // — so the index cannot supply it and the gate has to ask.
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    expect(payload(await entry("wf-open")).description).toBe("what [mcp] hospital lookup does");
+  });
+
+  test("the per-workflow read happens once, and only for an allowed workflow", async () => {
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+    await entry("wf-open");
+    await entry("wf-open");
+    await entry("wf-tagged-only");
+
+    const reads = upstream.captured.filter((c) => c.pathname.startsWith("/api/v1/workflows/"));
+    expect(reads).toHaveLength(1);
+    expect(reads[0]?.pathname).toBe("/api/v1/workflows/wf-open");
+  });
+
+  test("a description that cannot be read still answers with the entry", async () => {
+    // Trading the useful half for nothing would be the wrong failure: the
+    // trigger information is what the caller cannot get anywhere else.
+    await upstream.server.stop(true);
+    upstream = startMockUpstream({ readFails: true });
+    start(policy({ allowTools: ALLOW, entryPathPattern: "__mcp__/*" }));
+
+    const seen = payload(await entry("wf-open")) as {
+      description?: string;
+      entry?: { name?: string };
+    };
+    expect(seen.description).toBeUndefined();
+    expect(seen.entry?.name).toBe("[MCP] entry");
   });
 
   test("both channels carry the same payload, the way n8n builds its own", async () => {


### PR DESCRIPTION
Found by calling the tool against a live instance after deploying it.

## What happened

`get_workflow_entry` came back with the entry trigger and **no `description`** — for a workflow that has one, and that `search_workflows` returns.

```json
{ "id": "0AWRJ0udrAJTnzlk", "name": "…", "tags": ["mcp"],
  "entry": { "name": "[MCP] エントリ", "type": "…webhook", "parameters": {…} } }
```

The tool's whole promise is *description + entry*. Half of it was missing, and it was the half that says what the workflow is for.

## Why

n8n's two endpoints disagree, which I had assumed they did not:

```
GET /api/v1/workflows       → no `description` field at all
GET /api/v1/workflows/{id}  → has it
```

The gate's index is built from the listing, so it never had a description to give. `WorkflowFacts.description` has been dead in practice since it was added.

## The fix

Read it per workflow, once per cache lifetime, and **only after the policy has already allowed that workflow** — so this never becomes a way to probe workflows the client cannot see.

Best effort by design: if that read fails, the tool still answers without the description. The trigger information is what a caller cannot get anywhere else, and trading it away for a missing sentence would be the wrong failure.

## Cost, honestly

The claim "costs no upstream call" is now wrong and is corrected in the README and the module doc. The trigger half still costs nothing — resolving the entry is already how the gate decides reachability. The description costs one `GET /api/v1/workflows/{id}` per workflow per cache lifetime (300s in a real deployment).

## Tests

The mock now reproduces the split — no `description` in the listing, present on the per-workflow read — so a test cannot pass on a shape n8n does not serve. Three new cases: the description is carried; the read happens once and only for an allowed workflow; a failed read still answers with the entry.

Full suite green (1559 pass), biome and tsc clean.