### PR TITLE
feat(proxy): enforce n8n built-in project roles on REST and MCP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/workflow-service.ts
+++ b/src/api/workflow-service.ts
@@ -1,3 +1,4 @@
+import { workflowProjectId } from "@/common/project-id.ts";
 import type { Client } from "./client.ts";
 import { BASE_UPDATED_AT_HEADER } from "./headers.ts";
 import type { ListWorkflowsResponse, TransferInput, Workflow, WorkflowInput } from "./types.ts";
@@ -140,17 +141,6 @@ export class WorkflowService {
    * Returns empty string if the workflow has no shared project info.
    */
   getWorkflowCurrentProjectID(workflow: Workflow | null): string {
-    if (!workflow?.shared?.length) {
-      return "";
-    }
-
-    // Find the owner project
-    const owner = workflow.shared.find((s) => s.role === "workflow:owner");
-    if (owner) {
-      return owner.projectId;
-    }
-
-    // Fallback to first project if no owner found
-    return workflow.shared[0]?.projectId ?? "";
+    return workflowProjectId(workflow);
   }
 }

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -86,6 +86,18 @@ interface ProxyOptions extends McpCliOptions {
   impersonatorVerifyEnforce?: string;
   impersonatorVerifyRequirement?: string;
   impersonatorVerifyExpectedAudiences?: string;
+  // project-role server middleware — enforces n8n built-in project roles.
+  projectRoleEnforce?: string;
+  projectRoleOnError?: string;
+  projectRoleOnMissingProject?: string;
+  projectRoleIdentitySource?: string;
+  projectRoleIdentityName?: string;
+  projectRoleIdentityDecode?: string;
+  projectRoleIdentityClaim?: string;
+  projectRoleMembersCacheTtlMs?: string;
+  projectRoleInstanceRoleCacheTtlMs?: string;
+  projectRoleTimeoutMs?: string;
+  projectRoleActions?: string;
 }
 
 export function registerProxyCommand(program: Command): void {
@@ -297,6 +309,51 @@ export function registerProxyCommand(program: Command): void {
       "--stale-write-actions <actions>",
       "Comma-separated route actions the guard applies to (default: update)",
     )
+    // project-role — mirrors n8n's built-in project Admin/Editor/Viewer roles.
+    .option(
+      "--project-role-enforce <level>",
+      "project-role enforcement level: off (default), warn, error. Requires user:list on the proxy's service API key for membership lookups. env: N8N_PROJECT_ROLE_ENFORCE",
+    )
+    .option(
+      "--project-role-on-error <mode>",
+      "Behavior when n8n membership lookups fail: deny (default) or allow. env: N8N_PROJECT_ROLE_ON_ERROR",
+    )
+    .option(
+      "--project-role-on-missing-project <mode>",
+      "What to do when the target workflow declares no project (typical on create): allow (default) or deny. env: N8N_PROJECT_ROLE_ON_MISSING_PROJECT",
+    )
+    .option(
+      "--project-role-identity-source <kind>",
+      "Where to read the caller email when oauth-verify did not populate it: header, env, none. env: N8N_PROJECT_ROLE_IDENTITY_SOURCE",
+    )
+    .option(
+      "--project-role-identity-name <name>",
+      "Header or env-var name holding the caller email. env: N8N_PROJECT_ROLE_IDENTITY_NAME",
+    )
+    .option(
+      "--project-role-identity-decode <mode>",
+      "Identity decode strategy: raw, jwt. env: N8N_PROJECT_ROLE_IDENTITY_DECODE",
+    )
+    .option(
+      "--project-role-identity-claim <name>",
+      "JWT claim name when decode=jwt. env: N8N_PROJECT_ROLE_IDENTITY_CLAIM",
+    )
+    .option(
+      "--project-role-members-cache-ttl-ms <ms>",
+      "Project member list cache TTL in milliseconds (default: 60000). env: N8N_PROJECT_ROLE_MEMBERS_CACHE_TTL_MS",
+    )
+    .option(
+      "--project-role-instance-role-cache-ttl-ms <ms>",
+      "Instance user role cache TTL in milliseconds (default: 60000). env: N8N_PROJECT_ROLE_INSTANCE_ROLE_CACHE_TTL_MS",
+    )
+    .option(
+      "--project-role-timeout-ms <ms>",
+      "HTTP timeout for n8n membership lookups in milliseconds (default: 10000). env: N8N_PROJECT_ROLE_TIMEOUT_MS",
+    )
+    .option(
+      "--project-role-actions <actions>",
+      "Comma-separated actions to authorize (default: all). Include read for GET /workflows/:id and MCP read tools. env: N8N_PROJECT_ROLE_ACTIONS",
+    )
     // oauth-verify — verifies incoming Authorization: Bearer via Google tokeninfo.
     .option(
       "--oauth-verify-enforce <level>",
@@ -443,6 +500,17 @@ export function extractMiddlewareCliOpts(opts: ProxyOptions): Record<string, unk
   copy("staleWriteOnMissingBase");
   copy("staleWriteOnError");
   copy("staleWriteActions");
+  copy("projectRoleEnforce");
+  copy("projectRoleOnError");
+  copy("projectRoleOnMissingProject");
+  copy("projectRoleIdentitySource");
+  copy("projectRoleIdentityName");
+  copy("projectRoleIdentityDecode");
+  copy("projectRoleIdentityClaim");
+  copy("projectRoleMembersCacheTtlMs");
+  copy("projectRoleInstanceRoleCacheTtlMs");
+  copy("projectRoleTimeoutMs");
+  copy("projectRoleActions");
   copy("oauthVerifyEnforce");
   copy("oauthVerifyExpectedAudiences");
   copy("oauthVerifyTrustedPrincipals");

--- a/src/common/project-id.ts
+++ b/src/common/project-id.ts
@@ -1,0 +1,15 @@
+import type { Workflow } from "@/api/types.ts";
+
+/**
+ * Returns the project that owns a workflow, mirroring n8n's `shared` payload.
+ *
+ * Prefers the entry whose role is `workflow:owner`; otherwise falls back to the
+ * first shared project. An empty string means the workflow carries no project
+ * context the proxy can enforce against.
+ */
+export function workflowProjectId(workflow: Workflow | null | undefined): string {
+  if (!workflow?.shared?.length) return "";
+  const owner = workflow.shared.find((s) => s.role === "workflow:owner");
+  if (owner) return owner.projectId;
+  return workflow.shared[0]?.projectId ?? "";
+}

--- a/src/middleware/builtin/project-role/checker.ts
+++ b/src/middleware/builtin/project-role/checker.ts
@@ -1,0 +1,117 @@
+import { workflowProjectId } from "@/common/project-id.ts";
+import { resolveIdentity } from "@/middleware/identity.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
+import { N8nProjectApi, type N8nProjectApiDeps } from "./n8n-api.ts";
+import { type AccessLevel, isInstanceWideAdmin, projectRoleSatisfies } from "./roles.ts";
+import type { ProjectRoleOptions } from "./types.ts";
+
+export interface ProjectRoleCheckInput {
+  email: string;
+  projectId: string;
+  level: AccessLevel;
+}
+
+export interface ProjectRoleCheckResult {
+  allowed: boolean;
+  reason?: string;
+  rule: string;
+}
+
+export interface ProjectRoleCheckerDeps extends N8nProjectApiDeps {}
+
+/**
+ * Shared decision engine for REST writes, REST reads, and MCP tool calls.
+ */
+export class ProjectRoleChecker {
+  readonly api: N8nProjectApi;
+
+  constructor(
+    private readonly options: ProjectRoleOptions,
+    deps: ProjectRoleCheckerDeps,
+  ) {
+    this.api = new N8nProjectApi(deps, options.membersCacheTtlMs, options.instanceRoleCacheTtlMs);
+  }
+
+  resolveEmail(ctx: ServerMiddlewareContext): string | undefined {
+    if (ctx.identity?.trim()) return ctx.identity.trim();
+    if (ctx.auth?.effective?.email?.trim()) return ctx.auth.effective.email.trim();
+    return resolveIdentity(this.options.identity, {
+      request: ctx.request,
+      env: process.env,
+    })?.trim();
+  }
+
+  resolveProjectId(ctx: ServerMiddlewareContext): string {
+    return workflowProjectId(ctx.workflow);
+  }
+
+  async check(input: ProjectRoleCheckInput): Promise<ProjectRoleCheckResult> {
+    const { email, projectId, level } = input;
+    if (!projectId) {
+      if (this.options.onMissingProject === "allow") {
+        return { allowed: true, rule: "project-role-missing-project-allowed" };
+      }
+      return {
+        allowed: false,
+        rule: "project-role-missing-project",
+        reason:
+          "The target workflow does not declare a project, so this proxy cannot verify n8n project membership.",
+      };
+    }
+
+    try {
+      const instanceRole = await this.api.instanceRoleForEmail(email);
+      if (isInstanceWideAdmin(instanceRole)) {
+        return { allowed: true, rule: "project-role-instance-admin" };
+      }
+
+      const projectRole = await this.api.projectRoleForEmail(projectId, email);
+      if (projectRoleSatisfies(projectRole, level)) {
+        return { allowed: true, rule: "project-role-allowed" };
+      }
+
+      const needed = level === "write" ? "project:editor or higher" : "project:viewer or higher";
+      const have = projectRole ?? "no project membership";
+      return {
+        allowed: false,
+        rule: "project-role-denied",
+        reason: `Identity "${email}" has ${have} in project ${projectId}, but ${needed} is required.`,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.options.onError === "allow") {
+        return {
+          allowed: true,
+          rule: "project-role-lookup-warning",
+          reason: `Membership lookup failed (fail-open): ${message}`,
+        };
+      }
+      return {
+        allowed: false,
+        rule: "project-role-lookup-error",
+        reason: `Membership lookup failed: ${message}`,
+      };
+    }
+  }
+
+  actionAccessLevel(action: string | undefined): AccessLevel | undefined {
+    if (!action) return undefined;
+    if (action === "read") return "read";
+    if (
+      action === "create" ||
+      action === "update" ||
+      action === "delete" ||
+      action === "activate"
+    ) {
+      return "write";
+    }
+    if (action === "tags") return "write";
+    return undefined;
+  }
+
+  shouldApplyToAction(action: string | undefined): boolean {
+    const scoped = this.options.actions;
+    if (scoped.length === 0) return true;
+    return !!action && scoped.includes(action);
+  }
+}

--- a/src/middleware/builtin/project-role/factory.ts
+++ b/src/middleware/builtin/project-role/factory.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import type { ServerMiddlewareFactory } from "@/middleware/types.ts";
+import { ProjectRoleMiddleware } from "./middleware.ts";
+import type {
+  ProjectRoleEnforce,
+  ProjectRoleOnError,
+  ProjectRoleOnMissingProject,
+  ProjectRoleOptions,
+} from "./types.ts";
+
+const identitySchema = z.object({
+  source: z.union([z.literal("header"), z.literal("env"), z.literal("none")]).default("none"),
+  name: z.string().optional(),
+  decode: z.union([z.literal("raw"), z.literal("jwt")]).default("raw"),
+  claim: z.string().optional(),
+});
+
+const optionsSchema = z.object({
+  enforce: z.union([z.literal("off"), z.literal("warn"), z.literal("error")]).default("off"),
+  onError: z.union([z.literal("deny"), z.literal("allow")]).default("deny"),
+  onMissingProject: z.union([z.literal("deny"), z.literal("allow")]).default("allow"),
+  identity: identitySchema.default({ source: "none", decode: "raw" }),
+  membersCacheTtlMs: z.number().int().min(0).default(60_000),
+  instanceRoleCacheTtlMs: z.number().int().min(0).default(60_000),
+  timeoutMs: z.number().int().min(0).default(10_000),
+  actions: z.array(z.string()).default([]),
+  upstream: z.string().url({ message: "project-role: upstream URL is required" }),
+});
+
+function splitList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function fromEnv(env: NodeJS.ProcessEnv): Partial<ProjectRoleOptions & { upstream?: string }> {
+  const opts: Partial<ProjectRoleOptions & { upstream?: string }> = {};
+  if (env.N8N_PROJECT_ROLE_ENFORCE) {
+    opts.enforce = env.N8N_PROJECT_ROLE_ENFORCE as ProjectRoleEnforce;
+  }
+  if (env.N8N_PROJECT_ROLE_ON_ERROR) {
+    opts.onError = env.N8N_PROJECT_ROLE_ON_ERROR as ProjectRoleOnError;
+  }
+  if (env.N8N_PROJECT_ROLE_ON_MISSING_PROJECT) {
+    opts.onMissingProject = env.N8N_PROJECT_ROLE_ON_MISSING_PROJECT as ProjectRoleOnMissingProject;
+  }
+  if (env.N8N_PROJECT_ROLE_MEMBERS_CACHE_TTL_MS) {
+    opts.membersCacheTtlMs = Number.parseInt(env.N8N_PROJECT_ROLE_MEMBERS_CACHE_TTL_MS, 10);
+  }
+  if (env.N8N_PROJECT_ROLE_INSTANCE_ROLE_CACHE_TTL_MS) {
+    opts.instanceRoleCacheTtlMs = Number.parseInt(
+      env.N8N_PROJECT_ROLE_INSTANCE_ROLE_CACHE_TTL_MS,
+      10,
+    );
+  }
+  if (env.N8N_PROJECT_ROLE_TIMEOUT_MS) {
+    opts.timeoutMs = Number.parseInt(env.N8N_PROJECT_ROLE_TIMEOUT_MS, 10);
+  }
+  if (env.N8N_PROJECT_ROLE_ACTIONS) {
+    opts.actions = splitList(env.N8N_PROJECT_ROLE_ACTIONS);
+  }
+  if (env.N8N_PROJECT_ROLE_UPSTREAM) {
+    opts.upstream = env.N8N_PROJECT_ROLE_UPSTREAM;
+  }
+
+  const identity = {
+    source: env.N8N_PROJECT_ROLE_IDENTITY_SOURCE as "header" | "env" | "none" | undefined,
+    name: env.N8N_PROJECT_ROLE_IDENTITY_NAME,
+    decode: env.N8N_PROJECT_ROLE_IDENTITY_DECODE as "raw" | "jwt" | undefined,
+    claim: env.N8N_PROJECT_ROLE_IDENTITY_CLAIM,
+  };
+  if (Object.values(identity).some((v) => v !== undefined)) {
+    opts.identity = identity as ProjectRoleOptions["identity"];
+  }
+  return opts;
+}
+
+function fromCLI(
+  cliOpts: Record<string, unknown>,
+): Partial<ProjectRoleOptions & { upstream?: string }> {
+  const out: Partial<ProjectRoleOptions & { upstream?: string }> = {};
+  const s = (k: string) => (typeof cliOpts[k] === "string" ? (cliOpts[k] as string) : undefined);
+  const n = (k: string) => {
+    const v = cliOpts[k];
+    if (typeof v === "string" && /^\d+$/.test(v)) return Number.parseInt(v, 10);
+    if (typeof v === "number") return v;
+    return undefined;
+  };
+
+  if (s("projectRoleEnforce")) out.enforce = s("projectRoleEnforce") as ProjectRoleEnforce;
+  if (s("projectRoleOnError")) out.onError = s("projectRoleOnError") as ProjectRoleOnError;
+  if (s("projectRoleOnMissingProject")) {
+    out.onMissingProject = s("projectRoleOnMissingProject") as ProjectRoleOnMissingProject;
+  }
+  const membersTtl = n("projectRoleMembersCacheTtlMs");
+  if (membersTtl !== undefined) out.membersCacheTtlMs = membersTtl;
+  const instanceTtl = n("projectRoleInstanceRoleCacheTtlMs");
+  if (instanceTtl !== undefined) out.instanceRoleCacheTtlMs = instanceTtl;
+  const timeout = n("projectRoleTimeoutMs");
+  if (timeout !== undefined) out.timeoutMs = timeout;
+  if (s("projectRoleActions")) out.actions = splitList(s("projectRoleActions") as string);
+  if (typeof cliOpts.projectRoleUpstream === "string") {
+    out.upstream = cliOpts.projectRoleUpstream;
+  }
+  if (Array.isArray(cliOpts.clientMiddlewares)) {
+    (out as { clientMiddlewares?: unknown }).clientMiddlewares = cliOpts.clientMiddlewares;
+  }
+
+  const identity = {
+    source: s("projectRoleIdentitySource") as "header" | "env" | "none" | undefined,
+    name: s("projectRoleIdentityName"),
+    decode: s("projectRoleIdentityDecode") as "raw" | "jwt" | undefined,
+    claim: s("projectRoleIdentityClaim"),
+  };
+  if (Object.values(identity).some((v) => v !== undefined)) {
+    out.identity = identity as ProjectRoleOptions["identity"];
+  }
+  return out;
+}
+
+export const projectRoleFactory: ServerMiddlewareFactory<
+  ProjectRoleOptions & { upstream: string }
+> = {
+  name: "project-role",
+  loadFromEnv: fromEnv,
+  loadFromCLI: fromCLI,
+  build(merged) {
+    const parsed = optionsSchema.parse(merged);
+    const { upstream, ...options } = parsed;
+    const clientMiddlewares = (
+      merged as { clientMiddlewares?: import("@/middleware/types.ts").ClientMiddleware[] }
+    ).clientMiddlewares;
+    return new ProjectRoleMiddleware(options as ProjectRoleOptions, {
+      upstream,
+      clientMiddlewares,
+      timeoutMs: options.timeoutMs,
+    });
+  },
+};
+
+export const projectRoleOptionsSchema = optionsSchema;

--- a/src/middleware/builtin/project-role/mcp-tools.ts
+++ b/src/middleware/builtin/project-role/mcp-tools.ts
@@ -1,0 +1,34 @@
+import type { AccessLevel } from "./roles.ts";
+
+/** MCP tools that mutate a workflow or run it — editor or above. */
+const MCP_WRITE_TOOLS = new Set([
+  "execute_workflow",
+  "test_workflow",
+  "prepare_test_pin_data",
+  "prepare_workflow_pin_data",
+  "update_workflow",
+  "publish_workflow",
+  "unpublish_workflow",
+  "archive_workflow",
+  "restore_workflow_version",
+  "create_workflow_from_code",
+]);
+
+/** MCP tools that only read workflow state — viewer or above. */
+const MCP_READ_TOOLS = new Set([
+  "get_workflow_details",
+  "get_workflow_history",
+  "get_workflow_version",
+]);
+
+/**
+ * Maps an MCP tool name to the project access level it needs.
+ *
+ * Returns `undefined` when the tool is not workflow-scoped (for example
+ * `search_workflows`) and this gate has nothing to decide.
+ */
+export function mcpToolAccessLevel(tool: string): AccessLevel | undefined {
+  if (MCP_WRITE_TOOLS.has(tool)) return "write";
+  if (MCP_READ_TOOLS.has(tool)) return "read";
+  return undefined;
+}

--- a/src/middleware/builtin/project-role/middleware.ts
+++ b/src/middleware/builtin/project-role/middleware.ts
@@ -1,0 +1,102 @@
+import { workflowProjectId } from "@/common/project-id.ts";
+import type {
+  MiddlewareVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
+import { ProjectRoleChecker, type ProjectRoleCheckerDeps } from "./checker.ts";
+import type { ProjectRoleOptions } from "./types.ts";
+
+export class ProjectRoleMiddleware implements ServerMiddleware {
+  readonly name = "project-role";
+  readonly readsWorkflowBody = false;
+  readonly checker: ProjectRoleChecker;
+
+  constructor(
+    private readonly options: ProjectRoleOptions,
+    deps: ProjectRoleCheckerDeps,
+  ) {
+    this.checker = new ProjectRoleChecker(options, deps);
+  }
+
+  async evaluate(ctx: ServerMiddlewareContext): Promise<MiddlewareVerdict> {
+    if (this.options.enforce === "off") return pass();
+    if (ctx.mode !== "proxy") return pass();
+    if (!this.checker.shouldApplyToAction(ctx.action)) return pass();
+
+    const level = this.checker.actionAccessLevel(ctx.action);
+    if (!level) return pass();
+
+    const email = this.checker.resolveEmail(ctx);
+    if (!email) {
+      return this.dispatchDenial(
+        "project-role-missing-identity",
+        "Actor identity could not be resolved (header/env not present or claim missing)",
+      );
+    }
+
+    let projectId = this.checker.resolveProjectId(ctx);
+    if (!projectId && ctx.workflowId && ctx.fetchStoredWorkflow) {
+      try {
+        const stored = await ctx.fetchStoredWorkflow(ctx.workflowId);
+        projectId = workflowProjectId(stored);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (this.options.onError === "allow") {
+          return warn(`Stored workflow lookup failed (fail-open): ${message}`);
+        }
+        return this.dispatchDenial("project-role-stored-lookup-error", message);
+      }
+    }
+
+    const verdict = await this.checker.check({ email, projectId, level });
+    if (verdict.allowed) {
+      if (verdict.reason && verdict.rule.endsWith("-warning")) {
+        return warn(verdict.reason);
+      }
+      return pass();
+    }
+    return this.dispatchDenial(verdict.rule, verdict.reason ?? "Project role check failed");
+  }
+
+  private dispatchDenial(rule: string, message: string): MiddlewareVerdict {
+    const violations = [{ rule, severity: "error" as const, message }];
+    if (this.options.enforce === "warn") {
+      return {
+        block: false,
+        violations: violations.map((v) => ({ ...v, severity: "warning" as const })),
+      };
+    }
+    return {
+      block: true,
+      violations,
+      denial: {
+        status: 403,
+        error: "workflow_project_role_denied",
+        message,
+      },
+    };
+  }
+}
+
+function pass(): MiddlewareVerdict {
+  return { block: false, violations: [] };
+}
+
+function warn(message: string): MiddlewareVerdict {
+  return {
+    block: false,
+    violations: [{ rule: "project-role-warning", severity: "warning", message }],
+  };
+}
+
+export function extractProjectRoleChecker(
+  middlewares: ServerMiddleware[],
+): ProjectRoleChecker | null {
+  for (const mw of middlewares) {
+    if (mw.name === "project-role" && mw instanceof ProjectRoleMiddleware) {
+      return mw.checker;
+    }
+  }
+  return null;
+}

--- a/src/middleware/builtin/project-role/n8n-api.ts
+++ b/src/middleware/builtin/project-role/n8n-api.ts
@@ -1,0 +1,161 @@
+import type { ClientMiddleware } from "@/middleware/types.ts";
+import { forwardRequest } from "@/proxy/upstream.ts";
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface ProjectMember {
+  id: string;
+  email: string;
+  role: string | null;
+}
+
+export interface InstanceUser {
+  id: string;
+  email: string;
+  role: string | null;
+}
+
+export interface N8nProjectApiDeps {
+  upstream: string;
+  clientMiddlewares?: ClientMiddleware[];
+  timeoutMs?: number;
+  fetch?: FetchLike;
+}
+
+interface Paginated<T> {
+  data: T[];
+  nextCursor?: string;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+/**
+ * Reads n8n project membership and instance roles through the public API.
+ *
+ * Calls run under the proxy's own credentials (client middleware chain), not
+ * the caller's API key — listing members requires `user:list` on a service key.
+ */
+export class N8nProjectApi {
+  private readonly fetchImpl: FetchLike;
+  private readonly now: () => number;
+  private readonly membersCache = new Map<string, CacheEntry<ProjectMember[]>>();
+  private instanceUsersCache: CacheEntry<InstanceUser[]> | null = null;
+
+  constructor(
+    private readonly deps: N8nProjectApiDeps,
+    private readonly membersCacheTtlMs: number,
+    private readonly instanceRoleCacheTtlMs: number,
+    now: () => number = () => Date.now(),
+  ) {
+    this.fetchImpl =
+      deps.fetch ??
+      ((input, init) =>
+        forwardRequest(new Request(input, init), deps.upstream, undefined, {
+          timeoutMs: deps.timeoutMs,
+          clientMiddlewares: deps.clientMiddlewares,
+        }).then((r) => r.response));
+    this.now = now;
+  }
+
+  async projectRoleForEmail(projectId: string, email: string): Promise<string | null> {
+    const members = await this.listProjectMembers(projectId);
+    const normalized = email.trim().toLowerCase();
+    const hit = members.find((m) => m.email.trim().toLowerCase() === normalized);
+    return hit?.role ?? null;
+  }
+
+  async instanceRoleForEmail(email: string): Promise<string | null> {
+    const users = await this.listInstanceUsers();
+    const normalized = email.trim().toLowerCase();
+    const hit = users.find((u) => u.email.trim().toLowerCase() === normalized);
+    return hit?.role ?? null;
+  }
+
+  async listProjectMembers(projectId: string): Promise<ProjectMember[]> {
+    const cached = this.membersCache.get(projectId);
+    if (cached && cached.expiresAt > this.now()) return cached.value;
+
+    const collected: ProjectMember[] = [];
+    let cursor: string | undefined;
+    do {
+      const query = new URLSearchParams({ limit: "100" });
+      if (cursor) query.set("cursor", cursor);
+      const response = await this.get(
+        `/api/v1/projects/${encodeURIComponent(projectId)}/users?${query}`,
+      );
+      if (response.status === 404) {
+        throw new Error(`project ${projectId} was not found upstream`);
+      }
+      if (!response.ok) {
+        throw new Error(`project members lookup returned HTTP ${response.status}`);
+      }
+      const page = (await response.json()) as Paginated<Record<string, unknown>>;
+      for (const row of page.data ?? []) {
+        const id = typeof row.id === "string" ? row.id : "";
+        const memberEmail = typeof row.email === "string" ? row.email : "";
+        const role = typeof row.role === "string" ? row.role : null;
+        if (id && memberEmail) collected.push({ id, email: memberEmail, role });
+      }
+      cursor =
+        typeof page.nextCursor === "string" && page.nextCursor !== "" ? page.nextCursor : undefined;
+    } while (cursor);
+
+    if (this.membersCacheTtlMs > 0) {
+      this.membersCache.set(projectId, {
+        value: collected,
+        expiresAt: this.now() + this.membersCacheTtlMs,
+      });
+    }
+    return collected;
+  }
+
+  private async listInstanceUsers(): Promise<InstanceUser[]> {
+    if (this.instanceUsersCache && this.instanceUsersCache.expiresAt > this.now()) {
+      return this.instanceUsersCache.value;
+    }
+
+    const collected: InstanceUser[] = [];
+    let cursor: string | undefined;
+    do {
+      const query = new URLSearchParams({ limit: "100", includeRole: "true" });
+      if (cursor) query.set("cursor", cursor);
+      const response = await this.get(`/api/v1/users?${query}`);
+      if (!response.ok) {
+        throw new Error(`instance users lookup returned HTTP ${response.status}`);
+      }
+      const page = (await response.json()) as Paginated<Record<string, unknown>>;
+      for (const row of page.data ?? []) {
+        const id = typeof row.id === "string" ? row.id : "";
+        const userEmail = typeof row.email === "string" ? row.email : "";
+        const role = typeof row.role === "string" ? row.role : null;
+        if (id && userEmail) collected.push({ id, email: userEmail, role });
+      }
+      cursor =
+        typeof page.nextCursor === "string" && page.nextCursor !== "" ? page.nextCursor : undefined;
+    } while (cursor);
+
+    if (this.instanceRoleCacheTtlMs > 0) {
+      this.instanceUsersCache = {
+        value: collected,
+        expiresAt: this.now() + this.instanceRoleCacheTtlMs,
+      };
+    }
+    return collected;
+  }
+
+  private get(path: string): Promise<Response> {
+    const url = `${this.deps.upstream}${path}`;
+    return this.fetchImpl(url, {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+  }
+
+  clearCache(): void {
+    this.membersCache.clear();
+    this.instanceUsersCache = null;
+  }
+}

--- a/src/middleware/builtin/project-role/roles.ts
+++ b/src/middleware/builtin/project-role/roles.ts
@@ -1,0 +1,25 @@
+/** Built-in n8n project roles exposed through the public API. */
+export const PROJECT_ROLE_ADMIN = "project:admin";
+export const PROJECT_ROLE_EDITOR = "project:editor";
+export const PROJECT_ROLE_VIEWER = "project:viewer";
+
+/** Instance roles that bypass per-project membership checks. */
+export const INSTANCE_ROLE_OWNER = "global:owner";
+export const INSTANCE_ROLE_ADMIN = "global:admin";
+
+export type AccessLevel = "read" | "write";
+
+const WRITE_ROLES = new Set([PROJECT_ROLE_ADMIN, PROJECT_ROLE_EDITOR]);
+const READ_ROLES = new Set([PROJECT_ROLE_ADMIN, PROJECT_ROLE_EDITOR, PROJECT_ROLE_VIEWER]);
+
+/** True when an instance-level role grants access regardless of project membership. */
+export function isInstanceWideAdmin(role: string | null | undefined): boolean {
+  return role === INSTANCE_ROLE_OWNER || role === INSTANCE_ROLE_ADMIN;
+}
+
+/** True when a project role satisfies the requested access level. Unknown slugs deny. */
+export function projectRoleSatisfies(role: string | null | undefined, level: AccessLevel): boolean {
+  if (!role) return false;
+  if (level === "write") return WRITE_ROLES.has(role);
+  return READ_ROLES.has(role);
+}

--- a/src/middleware/builtin/project-role/types.ts
+++ b/src/middleware/builtin/project-role/types.ts
@@ -1,0 +1,30 @@
+import type { IdentitySpec } from "@/middleware/identity.ts";
+
+export type ProjectRoleEnforce = "off" | "warn" | "error";
+export type ProjectRoleOnError = "deny" | "allow";
+export type ProjectRoleOnMissingProject = "deny" | "allow";
+
+export interface ProjectRoleOptions {
+  enforce: ProjectRoleEnforce;
+  /** Behavior when n8n membership lookups fail. */
+  onError: ProjectRoleOnError;
+  /**
+   * What to do when the target workflow has no project id (typical on create).
+   * n8n assigns those to the caller's personal project upstream; the proxy
+   * cannot see that mapping without an extra round trip.
+   */
+  onMissingProject: ProjectRoleOnMissingProject;
+  /** Where to read the actor email when oauth-verify did not populate ctx.identity. */
+  identity: IdentitySpec;
+  /** Cache TTL for project member lists (milliseconds). */
+  membersCacheTtlMs: number;
+  /** Cache TTL for instance user roles (milliseconds). */
+  instanceRoleCacheTtlMs: number;
+  /** HTTP timeout for n8n membership lookups. */
+  timeoutMs: number;
+  /**
+   * When non-empty, only these route actions run the check. Empty means every
+   * action the host hands us (create, update, delete, activate, tags, read).
+   */
+  actions: string[];
+}

--- a/src/middleware/wiring.ts
+++ b/src/middleware/wiring.ts
@@ -2,6 +2,7 @@ import { authzFactory } from "./builtin/authz/factory.ts";
 import { impersonatorVerifyFactory } from "./builtin/impersonator-verify/factory.ts";
 import { lintFactory } from "./builtin/lint/factory.ts";
 import { oauthVerifyFactory } from "./builtin/oauth-verify/factory.ts";
+import { projectRoleFactory } from "./builtin/project-role/factory.ts";
 import { staleWriteFactory } from "./builtin/stale-write/factory.ts";
 import { knownMiddlewareNames, registerFactory } from "./registry.ts";
 
@@ -17,6 +18,7 @@ export function registerBuiltins(): void {
   registerFactory(oauthVerifyFactory);
   registerFactory(impersonatorVerifyFactory);
   registerFactory(staleWriteFactory);
+  registerFactory(projectRoleFactory);
 }
 
 /**

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -18,6 +18,8 @@
  * server-to-client `GET` stream, session teardown — is forwarded untouched.
  */
 
+import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
+import { mcpToolAccessLevel } from "@/middleware/builtin/project-role/mcp-tools.ts";
 import type { EnforceLevel } from "../config.ts";
 import type { Logger } from "../logging.ts";
 import { forwardRequest } from "../upstream.ts";
@@ -55,6 +57,8 @@ export interface McpGateDeps {
   logger: Logger;
   timeoutMs?: number;
   clientMiddlewares?: import("@/middleware/types.ts").ClientMiddleware[];
+  /** When set, workflow-scoped tool calls also require n8n project membership. */
+  projectRoleChecker?: ProjectRoleChecker | null;
 }
 
 /**
@@ -111,7 +115,7 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
 
   const refusals: JsonRpcMessage[] = [];
   for (const message of parsed.messages) {
-    const refusal = await refuse(message, pathname, deps);
+    const refusal = await refuse(message, pathname, deps, req);
     if (refusal) refusals.push(refusal);
   }
 
@@ -284,6 +288,7 @@ async function refuse(
   message: JsonRpcMessage,
   pathname: string,
   deps: McpGateDeps,
+  req: Request,
 ): Promise<JsonRpcMessage | null> {
   const tool = toolCallName(message);
   if (tool === null) return null;
@@ -332,21 +337,51 @@ async function refuse(
   if (target !== undefined) mentioned.add(target);
 
   const forbidden = [...mentioned].filter((id) => !sets.allowed.has(id));
-  if (forbidden.length === 0) return null;
+  if (forbidden.length > 0) {
+    // Name the reason. An agent told only "no" retries; one told the entry
+    // trigger declares no path can report something its user can act on.
+    const detail = forbidden
+      .map((id) => `${id} (${explainRefusal(deps.policy, sets.facts.get(id))})`)
+      .join("; ");
 
-  // Name the reason. An agent told only "no" retries; one told the entry
-  // trigger declares no path can report something its user can act on.
-  const detail = forbidden
-    .map((id) => `${id} (${explainRefusal(deps.policy, sets.facts.get(id))})`)
-    .join("; ");
+    log(deps, pathname, `workflow out of MCP scope: ${detail}`, tool);
+    return toolErrorResult(
+      message.id,
+      `Not available over MCP: ${detail}. Note that every workflow id anywhere in the arguments is ` +
+        "checked, so this may name one the call merely referenced — a sub-workflow, say — rather " +
+        "than the one it targeted. Ask the owner to bring it under this instance's MCP policy.",
+    );
+  }
 
-  log(deps, pathname, `workflow out of MCP scope: ${detail}`, tool);
-  return toolErrorResult(
-    message.id,
-    `Not available over MCP: ${detail}. Note that every workflow id anywhere in the arguments is ` +
-      "checked, so this may name one the call merely referenced — a sub-workflow, say — rather " +
-      "than the one it targeted. Ask the owner to bring it under this instance's MCP policy.",
-  );
+  if (deps.projectRoleChecker && target !== undefined) {
+    const level = mcpToolAccessLevel(tool);
+    if (level) {
+      const facts = sets.facts.get(target);
+      const projectId = facts?.projectId ?? "";
+      const email = deps.projectRoleChecker.resolveEmail({
+        workflow: null,
+        request: req,
+        mode: "proxy",
+      });
+      if (!email) {
+        log(deps, pathname, "project-role: missing identity", tool);
+        return toolErrorResult(
+          message.id,
+          "This proxy could not resolve the caller identity required for n8n project authorization.",
+        );
+      }
+      const verdict = await deps.projectRoleChecker.check({ email, projectId, level });
+      if (!verdict.allowed) {
+        log(deps, pathname, `project-role denied: ${verdict.reason ?? verdict.rule}`, tool);
+        return toolErrorResult(
+          message.id,
+          verdict.reason ?? "This caller lacks the n8n project role required for that tool.",
+        );
+      }
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/proxy/mcp/workflow-index.ts
+++ b/src/proxy/mcp/workflow-index.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Workflow } from "@/api/types.ts";
+import { workflowProjectId } from "@/common/project-id.ts";
 import type { ClientMiddleware } from "@/middleware/types.ts";
 import { forwardRequest } from "../upstream.ts";
 import {
@@ -53,6 +54,8 @@ export interface WorkflowFacts {
   availableInMCP: boolean;
   /** The trigger n8n would start an MCP execution from, if any. */
   entry: EntryTrigger | null;
+  /** Owning n8n project, when upstream includes shared metadata. */
+  projectId: string;
 }
 
 export interface WorkflowSets {
@@ -289,5 +292,6 @@ function toFacts(workflow: Workflow): WorkflowFacts {
     tags: (workflow.tags ?? []).map((t) => t.name),
     availableInMCP: workflow.settings?.availableInMCP === true,
     entry: findEntryTrigger(workflow.nodes),
+    projectId: workflowProjectId(workflow),
   };
 }

--- a/src/proxy/rest/read-gate.ts
+++ b/src/proxy/rest/read-gate.ts
@@ -1,0 +1,63 @@
+import type { Workflow } from "@/api/types.ts";
+import { workflowProjectId } from "@/common/project-id.ts";
+import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
+import type { PipelineVerdict } from "@/middleware/types.ts";
+
+export interface ReadGateDeps {
+  checker: ProjectRoleChecker;
+  fetchStoredWorkflow: (id: string, apiKey: string | null) => Promise<Workflow | null>;
+}
+
+/**
+ * Runs the project-role checker for a GET /api/v1/workflows/:id request.
+ * Returns a pipeline-shaped denial when the caller lacks viewer access.
+ */
+export async function evaluateWorkflowReadGate(
+  req: Request,
+  workflowId: string,
+  deps: ReadGateDeps,
+): Promise<PipelineVerdict | null> {
+  const checker = deps.checker;
+  if (!checker.shouldApplyToAction("read")) return null;
+
+  const ctx = {
+    workflow: null,
+    request: req,
+    mode: "proxy" as const,
+    action: "read",
+    workflowId,
+    fetchStoredWorkflow: (id: string) =>
+      deps.fetchStoredWorkflow(id, req.headers.get("x-n8n-api-key")),
+  };
+
+  const email = checker.resolveEmail(ctx);
+  if (!email) {
+    return denial("project-role-missing-identity", "Actor identity could not be resolved");
+  }
+
+  let stored: Workflow | null;
+  try {
+    stored = await deps.fetchStoredWorkflow(workflowId, req.headers.get("x-n8n-api-key"));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return denial("project-role-stored-lookup-error", message);
+  }
+
+  const projectId = workflowProjectId(stored);
+  const verdict = await checker.check({ email, projectId, level: "read" });
+  if (verdict.allowed) return null;
+  return denial(verdict.rule, verdict.reason ?? "Project role check failed");
+}
+
+function denial(rule: string, message: string): PipelineVerdict {
+  return {
+    block: true,
+    blockedBy: "project-role",
+    violations: [{ rule, severity: "error", message }],
+    denial: {
+      status: 403,
+      error: "workflow_project_role_denied",
+      message,
+    },
+  };
+}

--- a/src/proxy/rest/read-router.ts
+++ b/src/proxy/rest/read-router.ts
@@ -1,0 +1,23 @@
+/**
+ * Read routes where the proxy can resolve a single workflow and enforce n8n
+ * project membership before forwarding to upstream.
+ */
+
+export interface WorkflowRead {
+  action: "read";
+  id: string;
+}
+
+const READ_PATTERN = /^\/api\/v1\/workflows\/([^/]+)$/;
+
+/**
+ * Matches GET requests for a single workflow by id. List endpoints and
+ * unrelated paths return null and are forwarded without a project-role check.
+ */
+export function matchWorkflowRead(method: string, pathname: string): WorkflowRead | null {
+  if (method.toUpperCase() !== "GET") return null;
+  const normalized = pathname.replace(/\/+$/, "");
+  const hit = normalized.match(READ_PATTERN);
+  if (!hit?.[1]) return null;
+  return { action: "read", id: decodeURIComponent(hit[1]) };
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,6 +1,8 @@
 import { STALE_WRITE_WARNING_HEADER } from "@/api/headers.ts";
 import type { Workflow } from "@/api/types.ts";
 import { hasAllTags } from "@/common/tags.ts";
+import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
+import { extractProjectRoleChecker } from "@/middleware/builtin/project-role/middleware.ts";
 import { STALE_WRITE_RULE } from "@/middleware/builtin/stale-write/middleware.ts";
 import { buildClientMiddlewares } from "@/middleware/client-registry.ts";
 import {
@@ -22,6 +24,8 @@ import {
   buildDuplicateResponse,
   buildErrorResponse,
 } from "./response.ts";
+import { evaluateWorkflowReadGate } from "./rest/read-gate.ts";
+import { matchWorkflowRead } from "./rest/read-router.ts";
 import { matchWorkflowMutation, type WorkflowMutation } from "./rest/router.ts";
 import { forwardRequest } from "./upstream.ts";
 
@@ -52,6 +56,7 @@ interface HandlerDeps {
   readiness: ReadinessState;
   /** Built when the operator configured an MCP policy; absent otherwise. */
   mcp: McpGateDeps | null;
+  projectRoleChecker: ProjectRoleChecker | null;
 }
 
 /** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
@@ -80,21 +85,8 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
   // Stitch the legacy --enforce / --lint-config / --disable-rule flags into
   // the lint middleware's CLI options bag. This lets the existing test
   // surface keep working without callers having to change to the new flags.
-  const legacyCliOpts: Record<string, unknown> = {
-    lintEnforce: config.enforce,
-    ...(config.lintConfigPath ? { lintConfig: config.lintConfigPath } : {}),
-    ...(config.disableRules.length ? { lintDisableRule: config.disableRules } : {}),
-    ...(config.middlewareCliOptions ?? {}),
-  };
-
-  const middlewares = buildMiddlewares({
-    enabled,
-    env: process.env,
-    cliOpts: legacyCliOpts,
-  });
-
-  // Resolve and build the client-side (outgoing) middleware chain. Empty by
-  // default — deployments without IAP / shared API key skip this entirely.
+  // Resolve and build the client-side (outgoing) middleware chain first —
+  // project-role membership lookups run through it when listing members.
   const enabledClient = resolveEnabledList({
     cliValue: config.clientMiddlewares?.join(","),
     env: process.env,
@@ -106,6 +98,23 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     env: process.env,
     cliOpts: config.clientMiddlewareCliOptions ?? {},
   });
+
+  const legacyCliOpts: Record<string, unknown> = {
+    lintEnforce: config.enforce,
+    ...(config.lintConfigPath ? { lintConfig: config.lintConfigPath } : {}),
+    ...(config.disableRules.length ? { lintDisableRule: config.disableRules } : {}),
+    ...(config.middlewareCliOptions ?? {}),
+    projectRoleUpstream: upstream,
+    clientMiddlewares,
+  };
+
+  const middlewares = buildMiddlewares({
+    enabled,
+    env: process.env,
+    cliOpts: legacyCliOpts,
+  });
+
+  const projectRoleChecker = extractProjectRoleChecker(middlewares);
 
   const mcpSettings = config.mcp ?? null;
   const mcp: McpGateDeps | null = mcpSettings
@@ -125,6 +134,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
         logger,
         timeoutMs: config.upstreamTimeoutMs,
         clientMiddlewares,
+        projectRoleChecker,
       }
     : null;
 
@@ -185,6 +195,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     clientMiddlewares,
     readiness,
     mcp,
+    projectRoleChecker,
   };
 
   const server = Bun.serve({
@@ -293,6 +304,28 @@ async function handleTransparentForward(
   pathname: string,
   deps: HandlerDeps,
 ): Promise<Response> {
+  const read = matchWorkflowRead(req.method, pathname);
+  if (read && deps.projectRoleChecker) {
+    try {
+      const denial = await evaluateWorkflowReadGate(req, read.id, {
+        checker: deps.projectRoleChecker,
+        fetchStoredWorkflow: (id, apiKey) => fetchStoredWorkflow(id, apiKey, deps),
+      });
+      if (denial?.block) {
+        deps.logger.log({
+          action: "block",
+          method: req.method,
+          path: pathname,
+          status: denial.denial?.status ?? 403,
+          message: denial.denial?.message,
+        });
+        return buildDenialResponse(denial);
+      }
+    } catch (err) {
+      return reportError(err, req, pathname, deps);
+    }
+  }
+
   try {
     const { response, elapsedMs } = await forwardRequest(req, deps.upstream, undefined, {
       timeoutMs: deps.config.upstreamTimeoutMs,

--- a/tests/middleware/builtin/project-role.test.ts
+++ b/tests/middleware/builtin/project-role.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import type { Workflow } from "@/api/types.ts";
+import { workflowProjectId } from "@/common/project-id.ts";
+import { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
+import { mcpToolAccessLevel } from "@/middleware/builtin/project-role/mcp-tools.ts";
+import { ProjectRoleMiddleware } from "@/middleware/builtin/project-role/middleware.ts";
+import type { FetchLike } from "@/middleware/builtin/project-role/n8n-api.ts";
+import {
+  PROJECT_ROLE_EDITOR,
+  PROJECT_ROLE_VIEWER,
+  projectRoleSatisfies,
+} from "@/middleware/builtin/project-role/roles.ts";
+import type { ProjectRoleOptions } from "@/middleware/builtin/project-role/types.ts";
+import type { ServerMiddlewareContext } from "@/middleware/types.ts";
+
+const PROJECT = "proj-1";
+
+function workflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    name: "wf",
+    active: false,
+    nodes: [],
+    connections: {},
+    shared: [{ role: "workflow:owner", projectId: PROJECT }],
+    ...overrides,
+  };
+}
+
+function options(overrides: Partial<ProjectRoleOptions> = {}): ProjectRoleOptions {
+  return {
+    enforce: "error",
+    onError: "deny",
+    onMissingProject: "deny",
+    identity: { source: "header", name: "x-user-email", decode: "raw" },
+    membersCacheTtlMs: 60_000,
+    instanceRoleCacheTtlMs: 60_000,
+    timeoutMs: 5_000,
+    actions: [],
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function apiFetch(
+  members: Array<{ email: string; role: string }>,
+  instanceUsers: Array<{ email: string; role: string }>,
+): FetchLike {
+  return (input) => {
+    const url = String(input);
+    if (url.includes("/projects/") && url.includes("/users")) {
+      return Promise.resolve(
+        jsonResponse({
+          data: members.map((m, i) => ({ id: `u${i}`, email: m.email, role: m.role })),
+        }),
+      );
+    }
+    if (url.includes("/api/v1/users")) {
+      return Promise.resolve(
+        jsonResponse({
+          data: instanceUsers.map((u, i) => ({ id: `iu${i}`, email: u.email, role: u.role })),
+        }),
+      );
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+}
+
+describe("project roles", () => {
+  test("viewer satisfies read but not write", () => {
+    expect(projectRoleSatisfies(PROJECT_ROLE_VIEWER, "read")).toBe(true);
+    expect(projectRoleSatisfies(PROJECT_ROLE_VIEWER, "write")).toBe(false);
+  });
+
+  test("editor satisfies read and write", () => {
+    expect(projectRoleSatisfies(PROJECT_ROLE_EDITOR, "read")).toBe(true);
+    expect(projectRoleSatisfies(PROJECT_ROLE_EDITOR, "write")).toBe(true);
+  });
+
+  test("workflowProjectId prefers workflow:owner", () => {
+    expect(
+      workflowProjectId(
+        workflow({
+          shared: [
+            { role: "workflow:editor", projectId: "other" },
+            { role: "workflow:owner", projectId: PROJECT },
+          ],
+        }),
+      ),
+    ).toBe(PROJECT);
+  });
+});
+
+describe("ProjectRoleChecker", () => {
+  test("allows editor on write", async () => {
+    const checker = new ProjectRoleChecker(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([{ email: "editor@example.com", role: PROJECT_ROLE_EDITOR }], []),
+    });
+    const result = await checker.check({
+      email: "editor@example.com",
+      projectId: PROJECT,
+      level: "write",
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  test("denies viewer on write", async () => {
+    const checker = new ProjectRoleChecker(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([{ email: "viewer@example.com", role: PROJECT_ROLE_VIEWER }], []),
+    });
+    const result = await checker.check({
+      email: "viewer@example.com",
+      projectId: PROJECT,
+      level: "write",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.rule).toBe("project-role-denied");
+  });
+
+  test("allows viewer on read", async () => {
+    const checker = new ProjectRoleChecker(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([{ email: "viewer@example.com", role: PROJECT_ROLE_VIEWER }], []),
+    });
+    const result = await checker.check({
+      email: "viewer@example.com",
+      projectId: PROJECT,
+      level: "read",
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  test("denies user with no project membership", async () => {
+    const checker = new ProjectRoleChecker(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([], []),
+    });
+    const result = await checker.check({
+      email: "stranger@example.com",
+      projectId: PROJECT,
+      level: "read",
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  test("instance admin bypasses project membership", async () => {
+    const checker = new ProjectRoleChecker(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([], [{ email: "admin@example.com", role: "global:admin" }]),
+    });
+    const result = await checker.check({
+      email: "admin@example.com",
+      projectId: PROJECT,
+      level: "write",
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.rule).toBe("project-role-instance-admin");
+  });
+});
+
+describe("ProjectRoleMiddleware", () => {
+  function ctx(overrides: Partial<ServerMiddlewareContext> = {}): ServerMiddlewareContext {
+    const headers = new Headers({ "x-user-email": "viewer@example.com" });
+    return {
+      workflow: workflow(),
+      request: new Request("http://proxy/api/v1/workflows/wf1", { method: "PUT", headers }),
+      mode: "proxy",
+      action: "update",
+      workflowId: "wf1",
+      ...overrides,
+    };
+  }
+
+  test("blocks viewer updating a workflow", async () => {
+    const mw = new ProjectRoleMiddleware(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([{ email: "viewer@example.com", role: PROJECT_ROLE_VIEWER }], []),
+    });
+    const verdict = await mw.evaluate(ctx());
+    expect(verdict.block).toBe(true);
+    expect(verdict.denial?.error).toBe("workflow_project_role_denied");
+  });
+
+  test("passes editor updating a workflow", async () => {
+    const mw = new ProjectRoleMiddleware(options(), {
+      upstream: "http://n8n.invalid",
+      fetch: apiFetch([{ email: "editor@example.com", role: PROJECT_ROLE_EDITOR }], []),
+    });
+    const verdict = await mw.evaluate(
+      ctx({
+        request: new Request("http://proxy/api/v1/workflows/wf1", {
+          method: "PUT",
+          headers: { "x-user-email": "editor@example.com" },
+        }),
+      }),
+    );
+    expect(verdict.block).toBe(false);
+  });
+});
+
+describe("mcpToolAccessLevel", () => {
+  test("classifies read and write MCP tools", () => {
+    expect(mcpToolAccessLevel("get_workflow_details")).toBe("read");
+    expect(mcpToolAccessLevel("execute_workflow")).toBe("write");
+    expect(mcpToolAccessLevel("search_workflows")).toBeUndefined();
+  });
+});

--- a/tests/proxy/proxy.project-role.test.ts
+++ b/tests/proxy/proxy.project-role.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { matchWorkflowRead } from "@/proxy/rest/read-router.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface MockUpstream {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  captured: CapturedRequest[];
+}
+
+function startMockUpstream(handlers: {
+  members?: Array<{ email: string; role: string }>;
+  instanceUsers?: Array<{ email: string; role: string }>;
+  workflows?: Record<string, unknown>;
+}): MockUpstream {
+  const captured: CapturedRequest[] = [];
+  const members = handlers.members ?? [];
+  const instanceUsers = handlers.instanceUsers ?? [];
+  const workflows = handlers.workflows ?? {};
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({ method: req.method, pathname: url.pathname, headers, body });
+
+      if (url.pathname.includes("/projects/") && url.pathname.endsWith("/users")) {
+        return Response.json({
+          data: members.map((m, i) => ({ id: `u${i}`, email: m.email, role: m.role })),
+        });
+      }
+      if (url.pathname === "/api/v1/users") {
+        return Response.json({
+          data: instanceUsers.map((u, i) => ({ id: `iu${i}`, email: u.email, role: u.role })),
+        });
+      }
+      const wfMatch = url.pathname.match(/^\/api\/v1\/workflows\/([^/]+)$/);
+      if (wfMatch?.[1]) {
+        const wf = workflows[decodeURIComponent(wfMatch[1])];
+        if (wf) return Response.json(wf);
+        return new Response("not found", { status: 404 });
+      }
+      if (req.method === "PUT" && url.pathname.startsWith("/api/v1/workflows/")) {
+        return Response.json({ ok: true });
+      }
+      return Response.json({ ok: true });
+    },
+  });
+
+  return { server, port: server.port as number, captured };
+}
+
+const STORED_WORKFLOW = {
+  id: "wf1",
+  name: "Demo",
+  active: false,
+  nodes: [],
+  connections: {},
+  shared: [{ role: "workflow:owner", projectId: "proj-1" }],
+};
+
+let proxy: ProxyHandle;
+let upstream: MockUpstream;
+
+beforeEach(() => {
+  upstream = startMockUpstream({
+    members: [{ email: "viewer@example.com", role: "project:viewer" }],
+    workflows: { wf1: STORED_WORKFLOW },
+  });
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+});
+
+function startProxyWithProjectRole(): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    middlewares: ["project-role"],
+    middlewareCliOptions: {
+      projectRoleEnforce: "error",
+      projectRoleIdentitySource: "header",
+      projectRoleIdentityName: "x-user-email",
+    },
+  });
+  return proxy;
+}
+
+describe("read router", () => {
+  test("matches GET /api/v1/workflows/:id", () => {
+    expect(matchWorkflowRead("GET", "/api/v1/workflows/wf1")).toEqual({
+      action: "read",
+      id: "wf1",
+    });
+    expect(matchWorkflowRead("GET", "/api/v1/workflows")).toBeNull();
+  });
+});
+
+describe("proxy project-role enforcement", () => {
+  test("blocks viewer from PUT /workflows/:id", async () => {
+    startProxyWithProjectRole();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "x-user-email": "viewer@example.com",
+      },
+      body: JSON.stringify({ name: "Demo", active: false, nodes: [], connections: {} }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("workflow_project_role_denied");
+    expect(
+      upstream.captured.some((c) => c.method === "PUT" && c.pathname.includes("/workflows/wf1")),
+    ).toBe(false);
+  });
+
+  test("allows viewer to GET /workflows/:id", async () => {
+    startProxyWithProjectRole();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      headers: { "x-user-email": "viewer@example.com" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("blocks non-member from GET /workflows/:id", async () => {
+    startProxyWithProjectRole();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      headers: { "x-user-email": "stranger@example.com" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("allows viewer to GET /workflows/:id when only write is in scope", async () => {
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      middlewares: ["project-role"],
+      middlewareCliOptions: {
+        projectRoleEnforce: "error",
+        projectRoleIdentitySource: "header",
+        projectRoleIdentityName: "x-user-email",
+        projectRoleActions: "update,delete",
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      headers: { "x-user-email": "viewer@example.com" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("allows editor to PUT /workflows/:id", async () => {
+    upstream.server.stop(true);
+    upstream = startMockUpstream({
+      members: [{ email: "editor@example.com", role: "project:editor" }],
+      workflows: { wf1: STORED_WORKFLOW },
+    });
+    startProxyWithProjectRole();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "x-user-email": "editor@example.com",
+      },
+      body: JSON.stringify({ name: "Demo", active: false, nodes: [], connections: {} }),
+    });
+    expect(res.status).toBe(200);
+    expect(upstream.captured.some((c) => c.method === "PUT")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `project-role` server middleware that mirrors n8n's built-in project roles (`project:admin`, `project:editor`, `project:viewer`): read requires viewer+, write requires editor+
- Resolve caller email from oauth-verify / impersonator headers (or configured identity header) and look up membership via n8n public API (`GET /api/v1/projects/:id/users`, `GET /api/v1/users?includeRole=true`)
- Enforce on workflow write routes (existing mutation pipeline), `GET /api/v1/workflows/:id`, and workflow-scoped MCP tool calls; instance `global:owner` / `global:admin` bypass project checks

## API investigation (blocker check)
- Project members: `GET /api/v1/projects/{projectId}/users` — requires `user:list` scope; available since n8n 2.8.0
- Instance roles: `GET /api/v1/users?includeRole=true` — used to bypass for owners/admins
- Custom project roles are not evaluated yet (unknown slugs deny)

## Usage
```bash
n8n-cli proxy \
  --server-middleware lint,oauth-verify,project-role \
  --project-role-enforce error \
  --project-role-identity-source header \
  --project-role-identity-name x-user-email \
  --client-middleware api-key-inject
```
The proxy's service API key (via client middleware) must carry `user:list` for membership lookups.

## Test plan
- [x] `make quality-gate` (typecheck, lint, third-party licenses, full test suite)
- [x] Unit tests for role hierarchy, checker, middleware
- [x] Integration tests for PUT/GET workflow enforcement via proxy


Made with [Cursor](https://cursor.com)