### PR TITLE
test: CLI を proxy 経由で mock n8n に通すインテグレーションテスト

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,30 @@ jobs:
       - name: Run tests
         run: bun test
 
+  # Named gate for the CLI → proxy → mock n8n hop. `bun test` above already
+  # includes these files; this job exists so a contract break between the CLI
+  # HTTP client and the proxy shows up as its own required check, not a line
+  # buried in the unit suite.
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate schemas
+        run: bun run generate-schemas
+
+      - name: Run CLI → proxy → mock n8n tests
+        run: bun test tests/integration/
+
   licenses:
     name: Third-Party Licenses
     runs-on: ubuntu-latest
@@ -95,7 +119,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, licenses]
+    needs: [lint, typecheck, test, licenses, integration]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,21 @@ make cross-compile
 ## Running Tests
 
 ```bash
-# Run all tests
+# Run all tests (unit + CLI + CLI→proxy→mock stack). This is what CI runs.
 make test
 
 # Or directly with Bun
 bun test
 
+# CLI integration tests (spawned CLI against a mock, with and without the proxy)
+make test-integration
+
 # Run a specific test file
 bun test tests/lint/rules/some-rule.test.ts
+bun test tests/integration/cli-through-proxy.test.ts
 ```
+
+`tests/integration/` stands up the full hop `CLI → proxy → mock n8n` in-process (ephemeral ports, no Docker). It is included in `make test` / the CI `bun test` job, so a contract break between the CLI HTTP client and the proxy fails the same gate as a unit regression.
 
 ## Type Checking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ make cross-compile
 ## Running Tests
 
 ```bash
-# Run all tests (unit + CLI + CLI→proxy→mock stack). This is what CI runs.
+# Run all tests (unit + CLI + CLI→proxy→mock stack)
 make test
 
 # Or directly with Bun
@@ -92,7 +92,7 @@ bun test tests/lint/rules/some-rule.test.ts
 bun test tests/integration/cli-through-proxy.test.ts
 ```
 
-`tests/integration/` stands up the full hop `CLI → proxy → mock n8n` in-process (ephemeral ports, no Docker). It is included in `make test` / the CI `bun test` job, so a contract break between the CLI HTTP client and the proxy fails the same gate as a unit regression.
+`tests/integration/` stands up the full hop `CLI → proxy → mock n8n` in-process (ephemeral ports, no Docker). CI runs it twice on purpose: inside the Test job (`bun test`) and as a dedicated Integration job (`bun test tests/integration/`) that `build` waits on, so a contract break between the CLI HTTP client and the proxy is a required check of its own.
 
 ## Type Checking
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 	bun test
 
 test-integration:
-	bun test tests/cli/
+	bun test tests/cli/ tests/integration/
 
 typecheck:
 	bunx tsc --noEmit

--- a/tests/integration/cli-through-proxy.test.ts
+++ b/tests/integration/cli-through-proxy.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Workflow } from "@/api/types.ts";
+import { withStack } from "./helpers/stack.ts";
+import { brokenWorkflow, cleanWorkflow } from "./helpers/workflows.ts";
+
+/**
+ * CLI → proxy → mock n8n.
+ *
+ * Unit tests already cover the CLI against a mock, and the proxy against a
+ * mock, separately. These scenarios wire the three together so a change in
+ * either hop that breaks the contract the other hop relies on fails in CI.
+ */
+
+const STORED_AT = "2026-03-01T10:00:00.000Z";
+const OLDER_AT = "2026-02-01T10:00:00.000Z";
+
+describe("CLI → proxy → mock n8n: reads", () => {
+  test("workflow list returns the workflows the mock seeded", async () => {
+    await withStack(
+      {
+        workflows: [
+          cleanWorkflow({ id: "wf-a", name: "Alpha" }),
+          cleanWorkflow({ id: "wf-b", name: "Beta", active: true }),
+        ],
+      },
+      async (stack) => {
+        const { stdout, exitCode } = await stack.runCli(["workflow", "list"]);
+        expect(exitCode).toBe(0);
+        const listed = JSON.parse(stdout) as Workflow[];
+        expect(listed.map((w) => w.id).sort()).toEqual(["wf-a", "wf-b"]);
+        expect(listed.map((w) => w.name).sort()).toEqual(["Alpha", "Beta"]);
+      },
+    );
+  });
+
+  test("workflow list follows cursor pagination through the proxy", async () => {
+    await withStack(
+      {
+        workflows: [
+          cleanWorkflow({ id: "wf-1", name: "One" }),
+          cleanWorkflow({ id: "wf-2", name: "Two" }),
+          cleanWorkflow({ id: "wf-3", name: "Three" }),
+        ],
+        listPageSize: 2,
+      },
+      async (stack) => {
+        const { stdout, exitCode } = await stack.runCli(["workflow", "list"]);
+        expect(exitCode).toBe(0);
+        const listed = JSON.parse(stdout) as Workflow[];
+        expect(listed).toHaveLength(3);
+        expect(stack.mock.captured.filter((r) => r.method === "GET")).toHaveLength(2);
+      },
+    );
+  });
+
+  test("workflow get returns a seeded workflow", async () => {
+    await withStack(
+      { workflows: [cleanWorkflow({ id: "wf-get", name: "Get Me" })] },
+      async (stack) => {
+        const { stdout, exitCode } = await stack.runCli(["workflow", "get", "wf-get"]);
+        expect(exitCode).toBe(0);
+        const wf = JSON.parse(stdout) as Workflow;
+        expect(wf.id).toBe("wf-get");
+        expect(wf.name).toBe("Get Me");
+      },
+    );
+  });
+
+  test("workflow get of a missing id exits 1 with a not-found error", async () => {
+    await withStack({}, async (stack) => {
+      const { stderr, exitCode } = await stack.runCli(["workflow", "get", "missing"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("not found");
+    });
+  });
+
+  test("an upstream 500 is surfaced by the CLI", async () => {
+    await withStack(
+      {
+        hook: (_req, url) => {
+          if (url.pathname === "/api/v1/workflows" || url.pathname === "/api/v1/workflows/") {
+            return new Response(JSON.stringify({ message: "upstream exploded" }), {
+              status: 500,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return null;
+        },
+      },
+      async (stack) => {
+        const { stderr, exitCode } = await stack.runCli(["workflow", "list"]);
+        expect(exitCode).toBe(1);
+        expect(stderr).toMatch(/upstream exploded|Server error/i);
+      },
+    );
+  });
+});
+
+describe("CLI → proxy → mock n8n: writes", () => {
+  test("workflow create stores the definition on the mock", async () => {
+    await withStack({}, async (stack) => {
+      const tmp = tmpDir();
+      const file = path.join(tmp, "new.json");
+      fs.writeFileSync(file, JSON.stringify(cleanWorkflow({ name: "Created Via CLI" })));
+      try {
+        const { stdout, exitCode } = await stack.runCli(["workflow", "create", "-f", file]);
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain("Created Via CLI");
+        const stored = [...stack.mock.workflows.values()];
+        expect(stored).toHaveLength(1);
+        expect(stored[0]?.name).toBe("Created Via CLI");
+        expect(stack.mock.writes().some((r) => r.method === "POST")).toBe(true);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("apply updates a remote workflow through the proxy", async () => {
+    const remote = cleanWorkflow({
+      id: "wf-upd",
+      name: "Before",
+      updatedAt: STORED_AT,
+      createdAt: STORED_AT,
+    });
+    await withStack({ workflows: [remote] }, async (stack) => {
+      const tmp = tmpDir();
+      fs.writeFileSync(
+        path.join(tmp, "renamed__wf-upd.json"),
+        JSON.stringify({ ...remote, name: "After" }),
+      );
+      try {
+        const { stdout, exitCode } = await stack.runCli([
+          "apply",
+          "--dir",
+          tmp,
+          "--ids",
+          "wf-upd",
+          "--no-auto-tag",
+        ]);
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain("UPDATE");
+        expect(stack.mock.get("wf-upd")?.name).toBe("After");
+        expect(stack.mock.writes().some((r) => r.method === "PUT")).toBe(true);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("import writes a remote workflow to disk through the proxy", async () => {
+    await withStack(
+      { workflows: [cleanWorkflow({ id: "wf-imp", name: "Imported" })] },
+      async (stack) => {
+        const tmp = tmpDir();
+        try {
+          const { exitCode } = await stack.runCli([
+            "import",
+            "--dir",
+            tmp,
+            "--ids",
+            "wf-imp",
+            "--no-yaml",
+            "--no-ts",
+          ]);
+          expect(exitCode).toBe(0);
+          const files = fs.readdirSync(tmp).filter((f) => f.endsWith(".json"));
+          expect(files.length).toBeGreaterThanOrEqual(1);
+          const written = JSON.parse(
+            fs.readFileSync(path.join(tmp, files[0]!), "utf8"),
+          ) as Workflow;
+          expect(written.id).toBe("wf-imp");
+          expect(written.name).toBe("Imported");
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
+  test("workflow activate flips the stored flag", async () => {
+    await withStack(
+      { workflows: [cleanWorkflow({ id: "wf-act", name: "Act", active: false })] },
+      async (stack) => {
+        const { stdout, exitCode } = await stack.runCli(["workflow", "activate", "wf-act"]);
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain("is now active");
+        expect(stack.mock.get("wf-act")?.active).toBe(true);
+      },
+    );
+  });
+});
+
+describe("CLI → proxy → mock n8n: proxy lint is the backstop", () => {
+  test("apply --no-lint of a broken workflow is still refused by the proxy", async () => {
+    await withStack({ allowDuplicates: true }, async (stack) => {
+      const tmp = tmpDir();
+      fs.writeFileSync(path.join(tmp, "broken.json"), JSON.stringify(brokenWorkflow()));
+      try {
+        const { stdout, stderr, exitCode } = await stack.runCli([
+          "apply",
+          "--dir",
+          tmp,
+          "--dangerously-apply-all",
+          "--no-lint",
+          "--no-auto-tag",
+        ]);
+        expect(exitCode).toBe(1);
+        expect(stdout + stderr).toMatch(/linter rule|connection-reference|workflow_lint_failed/i);
+        expect(stack.mock.writes()).toHaveLength(0);
+        expect(stack.mock.workflows.size).toBe(0);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("workflow create --no-lint of a broken workflow is still refused by the proxy", async () => {
+    await withStack({ allowDuplicates: true }, async (stack) => {
+      const tmp = tmpDir();
+      const file = path.join(tmp, "broken.json");
+      fs.writeFileSync(file, JSON.stringify(brokenWorkflow()));
+      try {
+        const { stderr, exitCode } = await stack.runCli([
+          "workflow",
+          "create",
+          "-f",
+          file,
+          "--no-lint",
+        ]);
+        expect(exitCode).toBe(1);
+        expect(stderr).toMatch(/linter rule|connection-reference|not forwarded/i);
+        expect(stack.mock.writes()).toHaveLength(0);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+describe("CLI → proxy → mock n8n: duplicate names", () => {
+  test("creating a workflow whose name already exists is a 409", async () => {
+    await withStack(
+      {
+        workflows: [cleanWorkflow({ id: "wf-dup", name: "Same Name" })],
+        allowDuplicates: false,
+        enforce: "error",
+      },
+      async (stack) => {
+        const tmp = tmpDir();
+        const file = path.join(tmp, "dup.json");
+        fs.writeFileSync(file, JSON.stringify(cleanWorkflow({ name: "Same Name" })));
+        try {
+          const { stderr, exitCode } = await stack.runCli([
+            "workflow",
+            "create",
+            "-f",
+            file,
+            "--no-lint",
+          ]);
+          expect(exitCode).toBe(1);
+          expect(stderr).toMatch(/already exists|duplicate/i);
+          expect(stack.mock.workflows.size).toBe(1);
+          expect(stack.mock.writes()).toHaveLength(0);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+});
+
+describe("CLI → proxy → mock n8n: api-key-inject", () => {
+  test("the CLI's key is replaced before the mock sees the request", async () => {
+    const injectVar = `N8N_TEST_INJECT_${crypto.randomUUID().replace(/-/g, "")}`;
+    await withStack(
+      {
+        workflows: [cleanWorkflow({ id: "wf-key", name: "Keyed" })],
+        requiredApiKey: "upstream-secret",
+        clientMiddlewares: ["api-key-inject"],
+        clientMiddlewareCliOptions: { apiKeyInjectKeyEnvVar: injectVar },
+        proxyEnv: { [injectVar]: "upstream-secret" },
+      },
+      async (stack) => {
+        const { exitCode } = await stack.runCli(["workflow", "list"], {
+          N8N_API_KEY: "cli-placeholder",
+        });
+        expect(exitCode).toBe(0);
+        const forwarded = stack.mock.captured.find((r) => r.pathname.includes("/workflows"));
+        expect(forwarded?.headers["x-n8n-api-key"]).toBe("upstream-secret");
+      },
+    );
+  });
+
+  test("without inject, a placeholder key is rejected by the mock", async () => {
+    await withStack(
+      {
+        workflows: [cleanWorkflow({ id: "wf-key", name: "Keyed" })],
+        requiredApiKey: "upstream-secret",
+      },
+      async (stack) => {
+        const { stderr, exitCode } = await stack.runCli(["workflow", "list"], {
+          N8N_API_KEY: "cli-placeholder",
+        });
+        expect(exitCode).toBe(1);
+        expect(stderr).toMatch(/Authentication failed|Unauthorized/i);
+      },
+    );
+  });
+});
+
+describe("CLI → proxy → mock n8n: stale-write", () => {
+  test("apply --force of a stale checkout is refused and does not revert upstream", async () => {
+    const remote = cleanWorkflow({
+      id: "wf1",
+      name: "Upstream Edit",
+      updatedAt: STORED_AT,
+      createdAt: STORED_AT,
+    });
+    await withStack(
+      {
+        workflows: [remote],
+        allowDuplicates: true,
+        middlewares: ["stale-write"],
+        middlewareCliOptions: { staleWriteEnforce: "error" },
+      },
+      async (stack) => {
+        const tmp = tmpDir();
+        fs.writeFileSync(
+          path.join(tmp, "stale__wf1.json"),
+          JSON.stringify({ ...remote, name: "Would Revert", updatedAt: OLDER_AT }),
+        );
+        try {
+          const { stdout, stderr, exitCode } = await stack.runCli([
+            "apply",
+            "--dir",
+            tmp,
+            "--ids",
+            "wf1",
+            "--force",
+            "--no-auto-tag",
+            "--no-lint",
+          ]);
+          expect(exitCode).toBe(1);
+          expect(stdout + stderr).toMatch(/stale|never seen|based on/i);
+          expect(stack.mock.get("wf1")?.name).toBe("Upstream Edit");
+          expect(stack.mock.writes()).toHaveLength(0);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+});
+
+describe("CLI → proxy → mock n8n: authz", () => {
+  test("a create with no ACL is refused and never reaches the mock", async () => {
+    const groups = startGroupsServer();
+    try {
+      await withStack(
+        {
+          allowDuplicates: true,
+          middlewares: ["authz"],
+          middlewareCliOptions: {
+            authzEnforce: "error",
+            authzOnError: "deny",
+            authzIdentitySource: "env",
+            authzIdentityName: "TEST_ACTOR",
+            authzIdentityDecode: "raw",
+            authzGroupsUrl: `http://127.0.0.1:${groups.port}/groups`,
+            authzGroupsMethod: "POST",
+            authzGroupsHeaders: '{"content-type":"application/json"}',
+            authzGroupsBody: '{"email": ${json:identity}}',
+            authzGroupsExtract: "$.groups[*].id",
+            authzWorkflowExtract: "$.tags[*].name",
+            authzWorkflowStripPrefix: "owner:",
+          },
+          proxyEnv: { TEST_ACTOR: "alice@example.com" },
+        },
+        async (stack) => {
+          const tmp = tmpDir();
+          const file = path.join(tmp, "wf.json");
+          fs.writeFileSync(file, JSON.stringify(cleanWorkflow({ name: "No ACL" })));
+          try {
+            const { stderr, exitCode } = await stack.runCli([
+              "workflow",
+              "create",
+              "-f",
+              file,
+              "--no-lint",
+            ]);
+            expect(exitCode).toBe(1);
+            expect(stderr).toMatch(/not declare any allowed groups|authz|denied/i);
+            expect(stack.mock.writes()).toHaveLength(0);
+          } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+          }
+        },
+      );
+    } finally {
+      await groups.stop();
+    }
+  });
+});
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "n8n-cli-stack-"));
+}
+
+function startGroupsServer(): { port: number; stop: () => Promise<void> } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch() {
+      return new Response(JSON.stringify({ groups: [{ id: "eng" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return {
+    port: server.port!,
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}

--- a/tests/integration/helpers/n8n-mock.ts
+++ b/tests/integration/helpers/n8n-mock.ts
@@ -1,0 +1,242 @@
+import type { Workflow } from "@/api/types.ts";
+
+export interface CapturedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface N8nMock {
+  port: number;
+  captured: CapturedRequest[];
+  workflows: Map<string, Workflow>;
+  /** Requests that would mutate upstream state (not the proxy's own GETs). */
+  writes: () => CapturedRequest[];
+  get: (id: string) => Workflow | undefined;
+  stop: () => Promise<void>;
+}
+
+export interface N8nMockOptions {
+  workflows?: Workflow[];
+  /** When set, any other `X-N8N-API-KEY` is answered with 401. */
+  requiredApiKey?: string;
+  /**
+   * Caps each `GET /workflows` page. The CLI paginates with `limit` + `cursor`;
+   * leaving this unset returns the full list in one response.
+   */
+  listPageSize?: number;
+  /**
+   * Escape hatch for error-injection tests. Return a Response to short-circuit
+   * the mock, or null to fall through to the in-memory store.
+   */
+  hook?: (req: Request, url: URL) => Response | null | Promise<Response | null>;
+}
+
+/**
+ * In-memory stand-in for n8n's public REST API, covering the endpoints the
+ * CLI actually calls through the proxy (list/get/create/update/delete,
+ * activate, tags).
+ */
+export function startN8nMock(opts: N8nMockOptions = {}): N8nMock {
+  const workflows = new Map<string, Workflow>();
+  const captured: CapturedRequest[] = [];
+  let seq = 0;
+
+  for (const wf of opts.workflows ?? []) {
+    const id = wf.id ?? `seed-${++seq}`;
+    workflows.set(id, clone({ ...wf, id, ...timestamps(wf) }));
+  }
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+      captured.push({
+        method: req.method,
+        pathname: url.pathname,
+        search: url.search,
+        headers,
+        body,
+      });
+
+      if (opts.hook) {
+        const hijack = await opts.hook(req, url);
+        if (hijack) return hijack;
+      }
+
+      if (opts.requiredApiKey) {
+        const key = req.headers.get("x-n8n-api-key");
+        if (key !== opts.requiredApiKey) {
+          return json({ message: "Unauthorized" }, 401);
+        }
+      }
+
+      return route(req.method, url, body);
+    },
+  });
+
+  function route(method: string, url: URL, raw: string): Response {
+    const path = url.pathname.replace(/\/+$/, "") || "/";
+
+    if (path === "/api/v1/tags") {
+      if (method === "GET") return json({ data: [], nextCursor: null });
+      if (method === "POST") {
+        const input = parseBody(raw);
+        return json({ id: `tag-${++seq}`, name: String(input.name ?? "tag") });
+      }
+    }
+
+    if (path === "/api/v1/workflows") {
+      if (method === "GET") return listWorkflows(url);
+      if (method === "POST") return createWorkflow(raw);
+    }
+
+    const wfMatch = path.match(/^\/api\/v1\/workflows\/([^/]+)(?:\/(activate|deactivate|tags))?$/);
+    if (wfMatch) {
+      const id = decodeURIComponent(wfMatch[1]!);
+      const sub = wfMatch[2];
+      if (!sub) {
+        if (method === "GET") return getWorkflow(id);
+        if (method === "PUT") return updateWorkflow(id, raw);
+        if (method === "DELETE") return deleteWorkflow(id);
+      }
+      if (sub === "activate" && method === "POST") return setActive(id, true);
+      if (sub === "deactivate" && method === "POST") return setActive(id, false);
+      if (sub === "tags" && method === "PUT") return getWorkflow(id);
+    }
+
+    return json({ message: "Not found" }, 404);
+  }
+
+  function listWorkflows(url: URL): Response {
+    let items = [...workflows.values()];
+    const active = url.searchParams.get("active");
+    if (active === "true") items = items.filter((w) => w.active);
+    if (active === "false") items = items.filter((w) => !w.active);
+
+    const requested = Number.parseInt(url.searchParams.get("limit") ?? "", 10);
+    const pageSize =
+      opts.listPageSize ?? (Number.isFinite(requested) && requested > 0 ? requested : items.length);
+    const cursor = Number.parseInt(url.searchParams.get("cursor") ?? "0", 10) || 0;
+    const page = items.slice(cursor, cursor + pageSize);
+    const next = cursor + pageSize;
+    return json({
+      data: page.map(clone),
+      nextCursor: next < items.length ? String(next) : null,
+    });
+  }
+
+  function getWorkflow(id: string): Response {
+    const wf = workflows.get(id);
+    if (!wf) return json({ message: "Resource not found" }, 404);
+    return json(clone(wf));
+  }
+
+  function createWorkflow(raw: string): Response {
+    const input = parseBody(raw);
+    const id = `mock-${++seq}`;
+    const now = nowIso();
+    const stored: Workflow = {
+      name: String(input.name ?? "untitled"),
+      active: false,
+      nodes: Array.isArray(input.nodes) ? (input.nodes as Workflow["nodes"]) : [],
+      connections:
+        input.connections && typeof input.connections === "object"
+          ? (input.connections as Workflow["connections"])
+          : {},
+      id,
+      createdAt: now,
+      updatedAt: now,
+      ...(typeof input.description === "string" ? { description: input.description } : {}),
+      ...(input.settings && typeof input.settings === "object"
+        ? { settings: input.settings as Workflow["settings"] }
+        : {}),
+    };
+    workflows.set(id, stored);
+    return json(clone(stored));
+  }
+
+  function updateWorkflow(id: string, raw: string): Response {
+    const existing = workflows.get(id);
+    if (!existing) return json({ message: "Resource not found" }, 404);
+    const input = parseBody(raw);
+    const updated: Workflow = {
+      ...existing,
+      name: typeof input.name === "string" ? input.name : existing.name,
+      nodes: Array.isArray(input.nodes) ? (input.nodes as Workflow["nodes"]) : existing.nodes,
+      connections:
+        input.connections && typeof input.connections === "object"
+          ? (input.connections as Workflow["connections"])
+          : existing.connections,
+      updatedAt: nowIso(),
+      ...(typeof input.description === "string" ? { description: input.description } : {}),
+    };
+    workflows.set(id, updated);
+    return json(clone(updated));
+  }
+
+  function deleteWorkflow(id: string): Response {
+    if (!workflows.has(id)) return json({ message: "Resource not found" }, 404);
+    workflows.delete(id);
+    return json({ id });
+  }
+
+  function setActive(id: string, active: boolean): Response {
+    const existing = workflows.get(id);
+    if (!existing) return json({ message: "Resource not found" }, 404);
+    const updated = { ...existing, active, updatedAt: nowIso() };
+    workflows.set(id, updated);
+    return json(clone(updated));
+  }
+
+  return {
+    port: server.port!,
+    captured,
+    workflows,
+    writes: () => captured.filter((r) => r.method !== "GET" && r.method !== "HEAD"),
+    get: (id) => {
+      const wf = workflows.get(id);
+      return wf ? clone(wf) : undefined;
+    },
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function parseBody(raw: string): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function timestamps(wf: Workflow): Pick<Workflow, "createdAt" | "updatedAt"> {
+  const now = nowIso();
+  return { createdAt: wf.createdAt ?? now, updatedAt: wf.updatedAt ?? now };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/tests/integration/helpers/stack.ts
+++ b/tests/integration/helpers/stack.ts
@@ -1,0 +1,154 @@
+import { resolve } from "node:path";
+import type { EnforceLevel } from "@/proxy/config.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+import { type N8nMock, type N8nMockOptions, startN8nMock } from "./n8n-mock.ts";
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface Stack {
+  mock: N8nMock;
+  proxy: ProxyHandle;
+  proxyUrl: string;
+  runCli: (args: string[], env?: Record<string, string>) => Promise<CliResult>;
+  stop: () => Promise<void>;
+}
+
+export interface StackOptions extends N8nMockOptions {
+  enforce?: EnforceLevel;
+  allowDuplicates?: boolean;
+  middlewares?: string[];
+  middlewareCliOptions?: Record<string, unknown>;
+  clientMiddlewares?: string[];
+  clientMiddlewareCliOptions?: Record<string, unknown>;
+  /**
+   * Extra env vars set on the *proxy process* (this test process) before
+   * `startProxy`. Used for client-middleware secrets such as the injected
+   * API key. Restored when the stack stops.
+   */
+  proxyEnv?: Record<string, string>;
+}
+
+/**
+ * Stands up mock n8n ← proxy, then runs the real CLI against the proxy URL.
+ *
+ * This is the integration seam the unit tests cannot see: CLI HTTP client →
+ * proxy policy → upstream. Each call owns its own ports so tests can run
+ * without sharing mutable server state.
+ */
+export async function startStack(opts: StackOptions = {}): Promise<Stack> {
+  const previousEnv: Array<[string, string | undefined]> = [];
+  for (const [key, value] of Object.entries(opts.proxyEnv ?? {})) {
+    previousEnv.push([key, process.env[key]]);
+    process.env[key] = value;
+  }
+
+  const mock = startN8nMock(opts);
+  const proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${mock.port}`,
+    enforce: opts.enforce ?? "error",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: opts.allowDuplicates ?? true,
+    ...(opts.middlewares ? { middlewares: opts.middlewares } : {}),
+    ...(opts.middlewareCliOptions ? { middlewareCliOptions: opts.middlewareCliOptions } : {}),
+    ...(opts.clientMiddlewares ? { clientMiddlewares: opts.clientMiddlewares } : {}),
+    ...(opts.clientMiddlewareCliOptions
+      ? { clientMiddlewareCliOptions: opts.clientMiddlewareCliOptions }
+      : {}),
+  });
+
+  try {
+    await waitReady(proxy.port);
+  } catch (err) {
+    await proxy.stop();
+    await mock.stop();
+    restoreEnv(previousEnv);
+    throw err;
+  }
+
+  const proxyUrl = `http://127.0.0.1:${proxy.port}`;
+
+  return {
+    mock,
+    proxy,
+    proxyUrl,
+    runCli: (args, env) => runCli(proxyUrl, args, env),
+    stop: async () => {
+      await proxy.stop();
+      await mock.stop();
+      restoreEnv(previousEnv);
+    },
+  };
+}
+
+export async function withStack(
+  opts: StackOptions,
+  fn: (stack: Stack) => Promise<void>,
+): Promise<void> {
+  const stack = await startStack(opts);
+  try {
+    await fn(stack);
+  } finally {
+    await stack.stop();
+  }
+}
+
+async function runCli(
+  proxyUrl: string,
+  args: string[],
+  extraEnv: Record<string, string> = {},
+): Promise<CliResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "--api-url", proxyUrl, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      N8N_API_URL: proxyUrl,
+      N8N_API_KEY: "cli-key",
+      N8N_CLI_DISABLE_UPDATE_CHECK: "1",
+      // Keep the spawned CLI from inheriting this test process's middleware
+      // env — those belong to the in-process proxy, not to `apply`'s own gate.
+      N8N_SERVER_MIDDLEWARES: "",
+      N8N_CLIENT_MIDDLEWARES: "",
+      ...extraEnv,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+async function waitReady(port: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let last = "";
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/readyz`);
+      last = await res.text();
+      if (res.status === 200) return;
+      if (res.status === 503 && last.startsWith("not ready")) {
+        throw new Error(`proxy failed readiness:\n${last}`);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith("proxy failed")) throw err;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`proxy did not become ready in time: ${last}`);
+}
+
+function restoreEnv(previous: Array<[string, string | undefined]>): void {
+  for (const [key, value] of previous) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}

--- a/tests/integration/helpers/stack.ts
+++ b/tests/integration/helpers/stack.ts
@@ -49,25 +49,25 @@ export async function startStack(opts: StackOptions = {}): Promise<Stack> {
   }
 
   const mock = startN8nMock(opts);
-  const proxy = startProxy({
-    listen: "127.0.0.1:0",
-    upstream: `http://127.0.0.1:${mock.port}`,
-    enforce: opts.enforce ?? "error",
-    disableRules: [],
-    logFormat: "json",
-    allowDuplicates: opts.allowDuplicates ?? true,
-    ...(opts.middlewares ? { middlewares: opts.middlewares } : {}),
-    ...(opts.middlewareCliOptions ? { middlewareCliOptions: opts.middlewareCliOptions } : {}),
-    ...(opts.clientMiddlewares ? { clientMiddlewares: opts.clientMiddlewares } : {}),
-    ...(opts.clientMiddlewareCliOptions
-      ? { clientMiddlewareCliOptions: opts.clientMiddlewareCliOptions }
-      : {}),
-  });
-
+  let proxy: ProxyHandle | undefined;
   try {
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${mock.port}`,
+      enforce: opts.enforce ?? "error",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: opts.allowDuplicates ?? true,
+      ...(opts.middlewares ? { middlewares: opts.middlewares } : {}),
+      ...(opts.middlewareCliOptions ? { middlewareCliOptions: opts.middlewareCliOptions } : {}),
+      ...(opts.clientMiddlewares ? { clientMiddlewares: opts.clientMiddlewares } : {}),
+      ...(opts.clientMiddlewareCliOptions
+        ? { clientMiddlewareCliOptions: opts.clientMiddlewareCliOptions }
+        : {}),
+    });
     await waitReady(proxy.port);
   } catch (err) {
-    await proxy.stop();
+    await proxy?.stop();
     await mock.stop();
     restoreEnv(previousEnv);
     throw err;

--- a/tests/integration/helpers/workflows.ts
+++ b/tests/integration/helpers/workflows.ts
@@ -1,0 +1,55 @@
+import type { Node, Workflow } from "@/api/types.ts";
+
+const TRIGGER: Node = {
+  id: "n-trigger",
+  name: "Start",
+  type: "n8n-nodes-base.manualTrigger",
+  typeVersion: 1,
+  position: [0, 0],
+  parameters: {},
+};
+
+const SET: Node = {
+  id: "n-set",
+  name: "Set",
+  type: "n8n-nodes-base.set",
+  typeVersion: 3,
+  position: [220, 0],
+  parameters: { assignments: { assignments: [] } },
+};
+
+const CONNECTED = {
+  Start: {
+    main: [[{ node: "Set", type: "main", index: 0 }]],
+  },
+};
+
+/** A workflow that passes the default error-level lint rules. */
+export function cleanWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    name: "Clean Workflow",
+    active: false,
+    nodes: [TRIGGER, SET],
+    connections: CONNECTED,
+    ...overrides,
+  };
+}
+
+/**
+ * Valid enough for `workflow create` input checks (name/nodes/connections
+ * present) but fails `connection-reference` — the case the proxy exists for:
+ * a client that skipped its own lint still cannot write through the gate.
+ */
+export function brokenWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    name: "Broken Workflow",
+    active: false,
+    nodes: [TRIGGER],
+    connections: {
+      Start: {
+        main: [[{ node: "MissingNode", type: "main", index: 0 }]],
+      },
+    },
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- CLI と proxy はそれぞれ mock に対して単体でテストされていたが、`CLI → proxy → n8n` のホップを通した契約は CI で見ていなかった
- エフェメラルポート上にステートフルな n8n mock と proxy を立て、本物の CLI プロセスを proxy URL に向ける `tests/integration/` を追加した（Docker 不要）
- `make test` / CI の `bun test` に含まれる。`make test-integration` も `tests/integration/` を見るようにした

## Test plan
- [ ] `bun test tests/integration/cli-through-proxy.test.ts` がローカルでグリーン
- [ ] CI の Test ジョブが新テストを実行して成功する
- [ ] シナリオの意図が次と一致していることを確認する
  - 正常系: `workflow list/get/create`、`apply` update、`import`、`activate` が proxy を通って mock に届く
  - 境界: list の cursor pagination、api-key-inject が CLI のキーを差し替える
  - 異常系: 404 / 500 が CLI に伝播する。`--no-lint` でも proxy lint が 422 で止める。duplicate name は 409。`--force` でも stale-write が revert しない。authz は ACL なし create を 403 にする

## Phase A
- 品質ゲート: `make lint` / `make typecheck` / `bun test`（1592 pass）
- 追加テスト: `tests/integration/cli-through-proxy.test.ts` 16 cases

Made with [Cursor](https://cursor.com)