### PR TITLE
feat(lint): strengthen workflow data-flow checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,20 @@ n8n's `Available in MCP` toggle is per-workflow and anyone with edit rights can 
 
 #### Other Lint Rules
 
+##### `execute-workflow-inputs-extra` / `execute-workflow-inputs-missing`
+
+Compare an Execute Sub-workflow node's `workflowInputs.value` keys with the input names declared by the called workflow's Execute Sub-workflow Trigger. Extra caller keys are errors; declared inputs omitted by the caller are warnings. Dynamic workflow IDs and workflows that accept all input data are skipped.
+
+The called workflow must be part of the same lint batch. Use `--remote`, `--dir`, or pass both files to `--file` so the linter can resolve the workflow ID.
+
+##### `node-ref-field-check`
+
+Checks explicit references such as `$('Node').item.json.foo` against known output fields. For Set nodes configured without **Include Other Input Fields**, assignment names are treated as the complete output schema, so references to fields that the Set node drops are reported as warnings.
+
+##### `external-node-repeated-call` / `external-node-static-repeated-call`
+
+Detect BigQuery, HTTP Request, Notion, and Slack nodes that can receive multiple items from an upstream `1:N` node while **Execute Once** is disabled. A call that references upstream input is a warning. Repeating the same input-independent call is an error. Pass-through nodes between the `1:N` producer and external node are followed.
+
 ##### `filter-operator-valid`
 
 Validates that If / Filter node conditions (typeVersion >= 2) use valid operator operations. For example, it flags `isNotEmpty` and suggests `notEmpty` instead. Invalid operations silently evaluate to `false` at runtime, making bugs hard to detect.

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -130,6 +130,12 @@ async function lintRemote(
   };
 
   const failedWorkflows = new Set<string>();
+  const lintContext = {
+    workflows,
+    workflowsById: new Map(
+      workflows.flatMap((workflow) => (workflow.id ? [[workflow.id, workflow]] : [])),
+    ),
+  };
 
   for (const workflow of workflows) {
     result.filesChecked++;
@@ -142,7 +148,7 @@ async function lintRemote(
       disabledRules,
       workflowProjectId(workflow),
     );
-    const violations = lintWorkflow(workflow, rawJSON, rules, config);
+    const violations = lintWorkflow(workflow, rawJSON, rules, config, lintContext);
     for (const v of violations) {
       result.violations.push({ ...v, file: v.file ?? displayName, url });
       failedWorkflows.add(displayName);
@@ -194,10 +200,25 @@ async function lintLocal(
 
   const failedFiles = new Set<string>();
 
-  for (const filePath of files) {
+  // Load the batch first so cross-workflow rules can resolve referenced workflow IDs.
+  const outcomes = await Promise.all(
+    files.map((filePath) => loadFileForLint(filePath, filterByTags)),
+  );
+  const workflows = outcomes.flatMap((outcome) =>
+    outcome.status === "loaded" && outcome.data.workflow ? [outcome.data.workflow] : [],
+  );
+  const lintContext = {
+    workflows,
+    workflowsById: new Map(
+      workflows.flatMap((workflow) => (workflow.id ? [[workflow.id, workflow]] : [])),
+    ),
+  };
+
+  for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+    const filePath = files[fileIndex]!;
     result.filesChecked++;
 
-    const outcome = await loadFileForLint(filePath, filterByTags);
+    const outcome = outcomes[fileIndex]!;
     if (outcome.status === "skipped") {
       result.violations.push({
         file: filePath,
@@ -231,7 +252,7 @@ async function lintLocal(
 
     const projectId = opts.project ?? workflowProjectId(workflow);
     const rules = registry.enabledRulesWithConfig(config, disabledRules, projectId);
-    const violations = lintWorkflow(workflow, rawJSON, rules, config);
+    const violations = lintWorkflow(workflow, rawJSON, rules, config, lintContext);
     for (const v of violations) {
       result.violations.push({ ...v, file: v.file ?? filePath });
       failedFiles.add(filePath);

--- a/src/lint/engine.ts
+++ b/src/lint/engine.ts
@@ -1,6 +1,7 @@
 import type { Workflow } from "@/api/types.ts";
 import type { LintConfig } from "./config.ts";
 import type { RuleWithConfig } from "./registry.ts";
+import type { LintContext } from "./rules/rule.ts";
 import type { Violation } from "./rules/violation.ts";
 
 /**
@@ -23,11 +24,12 @@ export function lintWorkflow(
   rawJSON: string,
   enabledRules: RuleWithConfig[],
   _config: LintConfig | null,
+  context?: LintContext,
 ): Violation[] {
   const violations: Violation[] = [];
   const violationIndex = new Map<string, number>();
   for (const { rule, severity, options } of enabledRules) {
-    const found = rule.check(workflow, rawJSON, options);
+    const found = rule.check(workflow, rawJSON, options, context);
     for (const v of found) {
       const violation = { ...v, severity };
       const key = JSON.stringify({ ...violation, severity: undefined });

--- a/src/lint/rules/execute-workflow-inputs.ts
+++ b/src/lint/rules/execute-workflow-inputs.ts
@@ -1,0 +1,129 @@
+import type { Workflow } from "@/api/types.ts";
+import type { LintContext, Rule } from "./rule.ts";
+import type { Violation } from "./violation.ts";
+
+const EXECUTE_WORKFLOW = "n8n-nodes-base.executeWorkflow";
+const EXECUTE_WORKFLOW_TRIGGER = "n8n-nodes-base.executeWorkflowTrigger";
+
+/** Reports caller inputs that are not declared by the called workflow. */
+export const executeWorkflowInputsExtraRule: Rule = {
+  name: "execute-workflow-inputs-extra",
+  description: "Check executeWorkflow inputs are declared by the called workflow",
+  defaultSeverity: "error",
+  check(
+    workflow: Workflow | null,
+    _rawJSON: string,
+    _options?,
+    context?: LintContext,
+  ): Violation[] {
+    return checkWorkflowInputs(workflow, context).extra;
+  },
+};
+
+/** Reports called-workflow inputs that the caller does not provide. */
+export const executeWorkflowInputsMissingRule: Rule = {
+  name: "execute-workflow-inputs-missing",
+  description: "Check executeWorkflow provides every input declared by the called workflow",
+  defaultSeverity: "warning",
+  check(
+    workflow: Workflow | null,
+    _rawJSON: string,
+    _options?,
+    context?: LintContext,
+  ): Violation[] {
+    return checkWorkflowInputs(workflow, context).missing;
+  },
+};
+
+function checkWorkflowInputs(
+  workflow: Workflow | null,
+  context: LintContext | undefined,
+): { extra: Violation[]; missing: Violation[] } {
+  const extra: Violation[] = [];
+  const missing: Violation[] = [];
+  if (!workflow || !context?.workflows) return { extra, missing };
+
+  const workflowsById =
+    context.workflowsById ??
+    new Map(
+      context.workflows
+        .filter((candidate) => typeof candidate.id === "string" && candidate.id.length > 0)
+        .map((candidate) => [candidate.id!, candidate]),
+    );
+
+  for (const node of workflow.nodes) {
+    if (node.type !== EXECUTE_WORKFLOW) continue;
+    const parameters = node.parameters ?? {};
+    const workflowId = getStaticValue(parameters.workflowId);
+    if (typeof workflowId !== "string" || isDynamic(workflowId)) continue;
+
+    const callee = workflowsById.get(workflowId);
+    if (!callee) continue;
+
+    const declaredInputs = getDeclaredInputs(callee);
+    if (!declaredInputs) continue;
+
+    const callerInputs = getObjectKeys(parameters.workflowInputs);
+    if (!callerInputs) continue;
+
+    for (const key of callerInputs) {
+      if (!declaredInputs.has(key)) {
+        extra.push({
+          rule: "execute-workflow-inputs-extra",
+          severity: "error",
+          message: `Node "${node.name}" passes undeclared workflow input "${key}" to "${callee.name}"`,
+        });
+      }
+    }
+
+    for (const key of declaredInputs) {
+      if (!callerInputs.has(key)) {
+        missing.push({
+          rule: "execute-workflow-inputs-missing",
+          severity: "warning",
+          message: `Node "${node.name}" does not provide workflow input "${key}" declared by "${callee.name}"`,
+        });
+      }
+    }
+  }
+
+  return { extra, missing };
+}
+
+function getStaticValue(value: unknown): unknown {
+  if (isRecord(value) && "value" in value) return value.value;
+  return value;
+}
+
+function getObjectKeys(value: unknown): Set<string> | null {
+  const input = getStaticValue(value);
+  if (!isRecord(input)) return null;
+  return new Set(Object.keys(input));
+}
+
+/** Returns null when the called workflow has no explicit input declaration. */
+function getDeclaredInputs(workflow: Workflow): Set<string> | null {
+  for (const node of workflow.nodes) {
+    if (node.type !== EXECUTE_WORKFLOW_TRIGGER) continue;
+    const workflowInputs = node.parameters?.workflowInputs;
+    if (!isRecord(workflowInputs) || workflowInputs.acceptAll === true) return null;
+    if (!Array.isArray(workflowInputs.values)) return null;
+
+    const names = new Set<string>();
+    for (const value of workflowInputs.values) {
+      if (isRecord(value) && typeof value.name === "string" && value.name.length > 0) {
+        names.add(value.name);
+      }
+    }
+    return names;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isDynamic(value: string): boolean {
+  return value.startsWith("=") || value.includes("{{") || value.includes("$");
+}

--- a/src/lint/rules/external-node-execution.ts
+++ b/src/lint/rules/external-node-execution.ts
@@ -1,0 +1,132 @@
+import type { Node, Workflow } from "@/api/types.ts";
+import { getOutputSchema, parseNodeRefs } from "./node-schema.ts";
+import type { Rule } from "./rule.ts";
+import type { Violation } from "./violation.ts";
+
+const externalNodeTypes = new Set([
+  "n8n-nodes-base.googleBigQuery",
+  "n8n-nodes-base.httpRequest",
+  "n8n-nodes-base.notion",
+  "n8n-nodes-base.slack",
+]);
+
+/** Warn when a data-dependent external call will repeat for a multi-item input. */
+export const externalNodeRepeatedCallRule: Rule = {
+  name: "external-node-repeated-call",
+  description: "Check for external calls repeated for each upstream item",
+  defaultSeverity: "warning",
+  check(workflow: Workflow | null): Violation[] {
+    return findRepeatedCalls(workflow, true, "external-node-repeated-call", "warning");
+  },
+};
+
+/** Error when an identical external call will repeat for a multi-item input. */
+export const externalNodeStaticRepeatedCallRule: Rule = {
+  name: "external-node-static-repeated-call",
+  description: "Check for identical external calls repeated for each upstream item",
+  defaultSeverity: "error",
+  check(workflow: Workflow | null): Violation[] {
+    return findRepeatedCalls(workflow, false, "external-node-static-repeated-call", "error");
+  },
+};
+
+function findRepeatedCalls(
+  workflow: Workflow | null,
+  expectedInputDependency: boolean,
+  rule: string,
+  severity: "error" | "warning",
+): Violation[] {
+  if (!workflow) return [];
+
+  const nodes = new Map(workflow.nodes.map((node) => [node.name, node]));
+  const predecessors = buildPredecessors(workflow);
+  const violations: Violation[] = [];
+
+  for (const node of workflow.nodes) {
+    if (!externalNodeTypes.has(node.type) || node.disabled || node.executeOnce === true) continue;
+    if (!receivesMultipleItems(node.name, predecessors, nodes, new Set())) continue;
+
+    const ancestors = collectAncestors(node.name, predecessors);
+    const inputDependent = hasInputDependentParameter(node.parameters, ancestors);
+    if (inputDependent !== expectedInputDependency) continue;
+
+    violations.push({
+      rule,
+      severity,
+      message: inputDependent
+        ? `External node "${node.name}" (${node.type}) can run once per upstream item. Enable executeOnce when only one call is intended`
+        : `External node "${node.name}" (${node.type}) can repeat the same input-independent call for every upstream item. Enable executeOnce or reference upstream data`,
+    });
+  }
+
+  return violations;
+}
+
+function buildPredecessors(workflow: Workflow): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const [source, connection] of Object.entries(workflow.connections)) {
+    for (const output of connection.main ?? []) {
+      for (const target of output ?? []) {
+        const existing = result.get(target.node) ?? [];
+        existing.push(source);
+        result.set(target.node, existing);
+      }
+    }
+  }
+  return result;
+}
+
+function receivesMultipleItems(
+  nodeName: string,
+  predecessors: Map<string, string[]>,
+  nodes: Map<string, Node>,
+  visiting: Set<string>,
+): boolean {
+  if (visiting.has(nodeName)) return false;
+  visiting.add(nodeName);
+
+  const sources = predecessors.get(nodeName) ?? [];
+  if (sources.length > 1) return true;
+
+  for (const sourceName of sources) {
+    const source = nodes.get(sourceName);
+    if (!source || source.disabled) continue;
+    const schema = getOutputSchema(source.type);
+    const params = (source.parameters as Record<string, unknown>) ?? {};
+    const cardinality = schema?.parameterDerivedCardinality?.(params) ?? schema?.cardinality;
+    if (cardinality === "1:N") return true;
+    if (cardinality === "pass-through") {
+      if (receivesMultipleItems(sourceName, predecessors, nodes, new Set(visiting))) return true;
+    }
+  }
+
+  return false;
+}
+
+function collectAncestors(nodeName: string, predecessors: Map<string, string[]>): Set<string> {
+  const ancestors = new Set<string>();
+  const queue = [...(predecessors.get(nodeName) ?? [])];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (ancestors.has(current)) continue;
+    ancestors.add(current);
+    queue.push(...(predecessors.get(current) ?? []));
+  }
+  return ancestors;
+}
+
+function hasInputDependentParameter(value: unknown, ancestors: Set<string>): boolean {
+  if (typeof value === "string") {
+    if (/\$(?:json|input|item)\b/.test(value)) return true;
+    return parseNodeRefs(value).some((ref) => ancestors.has(ref.nodeName));
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasInputDependentParameter(entry, ancestors));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some((entry) =>
+      hasInputDependentParameter(entry, ancestors),
+    );
+  }
+  return false;
+}

--- a/src/lint/rules/index.ts
+++ b/src/lint/rules/index.ts
@@ -2,7 +2,15 @@ import { RuleRegistry } from "../registry.ts";
 import { aiAgentOutputRefRule } from "./ai-agent-output-ref.ts";
 import { bannedNodeRule } from "./banned-node.ts";
 import { connectionRefRule } from "./connection-ref.ts";
+import {
+  executeWorkflowInputsExtraRule,
+  executeWorkflowInputsMissingRule,
+} from "./execute-workflow-inputs.ts";
 import { expressionModePrefixRule } from "./expression-mode-prefix.ts";
+import {
+  externalNodeRepeatedCallRule,
+  externalNodeStaticRepeatedCallRule,
+} from "./external-node-execution.ts";
 import { filterOperatorValidRule } from "./filter-operator-valid.ts";
 import { implicitJsonRefRule } from "./implicit-json-ref.ts";
 import { jsonSyntaxRule } from "./json-syntax.ts";
@@ -26,6 +34,10 @@ export function registerDefaultRules(): RuleRegistry {
   registry.register(orphanedNodeRule);
   registry.register(implicitJsonRefRule);
   registry.register(expressionModePrefixRule);
+  registry.register(externalNodeRepeatedCallRule);
+  registry.register(externalNodeStaticRepeatedCallRule);
+  registry.register(executeWorkflowInputsExtraRule);
+  registry.register(executeWorkflowInputsMissingRule);
   registry.register(aiAgentOutputRefRule);
   registry.register(nodeParamsRule);
   registry.register(nodeRefFieldCheckRule);

--- a/src/lint/rules/node-schema.ts
+++ b/src/lint/rules/node-schema.ts
@@ -13,6 +13,8 @@ export interface OutputSchema {
   dynamicFields: boolean;
   /** Derive fields from node parameters */
   parameterDerivedFields?: (params: Record<string, unknown>) => string[];
+  /** Derive fields from the complete node when version/settings affect the output shape. */
+  nodeDerivedFields?: (node: Node) => string[] | null;
   /** Derive cardinality from node parameters (overrides static cardinality) */
   parameterDerivedCardinality?: (params: Record<string, unknown>) => OutputCardinality;
 }
@@ -64,6 +66,7 @@ export function getOutputSchema(nodeType: string): OutputSchema | undefined {
 export function getKnownOutputFields(node: Node): string[] | null {
   const schema = getOutputSchema(node.type);
   if (!schema) return null;
+  if (schema.nodeDerivedFields) return schema.nodeDerivedFields(node);
   if (schema.dynamicFields) return null;
   if (schema.fixedFields) return schema.fixedFields;
   if (schema.parameterDerivedFields) {

--- a/src/lint/rules/rule.ts
+++ b/src/lint/rules/rule.ts
@@ -4,6 +4,12 @@ import type { Violation } from "./violation.ts";
 /** Severity represents the severity level of a rule violation */
 export type Severity = "error" | "warning";
 
+/** Batch-level data available to rules that need to inspect related workflows. */
+export interface LintContext {
+  workflows: Workflow[];
+  workflowsById?: Map<string, Workflow>;
+}
+
 /** Rule defines the interface that all lint rules must implement */
 export interface Rule {
   /** Unique kebab-case identifier for the rule */
@@ -17,5 +23,10 @@ export interface Rule {
    * @param workflow Parsed workflow, or null if JSON parsing failed
    * @param rawJSON Raw JSON string for rules that need line number extraction
    */
-  check(workflow: Workflow | null, rawJSON: string, options?: Record<string, unknown>): Violation[];
+  check(
+    workflow: Workflow | null,
+    rawJSON: string,
+    options?: Record<string, unknown>,
+    context?: LintContext,
+  ): Violation[];
 }

--- a/src/lint/rules/schema-overrides.ts
+++ b/src/lint/rules/schema-overrides.ts
@@ -1,3 +1,4 @@
+import type { Node } from "@/api/types.ts";
 import type { NodeTypeSchema } from "./node-params-schema.ts";
 import type { OutputSchema } from "./node-schema.ts";
 
@@ -27,7 +28,11 @@ export const outputSchemaOverrides: Record<string, OutputSchema> = {
     dynamicFields: false,
     parameterDerivedFields: aggregateOutputFields,
   },
-  "n8n-nodes-base.set": { cardinality: "pass-through", dynamicFields: true },
+  "n8n-nodes-base.set": {
+    cardinality: "pass-through",
+    dynamicFields: true,
+    nodeDerivedFields: setOutputFields,
+  },
   "n8n-nodes-base.filter": {
     cardinality: "pass-through",
     dynamicFields: true,
@@ -90,6 +95,32 @@ function aggregateOutputFields(params: Record<string, unknown>): string[] {
       ? params.destinationFieldName
       : "data";
   return [destField];
+}
+
+/** Returns the fields a Set node keeps when it is configured to drop its input fields. */
+function setOutputFields(node: Node): string[] | null {
+  const params = (node.parameters as Record<string, unknown>) ?? {};
+
+  // Set v3.3+ renamed the setting to includeOtherFields and defaults it to false.
+  // v3.0-3.2 used include=none for the equivalent behavior.
+  const dropsInputFields =
+    node.typeVersion >= 3.3
+      ? params.includeOtherFields !== true
+      : node.typeVersion >= 3
+        ? params.include === "none"
+        : params.keepOnlySet === true;
+  if (!dropsInputFields) return null;
+
+  const assignments = (params.assignments as Record<string, unknown> | undefined)?.assignments;
+  if (!Array.isArray(assignments)) return null;
+
+  const fields = assignments.flatMap((assignment) => {
+    if (!assignment || typeof assignment !== "object") return [];
+    const name = (assignment as Record<string, unknown>).name;
+    if (typeof name !== "string" || name.length === 0) return [];
+    return [name.split(".")[0]!];
+  });
+  return [...new Set(fields)];
 }
 
 /**

--- a/tests/cli/lint-integration.test.ts
+++ b/tests/cli/lint-integration.test.ts
@@ -284,6 +284,71 @@ describe("CLI lint: multiple files", () => {
   });
 });
 
+describe("CLI lint: execute workflow inputs across files", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-workflow-inputs-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("resolves the called workflow from the same lint batch", async () => {
+    const callerPath = path.join(tmpDir, "caller.json");
+    const calleePath = path.join(tmpDir, "callee.json");
+    fs.writeFileSync(
+      callerPath,
+      JSON.stringify({
+        id: "caller",
+        name: "Caller",
+        active: false,
+        nodes: [
+          {
+            id: "execute",
+            name: "Execute child",
+            type: "n8n-nodes-base.executeWorkflow",
+            typeVersion: 1,
+            position: [0, 0],
+            parameters: {
+              workflowId: { value: "callee" },
+              workflowInputs: { value: { expected: "ok", extra: "no" } },
+            },
+          },
+        ],
+        connections: {},
+      }),
+    );
+    fs.writeFileSync(
+      calleePath,
+      JSON.stringify({
+        id: "callee",
+        name: "Callee",
+        active: false,
+        nodes: [
+          {
+            id: "trigger",
+            name: "When called",
+            type: "n8n-nodes-base.executeWorkflowTrigger",
+            typeVersion: 1,
+            position: [0, 0],
+            parameters: {
+              workflowInputs: { values: [{ name: "expected" }, { name: "missing" }] },
+            },
+          },
+        ],
+        connections: {},
+      }),
+    );
+
+    const { output, exitCode } = await runLint(["-f", callerPath, calleePath]);
+    expect(exitCode).toBe(1);
+    expect(byRule(output.violations, "execute-workflow-inputs-extra")).toHaveLength(1);
+    expect(byRule(output.violations, "execute-workflow-inputs-missing")).toHaveLength(1);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // --disable-rule
 // ---------------------------------------------------------------------------

--- a/tests/lint/rules/execute-workflow-inputs.test.ts
+++ b/tests/lint/rules/execute-workflow-inputs.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import type { Workflow } from "@/api/types.ts";
+import {
+  executeWorkflowInputsExtraRule,
+  executeWorkflowInputsMissingRule,
+} from "@/lint/rules/execute-workflow-inputs.ts";
+
+function workflow(id: string, nodes: Workflow["nodes"]): Workflow {
+  return { id, name: `Workflow ${id}`, active: false, nodes, connections: {} };
+}
+
+function executeNode(
+  inputs: Record<string, unknown>,
+  workflowId = "callee",
+): Workflow["nodes"][number] {
+  return {
+    id: "execute",
+    name: "Execute child",
+    type: "n8n-nodes-base.executeWorkflow",
+    typeVersion: 1,
+    position: [0, 0],
+    parameters: { workflowId: { value: workflowId }, workflowInputs: { value: inputs } },
+  };
+}
+
+function trigger(inputs: string[], acceptAll = false): Workflow["nodes"][number] {
+  return {
+    id: "trigger",
+    name: "When executed by another workflow",
+    type: "n8n-nodes-base.executeWorkflowTrigger",
+    typeVersion: 1,
+    position: [0, 0],
+    parameters: { workflowInputs: { acceptAll, values: inputs.map((name) => ({ name })) } },
+  };
+}
+
+describe("execute-workflow-inputs rules", () => {
+  test("caller extra keys are errors", () => {
+    const caller = workflow("caller", [executeNode({ expected: "ok", extra: "no" })]);
+    const callee = workflow("callee", [trigger(["expected"])]);
+
+    const violations = executeWorkflowInputsExtraRule.check(
+      caller,
+      "",
+      {},
+      { workflows: [caller, callee] },
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      severity: "error",
+      rule: "execute-workflow-inputs-extra",
+    });
+    expect(violations[0]!.message).toContain('"extra"');
+  });
+
+  test("caller missing declared keys are warnings", () => {
+    const caller = workflow("caller", [executeNode({ expected: "ok" })]);
+    const callee = workflow("callee", [trigger(["expected", "required"])]);
+
+    const violations = executeWorkflowInputsMissingRule.check(
+      caller,
+      "",
+      {},
+      { workflows: [caller, callee] },
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      severity: "warning",
+      rule: "execute-workflow-inputs-missing",
+    });
+    expect(violations[0]!.message).toContain('"required"');
+  });
+
+  test("matching keys produce no violations", () => {
+    const caller = workflow("caller", [executeNode({ expected: "ok" })]);
+    const callee = workflow("callee", [trigger(["expected"])]);
+    const context = { workflows: [caller, callee] };
+
+    expect(executeWorkflowInputsExtraRule.check(caller, "", {}, context)).toEqual([]);
+    expect(executeWorkflowInputsMissingRule.check(caller, "", {}, context)).toEqual([]);
+  });
+
+  test("unresolved or dynamic target and undeclared acceptAll input are skipped", () => {
+    const unresolved = workflow("caller", [executeNode({ extra: "x" }, "not-found")]);
+    const dynamic = workflow("dynamic", [executeNode({ extra: "x" }, "={{ $json.workflowId }}")]);
+    const acceptAll = workflow("callee", [trigger([], true)]);
+    const callerToAcceptAll = workflow("accept-caller", [executeNode({ extra: "x" })]);
+    const context = { workflows: [unresolved, dynamic, acceptAll, callerToAcceptAll] };
+
+    for (const caller of [unresolved, dynamic, callerToAcceptAll]) {
+      expect(executeWorkflowInputsExtraRule.check(caller, "", {}, context)).toEqual([]);
+      expect(executeWorkflowInputsMissingRule.check(caller, "", {}, context)).toEqual([]);
+    }
+  });
+});

--- a/tests/lint/rules/external-node-execution.test.ts
+++ b/tests/lint/rules/external-node-execution.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import type { Node, Workflow } from "@/api/types.ts";
+import {
+  externalNodeRepeatedCallRule,
+  externalNodeStaticRepeatedCallRule,
+} from "@/lint/rules/external-node-execution.ts";
+
+function workflow(external: Node): Workflow {
+  return {
+    name: "Test",
+    active: false,
+    nodes: [
+      {
+        id: "1",
+        name: "Query rows",
+        type: "n8n-nodes-base.googleBigQuery",
+        typeVersion: 2,
+        position: [0, 0],
+        parameters: { operation: "executeQuery" },
+      },
+      {
+        id: "2",
+        name: "Pass through",
+        type: "n8n-nodes-base.set",
+        typeVersion: 3.4,
+        position: [200, 0],
+        parameters: { includeOtherFields: true, assignments: { assignments: [] } },
+      },
+      external,
+    ],
+    connections: {
+      "Query rows": { main: [[{ node: "Pass through", type: "main", index: 0 }]] },
+      "Pass through": { main: [[{ node: external.name, type: "main", index: 0 }]] },
+    },
+  };
+}
+
+function http(parameters: Record<string, unknown>, executeOnce = false): Node {
+  return {
+    id: "3",
+    name: "HTTP",
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4,
+    position: [400, 0],
+    parameters,
+    executeOnce,
+  };
+}
+
+describe("external node execution rules", () => {
+  test("input-dependent repeated call is a warning", () => {
+    const wf = workflow(http({ url: "={{ $json.url }}" }));
+    expect(externalNodeRepeatedCallRule.check(wf, "")).toHaveLength(1);
+    expect(externalNodeStaticRepeatedCallRule.check(wf, "")).toHaveLength(0);
+  });
+
+  test("input-independent repeated call is an error", () => {
+    const wf = workflow(http({ url: "https://example.com/static" }));
+    expect(externalNodeRepeatedCallRule.check(wf, "")).toHaveLength(0);
+    const violations = externalNodeStaticRepeatedCallRule.check(wf, "");
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.severity).toBe("error");
+  });
+
+  test("executeOnce suppresses both findings", () => {
+    const wf = workflow(http({ url: "https://example.com/static" }, true));
+    expect(externalNodeRepeatedCallRule.check(wf, "")).toHaveLength(0);
+    expect(externalNodeStaticRepeatedCallRule.check(wf, "")).toHaveLength(0);
+  });
+
+  test("single-item upstream does not trigger", () => {
+    const wf = workflow(http({ url: "https://example.com/static" }));
+    wf.nodes[0] = {
+      id: "1",
+      name: "Query rows",
+      type: "n8n-nodes-base.manualTrigger",
+      typeVersion: 1,
+      position: [0, 0],
+    };
+    expect(externalNodeStaticRepeatedCallRule.check(wf, "")).toHaveLength(0);
+  });
+});

--- a/tests/lint/rules/node-ref-field-check.test.ts
+++ b/tests/lint/rules/node-ref-field-check.test.ts
@@ -163,6 +163,70 @@ describe("node-ref-field-check rule", () => {
     expect(nodeRefFieldCheckRule.check(wf, "").length).toBe(0);
   });
 
+  test("Set without includeOtherFields reports a field it drops", () => {
+    const wf: Workflow = {
+      name: "Test",
+      active: false,
+      nodes: [
+        {
+          id: "1",
+          name: "Set",
+          type: "n8n-nodes-base.set",
+          typeVersion: 3.4,
+          position: [0, 0],
+          parameters: {
+            assignments: { assignments: [{ name: "kept", value: "ok", type: "string" }] },
+          },
+        },
+        {
+          id: "2",
+          name: "Consumer",
+          type: "n8n-nodes-base.httpRequest",
+          typeVersion: 4,
+          position: [200, 0],
+          parameters: { url: "={{ $('Set').item.json.dropped }}" },
+        },
+      ],
+      connections: { Set: { main: [[{ node: "Consumer", type: "main", index: 0 }]] } },
+    };
+
+    const violations = nodeRefFieldCheckRule.check(wf, "");
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("dropped");
+    expect(violations[0]?.message).toContain("kept");
+  });
+
+  test("Set with includeOtherFields keeps unknown input fields", () => {
+    const wf: Workflow = {
+      name: "Test",
+      active: false,
+      nodes: [
+        {
+          id: "1",
+          name: "Set",
+          type: "n8n-nodes-base.set",
+          typeVersion: 3.4,
+          position: [0, 0],
+          parameters: {
+            includeOtherFields: true,
+            assignments: { assignments: [{ name: "kept", value: "ok", type: "string" }] },
+          },
+        },
+        {
+          id: "2",
+          name: "Consumer",
+          type: "n8n-nodes-base.httpRequest",
+          typeVersion: 4,
+          position: [200, 0],
+          parameters: { url: "={{ $('Set').item.json.inputField }}" },
+        },
+      ],
+      connections: { Set: { main: [[{ node: "Consumer", type: "main", index: 0 }]] } },
+    };
+
+    expect(nodeRefFieldCheckRule.check(wf, "")).toHaveLength(0);
+  });
+
   test("unknown node type - no violation (skip check)", () => {
     const wf: Workflow = {
       name: "Test",


### PR DESCRIPTION
## Summary

- Compare Execute Workflow input keys with the called Workflow Input Trigger, reporting extra keys as errors and missing keys as warnings
- Infer the complete output field set for Set nodes when Include Other Input Fields is disabled, and detect references to fields that were dropped
- Detect BigQuery, HTTP Request, Notion, and Slack nodes that can execute once per upstream item; report input-independent repeated calls as errors
- Add batch-level workflow context so local and remote lint runs can resolve cross-workflow references
- Add unit tests, CLI integration coverage, and README documentation for the new rules

## Validation

- make lint (passed with 23 pre-existing warnings)
- make typecheck
- make test (1,616 tests passed)

## Scope

- Inferring output schemas from Code node returns or arbitrary HTTP responses is out of scope for this change
