### PR TITLE
feat(lint): extend banned-node with allowlist and parameter policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,28 +272,69 @@ uses its existing `--project` / default-project setting.
 
 ##### `banned-node`
 
-Detects usage of banned node types. Requires the array config format to specify which nodes are banned.
+Detects usage of banned node types and enforces per-node parameter policies. Requires the array config format to specify options.
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `nodes` | `Array<{ type: string; reason?: string }>` | List of banned node types |
+| `deny` | `Array<Matcher>` | Node types banned outright. `deny` wins over `allow` |
+| `allow` | `Array<Matcher>` | When non-empty, switches the rule into **allowlist mode**: every node must match at least one entry, otherwise it is banned. Entries may still be narrowed by `params` |
+| `params` | `Record<node-matcher, ParamsPolicy>` | Per-node parameter policy (see below). Keys are node type matchers merged in order of specificity (broadest first, exact last) |
 
-- `type` — the `node.type` identifier (e.g., `n8n-nodes-base.executeCommand`)
-- `reason` — optional; included in the violation message when provided
+A `Matcher` is `{ "type": "..." }` (exact) or `{ "pattern": "...", "match": "exact" \| "glob" \| "regex" }` (`match` defaults to `"glob"`). `deny` entries may carry a `reason`. The legacy `nodes: [{ type, reason }]` option is an alias for `deny`.
+
+A `ParamsPolicy`:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `allowParams` | `string[]` | When present, every **top-level** parameter name must match at least one pattern. Patterns match the parameter key (e.g. `additional*`), not a path into it |
+| `denyParams` | `string[]` | Top-level parameter names matching any pattern are violations. To forbid a nested key, use `values` with an empty `allow` list |
+| `expressions` | `"allow"` \| `"deny"` | Default policy for expression values on this node. Expression values are strings beginning with `=` or containing `{{ ... }}`. Default: `"allow"` |
+| `values` | `Record<path, ValueRule>` | Value-level rules keyed by dot-path (`channelId.value`) supporting `*` globs and `/regex/`. For each field (`allow`, `pattern`, `expressions`) the most specific matching path rule that defines that field wins, so a broad rule and a narrow rule compose rather than shadow each other. Code-bearing params (`jsCode`, `inputSchema`) are exempt from expression checks |
+
+A `ValueRule` combines three orthogonal constraints:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `allow` | `string[]` | Exact values the parameter may hold. An empty array forbids the path entirely |
+| `pattern` | `string` | A glob (default) or, with `match: "regex"`, a regular expression the value must match |
+| `expressions` | `"allow"` \| `"deny"` | Overrides the node's `expressions` policy for just that path |
+
+Expression values skip the literal `allow` / `pattern` checks because they are dynamic; the expressions policy decides their fate instead. Invalid matchers, regexes and option values are reported as `error`-severity config violations.
 
 ```json
 {
   "rules": {
     "banned-node": ["error", {
-      "nodes": [
+      "deny": [
         { "type": "n8n-nodes-base.executeCommand", "reason": "Security risk: arbitrary command execution" },
-        { "type": "n8n-nodes-base.code", "reason": "Use HTTP Request node instead" },
-        { "type": "n8n-nodes-base.ssh" }
-      ]
+        { "pattern": "n8n-nodes-base.*Command", "match": "glob" },
+        { "pattern": "n8n-nodes-base\\.(code|function)", "match": "regex" }
+      ],
+      "allow": [
+        { "type": "n8n-nodes-base.slack" },
+        { "type": "n8n-nodes-base.httpRequest" }
+      ],
+      "params": {
+        "*": { "expressions": "deny" },
+        "n8n-nodes-base.slack": {
+          "allowParams": ["resource", "operation", "channelId", "text", "additionalFields"],
+          "denyParams": ["messageType"],
+          "values": {
+            "channelId.value": { "allow": ["#general", "#ops"] },
+            "text": { "expressions": "allow" }
+          }
+        },
+        "n8n-nodes-base.httpRequest": {
+          "allowParams": ["url", "method"],
+          "values": { "url": { "pattern": "^https://", "match": "regex" } }
+        }
+      }
     }]
   }
 }
 ```
+
+The example above bans `executeCommand`, all `*Command` glob matches and the Code/Function nodes; only Slack and HTTP Request are allowed; expressions are forbidden everywhere except `text` on Slack; Slack may only post to `#general` or `#ops`; and HTTP Request may only target `https://` URLs.
 
 ##### `no-plaintext-secrets`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/lint/rules/banned-node.ts
+++ b/src/lint/rules/banned-node.ts
@@ -1,21 +1,102 @@
-import type { Workflow } from "@/api/types.ts";
+import type { Node, Workflow } from "@/api/types.ts";
+import { globMatch } from "@/common/mcp.ts";
 import type { Rule } from "./rule.ts";
 import type { Violation } from "./violation.ts";
 
-interface BannedNodeEntry {
-  type: string;
+const RULE_NAME = "banned-node";
+
+type MatchKind = "exact" | "glob" | "regex";
+type ExpressionMode = "allow" | "deny";
+
+/** Raw matcher as written in the config: exactly one of `type` / `pattern`. */
+interface RawNodeMatcher {
+  type?: string;
+  pattern?: string;
+  match?: MatchKind;
   reason?: string;
 }
 
+/** Value-level rule attached to a parameter path. */
+interface RawValueRule {
+  allow?: string[];
+  pattern?: string;
+  match?: MatchKind;
+  expressions?: ExpressionMode;
+}
+
+/** Per-node parameter policy, keyed in the config by a node type matcher. */
+interface RawParamsPolicy {
+  allowParams?: string[];
+  denyParams?: string[];
+  expressions?: ExpressionMode;
+  values?: Record<string, RawValueRule>;
+}
+
+/** A compiled matcher. */
+type CompiledPattern =
+  | { kind: "exact"; value: string }
+  | { kind: "glob"; glob: string }
+  | { kind: "regex"; regex: RegExp };
+
+type CompiledNodeMatcher = CompiledPattern & { reason?: string };
+
+interface ParsedOptions {
+  deny: CompiledNodeMatcher[];
+  allow: CompiledNodeMatcher[];
+  params: Record<string, RawParamsPolicy>;
+}
+
+interface ParseResult {
+  options?: ParsedOptions;
+  errors: Violation[];
+}
+
 /**
- * Detects usage of banned node types specified in the rule options.
+ * Detects disallowed node types and parameter usage.
  *
- * Options:
- *   nodes: Array of { type: string; reason?: string }
+ * This is an extension of the original exact-match banned list. Options:
+ *
+ *   deny:   Array of node matchers. Any node matching one is banned outright
+ *           (this is the same list the legacy `nodes` option maps onto).
+ *   allow:  Array of node matchers. When non-empty this switches the rule into
+ *           allowlist mode: every node must match at least one entry, otherwise
+ *           it is banned. Entries may still be narrowed further by `params`.
+ *   params: Record keyed by a node type matcher (exact type, `*`-glob, or
+ *           `/regex/`) describing what the parameters of matching nodes must
+ *           look like. Multiple keys can match one node; they are merged in
+ *           order of specificity (broadest first, exact last) so a broad
+ *           default like `"*"` can be overridden per node type:
+ *             - allowParams: when present, every top-level parameter name must
+ *               match at least one of these patterns (exact, `*`-glob, or
+ *               `/re/`). Patterns match the parameter *key*, so allow a whole
+ *               object with `additionalFields` (exact) or `additional*`, not
+ *               `additionalFields.*` (which is a path into the parameter).
+ *               Parameters that match none are violations.
+ *             - denyParams: top-level parameter names matching any pattern are
+ *               violations. To forbid a nested key, use `values` with an empty
+ *               `allow` list instead.
+ *             - expressions: "allow" (default) or "deny" — the node's default
+ *               policy for expression values (strings beginning with `=` or
+ *               containing `{{ ... }}`).
+ *             - values: record of parameter path -> value rule. Paths use dot
+ *               notation (`channelId.value`) and support `*` globs; for each
+ *               field (`allow`, `pattern`, `expressions`) the most specific
+ *               matching path rule that defines that field wins, so a broad
+ *               rule and a narrow rule compose rather than shadow one another.
+ *               Each value rule can combine:
+ *                 - allow:      exact values the parameter may hold.
+ *                 - pattern:    a glob (default) or regex (with `match:
+ *                               "regex"`) the value must match.
+ *                 - expressions:"allow" / "deny" for just that path,
+ *                               overriding the node default.
+ *
+ * A `match` field on a matcher selects "exact" | "glob" | "regex" for `pattern`
+ * (default: "glob"). Expression values skip literal `allow` / `pattern` checks
+ * because they are dynamic; the expressions policy decides their fate instead.
  */
 export const bannedNodeRule: Rule = {
-  name: "banned-node",
-  description: "Detect usage of banned node types",
+  name: RULE_NAME,
+  description: "Detect usage of banned node types and parameter/value/expression policies",
   defaultSeverity: "warning",
   check(
     workflow: Workflow | null,
@@ -24,30 +105,586 @@ export const bannedNodeRule: Rule = {
   ): Violation[] {
     if (!workflow) return [];
 
-    const entries = (options?.nodes as BannedNodeEntry[] | undefined) ?? [];
-    if (entries.length === 0) return [];
-
-    const bannedMap = new Map<string, string | undefined>();
-    for (const entry of entries) {
-      bannedMap.set(entry.type, entry.reason);
-    }
-
-    const violations: Violation[] = [];
+    const { options: opts, errors } = parseOptions(options);
+    const violations: Violation[] = [...errors];
+    if (!opts) return violations;
 
     for (const node of workflow.nodes) {
-      if (bannedMap.has(node.type)) {
-        const reason = bannedMap.get(node.type);
-        const message = reason
-          ? `Node "${node.name}" uses banned type "${node.type}": ${reason}`
-          : `Node "${node.name}" uses banned type "${node.type}"`;
-        violations.push({
-          rule: "banned-node",
-          severity: "warning",
-          message,
-        });
-      }
+      violations.push(...checkNode(node, opts));
     }
-
     return violations;
   },
 };
+
+// ---------------------------------------------------------------------------
+// Options parsing
+// ---------------------------------------------------------------------------
+
+function parseOptions(options?: Record<string, unknown>): ParseResult {
+  if (!options) return { errors: [] };
+
+  const errors: Violation[] = [];
+  const deny: CompiledNodeMatcher[] = [];
+  const allow: CompiledNodeMatcher[] = [];
+
+  for (const raw of asObjectArray(options.deny, "deny", errors)) {
+    const matcher = parseMatcher(raw, errors);
+    if (matcher) deny.push(matcher);
+  }
+  // Legacy `nodes` option is an alias for `deny`.
+  for (const raw of asObjectArray(options.nodes, "nodes", errors)) {
+    const matcher = parseMatcher(raw, errors);
+    if (matcher) deny.push(matcher);
+  }
+  for (const raw of asObjectArray(options.allow, "allow", errors)) {
+    const matcher = parseMatcher(raw, errors);
+    if (matcher) allow.push(matcher);
+  }
+
+  const params: Record<string, RawParamsPolicy> = {};
+  const rawParams = options.params;
+  if (rawParams !== undefined) {
+    if (typeof rawParams !== "object" || Array.isArray(rawParams)) {
+      errors.push(configError(`"params" must be an object, got ${typeof rawParams}`));
+    } else {
+      for (const [key, value] of Object.entries(rawParams as Record<string, unknown>)) {
+        const policy = parseParamsPolicy(key, value, errors);
+        if (policy) params[key] = policy;
+      }
+    }
+  }
+
+  const hasAny = deny.length > 0 || allow.length > 0 || Object.keys(params).length > 0;
+  return { options: hasAny ? { deny, allow, params } : undefined, errors };
+}
+
+/** Reads an option as an array of objects, collecting invalid entries as errors. */
+function asObjectArray(
+  value: unknown,
+  optionName: string,
+  errors: Violation[],
+): Array<Record<string, unknown>> {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    errors.push(configError(`"${optionName}" must be an array, got ${typeof value}`));
+    return [];
+  }
+  return value.filter((entry) => {
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) return true;
+    errors.push(configError(`"${optionName}" entries must be objects`));
+    return false;
+  });
+}
+
+function parseMatcher(
+  raw: Record<string, unknown>,
+  errors: Violation[],
+): CompiledNodeMatcher | null {
+  const matcher = raw as RawNodeMatcher;
+  const reason = typeof matcher.reason === "string" ? matcher.reason : undefined;
+
+  if (typeof matcher.type === "string" && matcher.pattern === undefined) {
+    return { kind: "exact", value: matcher.type, reason };
+  }
+
+  if (typeof matcher.pattern === "string" && matcher.type === undefined) {
+    const match = matcher.match;
+    if (match !== undefined && match !== "exact" && match !== "glob" && match !== "regex") {
+      errors.push(
+        configError(`Invalid "match" value "${String(match)}" in matcher for "${matcher.pattern}"`),
+      );
+      return null;
+    }
+    const pattern = compilePattern(matcher.pattern, match, errors);
+    if (!pattern) return null;
+    return { ...pattern, reason };
+  }
+
+  errors.push(configError('Invalid node matcher: provide exactly one of "type" or "pattern"'));
+  return null;
+}
+
+function parseParamsPolicy(
+  key: string,
+  value: unknown,
+  errors: Violation[],
+): RawParamsPolicy | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    errors.push(configError(`"params.${key}" must be an object`));
+    return undefined;
+  }
+  // Validate regex-style keys up front so matcher resolution can trust them.
+  if (isRegexString(key)) {
+    if (!compileRegex(key)) {
+      errors.push(configError(`Invalid regex in params key "/${key}/"`));
+      return undefined;
+    }
+  }
+
+  const raw = value as Record<string, unknown>;
+  const policy: RawParamsPolicy = {};
+
+  if (raw.expressions !== undefined) {
+    if (raw.expressions !== "allow" && raw.expressions !== "deny") {
+      errors.push(
+        configError(
+          `"params.${key}.expressions" must be "allow" or "deny", got "${String(raw.expressions)}"`,
+        ),
+      );
+      return undefined;
+    }
+    policy.expressions = raw.expressions;
+  }
+
+  const allowParams = readStringArray(raw.allowParams, `params.${key}.allowParams`, errors);
+  if (allowParams !== undefined) policy.allowParams = allowParams;
+  const denyParams = readStringArray(raw.denyParams, `params.${key}.denyParams`, errors);
+  if (denyParams !== undefined) policy.denyParams = denyParams;
+
+  if (raw.values !== undefined) {
+    if (typeof raw.values !== "object" || raw.values === null || Array.isArray(raw.values)) {
+      errors.push(configError(`"params.${key}.values" must be an object`));
+    } else {
+      const values: Record<string, RawValueRule> = {};
+      for (const [path, ruleValue] of Object.entries(raw.values as Record<string, unknown>)) {
+        const rule = parseValueRule(key, path, ruleValue, errors);
+        if (rule) values[path] = rule;
+      }
+      if (Object.keys(values).length > 0) policy.values = values;
+    }
+  }
+
+  const isEmpty =
+    policy.expressions === undefined &&
+    policy.allowParams === undefined &&
+    policy.denyParams === undefined &&
+    policy.values === undefined;
+  return isEmpty ? undefined : policy;
+}
+
+function readStringArray(
+  value: unknown,
+  optionPath: string,
+  errors: Violation[],
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+    errors.push(configError(`"${optionPath}" must be an array of strings`));
+    return undefined;
+  }
+  return (value as string[]).filter((entry) => {
+    if (isRegexString(entry) && !compileRegex(entry)) {
+      errors.push(configError(`Invalid regex "/${entry}/" in "${optionPath}"`));
+      return false;
+    }
+    return true;
+  });
+}
+
+function parseValueRule(
+  paramsKey: string,
+  path: string,
+  raw: unknown,
+  errors: Violation[],
+): RawValueRule | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    errors.push(configError(`"params.${paramsKey}.values.${path}" must be an object`));
+    return undefined;
+  }
+  const rule = raw as Record<string, unknown>;
+  const out: RawValueRule = {};
+
+  if (rule.allow !== undefined) {
+    if (!Array.isArray(rule.allow) || rule.allow.some((v) => typeof v !== "string")) {
+      errors.push(
+        configError(`"params.${paramsKey}.values.${path}.allow" must be an array of strings`),
+      );
+      return undefined;
+    }
+    out.allow = rule.allow as string[];
+  }
+
+  if (rule.pattern !== undefined) {
+    if (typeof rule.pattern !== "string") {
+      errors.push(configError(`"params.${paramsKey}.values.${path}.pattern" must be a string`));
+      return undefined;
+    }
+    if (
+      rule.match !== undefined &&
+      rule.match !== "exact" &&
+      rule.match !== "glob" &&
+      rule.match !== "regex"
+    ) {
+      errors.push(
+        configError(
+          `Invalid "match" value "${String(rule.match)}" in "params.${paramsKey}.values.${path}"`,
+        ),
+      );
+      return undefined;
+    }
+    out.pattern = rule.pattern;
+    out.match = (rule.match as MatchKind) ?? "glob";
+    // Validate the pattern up front so a bad regex fails loudly in config
+    // review rather than silently disabling the check.
+    if (!compilePattern(out.pattern, out.match, errors)) return undefined;
+  } else if (rule.match !== undefined) {
+    errors.push(
+      configError(`"params.${paramsKey}.values.${path}.match" requires "pattern" to be set`),
+    );
+    return undefined;
+  }
+
+  if (rule.expressions !== undefined) {
+    if (rule.expressions !== "allow" && rule.expressions !== "deny") {
+      errors.push(
+        configError(`"params.${paramsKey}.values.${path}.expressions" must be "allow" or "deny"`),
+      );
+      return undefined;
+    }
+    out.expressions = rule.expressions;
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern helpers
+// ---------------------------------------------------------------------------
+
+function autoKind(s: string): MatchKind {
+  if (isRegexString(s)) return "regex";
+  if (s.includes("*")) return "glob";
+  return "exact";
+}
+
+/** A string wrapped in `/.../` is treated as a regular expression. */
+function isRegexString(s: string): boolean {
+  return s.length > 2 && s.startsWith("/") && s.endsWith("/");
+}
+
+function compileRegex(s: string): RegExp | null {
+  const body = isRegexString(s) ? s.slice(1, -1) : s;
+  try {
+    return new RegExp(body);
+  } catch {
+    return null;
+  }
+}
+
+function compilePattern(
+  s: string,
+  explicit?: MatchKind,
+  errors?: Violation[],
+): CompiledPattern | null {
+  const kind: MatchKind = explicit ?? autoKind(s);
+  if (kind === "regex") {
+    const re = compileRegex(s);
+    if (!re) {
+      errors?.push(configError(`Invalid regex "/${s}/"`));
+      return null;
+    }
+    return { kind: "regex", regex: re };
+  }
+  if (kind === "glob") return { kind: "glob", glob: s };
+  return { kind: "exact", value: s };
+}
+
+function patternMatches(pattern: CompiledPattern, value: string): boolean {
+  switch (pattern.kind) {
+    case "exact":
+      return pattern.value === value;
+    case "glob":
+      return globMatch(pattern.glob, value);
+    case "regex":
+      return pattern.regex.test(value);
+  }
+}
+
+/** Higher = more specific. exact > regex > glob > "*". */
+function patternSpecificity(pattern: CompiledPattern): number {
+  switch (pattern.kind) {
+    case "exact":
+      return 3;
+    case "regex":
+      return 2;
+    case "glob":
+      return pattern.glob === "*" ? 0 : 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-node evaluation
+// ---------------------------------------------------------------------------
+
+function checkNode(node: Node, opts: ParsedOptions): Violation[] {
+  const violations: Violation[] = [];
+
+  const deniedMatcher = opts.deny.find((m) => patternMatches(m, node.type));
+  if (deniedMatcher) {
+    const reason = deniedMatcher.reason;
+    const message = reason
+      ? `Node "${node.name}" uses banned type "${node.type}": ${reason}`
+      : `Node "${node.name}" uses banned type "${node.type}"`;
+    violations.push(violation(message));
+    return violations;
+  }
+
+  if (opts.allow.length > 0 && !opts.allow.some((m) => patternMatches(m, node.type))) {
+    violations.push(
+      violation(`Node "${node.name}" uses type "${node.type}" which is not in the allowlist`),
+    );
+    return violations;
+  }
+
+  const policy = resolveParamsPolicy(opts.params, node.type);
+  if (policy) {
+    const params = (node.parameters as Record<string, unknown>) ?? {};
+    violations.push(...checkParams(node, policy, params));
+  }
+
+  return violations;
+}
+
+/** Merges every params policy matching the node type, broadest first. */
+function resolveParamsPolicy(
+  params: Record<string, RawParamsPolicy>,
+  nodeType: string,
+): RawParamsPolicy | undefined {
+  interface Entry {
+    spec: number;
+    policy: RawParamsPolicy;
+  }
+  const entries: Entry[] = [];
+  for (const [key, policy] of Object.entries(params)) {
+    const pattern = compilePattern(key);
+    if (pattern && patternMatches(pattern, nodeType)) {
+      entries.push({ spec: patternSpecificity(pattern), policy });
+    }
+  }
+  if (entries.length === 0) return undefined;
+  entries.sort((a, b) => a.spec - b.spec);
+
+  const merged: RawParamsPolicy = {};
+  const allowParams: string[] = [];
+  const denyParams: string[] = [];
+  const values: Record<string, RawValueRule> = {};
+  for (const { policy } of entries) {
+    for (const p of policy.allowParams ?? []) {
+      if (!allowParams.includes(p)) allowParams.push(p);
+    }
+    for (const p of policy.denyParams ?? []) {
+      if (!denyParams.includes(p)) denyParams.push(p);
+    }
+    if (policy.expressions) merged.expressions = policy.expressions;
+    if (policy.values) {
+      for (const [path, rule] of Object.entries(policy.values)) {
+        values[path] = rule;
+      }
+    }
+  }
+  if (allowParams.length > 0) merged.allowParams = allowParams;
+  if (denyParams.length > 0) merged.denyParams = denyParams;
+  if (Object.keys(values).length > 0) merged.values = values;
+  return merged;
+}
+
+/** Parameter names that hold code rather than values; expressions never apply. */
+const CODE_PARAMS = new Set(["jsCode", "inputSchema"]);
+
+function checkParams(
+  node: Node,
+  policy: RawParamsPolicy,
+  params: Record<string, unknown>,
+): Violation[] {
+  const violations: Violation[] = [];
+  const topKeys = Object.keys(params);
+
+  if (policy.allowParams && policy.allowParams.length > 0) {
+    const patterns = policy.allowParams
+      .map((p) => compilePattern(p))
+      .filter(Boolean) as CompiledPattern[];
+    for (const key of topKeys) {
+      if (CODE_PARAMS.has(key)) continue;
+      if (!patterns.some((pat) => patternMatches(pat, key))) {
+        violations.push(
+          violation(`Node "${node.name}" (${node.type}): parameter "${key}" is not allowed`),
+        );
+      }
+    }
+  }
+
+  if (policy.denyParams && policy.denyParams.length > 0) {
+    const patterns = policy.denyParams
+      .map((p) => compilePattern(p))
+      .filter(Boolean) as CompiledPattern[];
+    for (const key of topKeys) {
+      if (patterns.some((pat) => patternMatches(pat, key))) {
+        violations.push(
+          violation(`Node "${node.name}" (${node.type}): parameter "${key}" is not allowed`),
+        );
+      }
+    }
+  }
+
+  const leaves: Array<{ path: string; value: unknown }> = [];
+  collectLeaves(params, (path, value) => leaves.push({ path, value }));
+
+  if (policy.values) {
+    for (const leaf of leaves) {
+      const isExpr = isExpressionValue(leaf.value);
+      if (!isExpr) {
+        const allowRule = findValueRule(leaf.path, policy.values, "allow");
+        if (allowRule?.allow) {
+          const str = stringifyValue(leaf.value);
+          if (!allowRule.allow.includes(str)) {
+            violations.push(
+              violation(
+                `Node "${node.name}" (${node.type}): parameter "${leaf.path}" has value "${str}" which is not allowed (allowed: ${allowRule.allow.join(", ")})`,
+              ),
+            );
+          }
+        }
+        const patternRule = findValueRule(leaf.path, policy.values, "pattern");
+        if (patternRule?.pattern !== undefined) {
+          const pattern = compilePattern(patternRule.pattern, patternRule.match ?? "glob");
+          const str = stringifyValue(leaf.value);
+          if (pattern && !patternMatches(pattern, str)) {
+            violations.push(
+              violation(
+                `Node "${node.name}" (${node.type}): parameter "${leaf.path}" value "${str}" does not match pattern /${patternRule.pattern}/`,
+              ),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (policy.expressions === "deny" || policy.values) {
+    violations.push(...checkExpressions(node, leaves, policy));
+  }
+
+  return violations;
+}
+
+function checkExpressions(
+  node: Node,
+  leaves: Array<{ path: string; value: unknown }>,
+  policy: RawParamsPolicy,
+): Violation[] {
+  const violations: Violation[] = [];
+  const nodeDefault = policy.expressions ?? "allow";
+
+  for (const leaf of leaves) {
+    if (!isExpressionValue(leaf.value)) continue;
+    let mode = nodeDefault;
+    if (policy.values) {
+      const rule = findValueRule(leaf.path, policy.values, "expressions");
+      if (rule?.expressions) mode = rule.expressions;
+    }
+    if (mode === "deny") {
+      violations.push(
+        violation(
+          `Node "${node.name}" (${node.type}): parameter "${leaf.path}" contains an expression, but expressions are not allowed`,
+        ),
+      );
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Returns the most specific value rule that defines the requested field for a
+ * given parameter path. Fields are resolved independently so that, e.g., a
+ * broad `additionalFields.*` expressions rule still applies to a leaf that a
+ * narrower allow-only rule also matches.
+ */
+function findValueRule(
+  path: string,
+  values: Record<string, RawValueRule>,
+  field: "allow" | "pattern" | "expressions",
+): RawValueRule | undefined {
+  let best: RawValueRule | undefined;
+  let bestSpec = -1;
+  for (const [pathRule, rule] of Object.entries(values)) {
+    if (!hasField(rule, field)) continue;
+    const pattern = compilePattern(pathRule);
+    if (pattern && patternMatches(pattern, path)) {
+      const spec = patternSpecificity(pattern);
+      if (spec > bestSpec) {
+        bestSpec = spec;
+        best = rule;
+      }
+    }
+  }
+  return best;
+}
+
+function hasField(rule: RawValueRule, field: "allow" | "pattern" | "expressions"): boolean {
+  switch (field) {
+    case "allow":
+      return rule.allow !== undefined;
+    case "pattern":
+      return rule.pattern !== undefined;
+    case "expressions":
+      return rule.expressions !== undefined;
+  }
+}
+
+/**
+ * Walks a parameters tree collecting leaf paths. Paths use dot notation with
+ * `[n]` array indices (e.g. `additionalFields.fallback`, `data[0].value`).
+ * Code-bearing parameters are skipped.
+ */
+function collectLeaves(
+  params: Record<string, unknown>,
+  onLeaf: (path: string, value: unknown) => void,
+  prefix = "",
+): void {
+  for (const [key, value] of Object.entries(params)) {
+    if (prefix === "" && CODE_PARAMS.has(key)) continue;
+    const path = prefix === "" ? key : `${prefix}.${key}`;
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const element = value[i];
+        if (element && typeof element === "object" && !Array.isArray(element)) {
+          collectLeaves(element as Record<string, unknown>, onLeaf, `${path}[${i}]`);
+        } else {
+          onLeaf(`${path}[${i}]`, element);
+        }
+      }
+    } else if (value && typeof value === "object") {
+      collectLeaves(value as Record<string, unknown>, onLeaf, path);
+    } else {
+      onLeaf(path, value);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Value helpers
+// ---------------------------------------------------------------------------
+
+/** True for strings n8n treats as expressions: `=...` or containing `{{ }}`. */
+function isExpressionValue(v: unknown): boolean {
+  if (typeof v !== "string") return false;
+  if (v.startsWith("=")) return true;
+  return v.includes("{{") && v.includes("}}");
+}
+
+function stringifyValue(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function configError(message: string): Violation {
+  return { rule: RULE_NAME, severity: "error", message };
+}
+
+function violation(message: string): Violation {
+  return { rule: RULE_NAME, severity: "warning", message };
+}

--- a/tests/cli/lint-integration.test.ts
+++ b/tests/cli/lint-integration.test.ts
@@ -526,3 +526,113 @@ describe("CLI lint: banned-node rule", () => {
     expect(stdout).toContain("banned-node");
   });
 });
+
+// ---------------------------------------------------------------------------
+// extended banned-node policy via config file
+// (allowlist + per-node parameter policies + expression policy)
+// ---------------------------------------------------------------------------
+
+describe("CLI lint: banned-node policy", () => {
+  const fixture = resolve(FIXTURE_DIR, "lint-node-policy.yaml");
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-node-policy-"));
+    configPath = path.join(tmpDir, ".n8nlintrc.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("allowlist bans every node outside it", async () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: {
+          "banned-node": ["error", { allow: [{ type: "n8n-nodes-base.slack" }] }],
+        },
+      }),
+    );
+    const { output } = await runLint(["-f", fixture, "-c", configPath]);
+    const banned = byRule(output.violations, "banned-node");
+    expect(banned.filter((v) => v.message.includes("not in the allowlist"))).toHaveLength(3);
+    // Slack is the only listed type and is itself allowed.
+    expect(banned.some((v) => v.message.includes("Slack Notify"))).toBe(false);
+  });
+
+  test("value allowlist flags an out-of-policy channel name", async () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: {
+          "banned-node": [
+            "error",
+            {
+              params: {
+                "n8n-nodes-base.slack": {
+                  values: { "channelId.value": { allow: ["#general", "#ops"] } },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const { output } = await runLint(["-f", fixture, "-c", configPath]);
+    const banned = byRule(output.violations, "banned-node");
+    expect(banned).toHaveLength(1);
+    expect(banned[0]!.message).toContain("channelId.value");
+    expect(banned[0]!.message).toContain("#random");
+  });
+
+  test("full policy: allowlist + params + expressions together", async () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: {
+          "banned-node": [
+            "error",
+            {
+              allow: [
+                { type: "n8n-nodes-base.manualTrigger" },
+                { type: "n8n-nodes-base.slack" },
+                { type: "n8n-nodes-base.httpRequest" },
+              ],
+              params: {
+                "*": { expressions: "deny" },
+                "n8n-nodes-base.slack": {
+                  allowParams: ["resource", "operation", "channelId", "text", "additionalFields"],
+                  values: {
+                    "channelId.value": { allow: ["#general", "#ops"] },
+                    text: { expressions: "allow" },
+                  },
+                },
+                "n8n-nodes-base.httpRequest": {
+                  allowParams: ["url", "method"],
+                  values: { url: { pattern: "https://example.com/*", match: "glob" } },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const { output } = await runLint(["-f", fixture, "-c", configPath]);
+    const banned = byRule(output.violations, "banned-node");
+    expect(banned).toHaveLength(3);
+
+    const messages = banned.map((v) => v.message);
+    // Code node is outside the allowlist.
+    expect(
+      messages.some((m) => m.includes("Code Node") && m.includes("not in the allowlist")),
+    ).toBe(true);
+    // Slack channel is outside the value allowlist.
+    expect(messages.some((m) => m.includes("channelId.value"))).toBe(true);
+    // The expression in additionalFields.iconEmoji hits the '*' deny default.
+    expect(messages.some((m) => m.includes("additionalFields.iconEmoji"))).toBe(true);
+    // The text expression is explicitly allowed by the per-path override.
+    expect(messages.some((m) => m.includes('parameter "text"'))).toBe(false);
+  });
+});

--- a/tests/fixtures/lint-node-policy.yaml
+++ b/tests/fixtures/lint-node-policy.yaml
@@ -1,0 +1,54 @@
+# Workflow exercising the extended banned-node policy:
+# allowlist + per-node parameter policies + expression policy.
+id: lint-node-policy-001
+name: Node Policy Test
+active: false
+nodes:
+  - id: "trigger-1"
+    name: Manual Trigger
+    type: n8n-nodes-base.manualTrigger
+    typeVersion: 1
+    position: [0, 0]
+    parameters: {}
+
+  # Allowed node, but channelId.value is outside the allowlist and
+  # additionalFields.iconEmoji carries an expression -> violations.
+  # text is an expression too, but the policy explicitly allows it.
+  - id: "slack-1"
+    name: Slack Notify
+    type: n8n-nodes-base.slack
+    typeVersion: 2
+    position: [200, 0]
+    parameters:
+      resource: "message"
+      operation: "post"
+      channelId:
+        __rl: true
+        value: "#random"
+        mode: "name"
+        cachedResultName: "#random"
+      text: "hello ={{ $json.text }}"
+      additionalFields:
+        fallback: "hi"
+        iconEmoji: "={{ $json.emoji }}"
+
+  # Allowed node with clean parameters -> no violations.
+  - id: "http-1"
+    name: HTTP Request
+    type: n8n-nodes-base.httpRequest
+    typeVersion: 4
+    position: [400, 0]
+    parameters:
+      url: "https://example.com/api"
+      method: "GET"
+
+  # NOT in the allowlist -> violation.
+  - id: "code-1"
+    name: Code Node
+    type: n8n-nodes-base.code
+    typeVersion: 1
+    position: [600, 0]
+    parameters:
+      jsCode: "return [];"
+
+connections: {}

--- a/tests/lint/rules/banned-node.test.ts
+++ b/tests/lint/rules/banned-node.test.ts
@@ -17,6 +17,24 @@ function makeWorkflow(nodes: Array<{ name: string; type: string }>): Workflow {
   };
 }
 
+function makeNode(name: string, type: string, parameters?: Record<string, unknown>): Workflow {
+  return {
+    name: "Test",
+    active: true,
+    nodes: [
+      {
+        id: "1",
+        name,
+        type,
+        typeVersion: 1,
+        position: [0, 0] as [number, number],
+        parameters,
+      },
+    ],
+    connections: {},
+  };
+}
+
 describe("banned-node rule", () => {
   test("name is banned-node", () => {
     expect(bannedNodeRule.name).toBe("banned-node");
@@ -96,5 +114,707 @@ describe("banned-node rule", () => {
     expect(violations.length).toBe(2);
     expect(violations[0]!.message).toContain("Code 1");
     expect(violations[1]!.message).toContain("Code 2");
+  });
+});
+
+describe("banned-node: deny matchers", () => {
+  test("deny by glob pattern", () => {
+    const wf = makeWorkflow([{ name: "Exec", type: "n8n-nodes-base.executeCommand" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "n8n-nodes-base.*Command", match: "glob" }],
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('banned type "n8n-nodes-base.executeCommand"');
+  });
+
+  test("deny pattern defaults to glob when match omitted", () => {
+    const wf = makeWorkflow([{ name: "Exec", type: "n8n-nodes-base.executeCommand" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "n8n-nodes-base.*" }],
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("deny by regex pattern", () => {
+    const wf = makeWorkflow([{ name: "Code", type: "n8n-nodes-base.code" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "n8n-nodes-base\\.(code|function)", match: "regex" }],
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("deny regex does not match a non-matching type", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "n8n-nodes-base\\.(code|function)", match: "regex" }],
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("deny with reason on a glob matcher", () => {
+    const wf = makeWorkflow([{ name: "SSH", type: "n8n-nodes-base.ssh" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "*.ssh", match: "glob", reason: "No SSH in CI" }],
+    });
+    expect(violations[0]!.message).toBe(
+      'Node "SSH" uses banned type "n8n-nodes-base.ssh": No SSH in CI',
+    );
+  });
+
+  test("deny wins over allow", () => {
+    const wf = makeWorkflow([{ name: "Slack", type: "n8n-nodes-base.slack" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ type: "n8n-nodes-base.slack", reason: "blocked" }],
+      allow: [{ type: "n8n-nodes-base.slack" }],
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain("blocked");
+  });
+});
+
+describe("banned-node: allowlist mode", () => {
+  test("node listed in allow passes", () => {
+    const wf = makeWorkflow([{ name: "Slack", type: "n8n-nodes-base.slack" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      allow: [{ type: "n8n-nodes-base.slack" }],
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("node not in allowlist is banned", () => {
+    const wf = makeWorkflow([{ name: "Code", type: "n8n-nodes-base.code" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      allow: [{ type: "n8n-nodes-base.slack" }],
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain("not in the allowlist");
+  });
+
+  test("allowlist with glob matches multiple types", () => {
+    const wf = makeWorkflow([
+      { name: "Slack", type: "n8n-nodes-base.slack" },
+      { name: "HTTP", type: "n8n-nodes-base.httpRequest" },
+      { name: "Code", type: "n8n-nodes-base.code" },
+    ]);
+    const violations = bannedNodeRule.check(wf, "", {
+      allow: [{ pattern: "n8n-nodes-base.*", match: "glob" }],
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("empty allow keeps deny-only behavior", () => {
+    const wf = makeWorkflow([{ name: "Slack", type: "n8n-nodes-base.slack" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      allow: [],
+      deny: [{ type: "n8n-nodes-base.code" }],
+    });
+    expect(violations.length).toBe(0);
+  });
+});
+
+describe("banned-node: params policy (allowParams / denyParams)", () => {
+  test("allowParams: all listed params pass", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      resource: "message",
+      text: "hello",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { allowParams: ["resource", "text"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("allowParams: unlisted param is a violation", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      resource: "message",
+      text: "hello",
+      extra: "x",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { allowParams: ["resource", "text"] } },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('parameter "extra" is not allowed');
+  });
+
+  test("denyParams: listed param present is a violation", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      resource: "message",
+      messageType: "chat",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { denyParams: ["messageType"] } },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('parameter "messageType" is not allowed');
+  });
+
+  test("denyParams: absent param is fine", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { denyParams: ["messageType"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("params keyed by glob node type applies to matching nodes", () => {
+    const wf = makeWorkflow([
+      { name: "Slack", type: "n8n-nodes-base.slack" },
+      { name: "HTTP", type: "n8n-nodes-base.httpRequest" },
+    ]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.*": { denyParams: ["additionalFields"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("params keyed by regex node type", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "/n8n-nodes-base\\.slack/": { denyParams: ["foo"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("params keyed by '*' applies to all nodes", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "*": { denyParams: ["resource"] } },
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("params policy only applies to the matching node type", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { denyParams: ["resource"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("empty policy object is ignored", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": {} },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("jsCode is exempt from allowParams even when not listed", () => {
+    const wf = makeNode("Code", "n8n-nodes-base.code", { jsCode: "return [];" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.code": { allowParams: ["other"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("empty allowParams disables the presence check entirely", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { resource: "message" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { allowParams: [] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+});
+
+describe("banned-node: params merge across specificity", () => {
+  test("'*' expressions deny overridden by exact node expressions allow", () => {
+    const wf = makeWorkflow([
+      { name: "Slack", type: "n8n-nodes-base.slack" },
+      { name: "HTTP", type: "n8n-nodes-base.httpRequest" },
+    ]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "*": { expressions: "deny" },
+        "n8n-nodes-base.slack": { expressions: "allow" },
+      },
+    });
+    // Slack explicitly allows expressions; HTTP inherits the '*' deny default.
+    expect(violations.filter((v) => v.message.includes("Slack"))).toHaveLength(0);
+    expect(violations.filter((v) => v.message.includes("HTTP"))).toHaveLength(0);
+  });
+
+  test("'*' deny + exact slack value override: only non-overridden paths flagged", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      text: "=dynamic",
+      channelId: { value: "=also-dynamic" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "*": { expressions: "deny" },
+        "n8n-nodes-base.slack": { values: { text: { expressions: "allow" } } },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('parameter "channelId.value"');
+  });
+
+  test("allowParams are unioned across matching entries", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      resource: "message",
+      text: "hi",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.*": { allowParams: ["resource"] },
+        "n8n-nodes-base.slack": { allowParams: ["text"] },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+});
+
+describe("banned-node: values rules", () => {
+  test("exact allow list satisfied passes", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      channelId: { value: "#general" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "channelId.value": { allow: ["#general", "#ops"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("value outside allow list is a violation", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      channelId: { value: "#random" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "channelId.value": { allow: ["#general", "#ops"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('parameter "channelId.value"');
+    expect(violations[0]!.message).toContain('"#random"');
+  });
+
+  test("empty allow list forbids the nested key entirely", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { attachments: "x" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "additionalFields.attachments": { allow: [] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("glob path pattern matches nested leaves", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "ok", iconEmoji: ":wave:" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "additionalFields.*": { allow: ["ok", ":wave:"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("glob path pattern flags a violating nested leaf", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "ok", iconEmoji: ":x:" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "additionalFields.*": { allow: ["ok", ":wave:"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('"additionalFields.iconEmoji"');
+  });
+
+  test("value pattern with glob", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { url: "https://example.com/api" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": {
+          values: { url: { pattern: "https://example.com/*", match: "glob" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("value pattern with glob violation", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { url: "http://evil.com" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": {
+          values: { url: { pattern: "https://example.com/*", match: "glob" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("value pattern with regex", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { url: "https://example.com/api" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": {
+          values: { url: { pattern: "^https://example\\.com/", match: "regex" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("value pattern with regex violation", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { url: "http://evil.com" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": {
+          values: { url: { pattern: "^https://example\\.com/", match: "regex" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain("does not match pattern /^https://example\\.com//");
+  });
+
+  test("most specific path rule wins", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "other", nested: "allowed" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: {
+            "additionalFields.*": { allow: ["allowed"] },
+            "additionalFields.fallback": { allow: ["specific"] },
+          },
+        },
+      },
+    });
+    // fallback is governed by the exact rule ("specific"), nested by the glob.
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('"additionalFields.fallback"');
+  });
+
+  test("expression value skips literal allow check", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      channelId: { value: "={{ $json.channel }}" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "channelId.value": { allow: ["#general"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("non-string values are stringified for allow comparison", () => {
+    const wf = makeNode("Split", "n8n-nodes-base.splitInBatches", { batchSize: 3 });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.splitInBatches": {
+          values: { batchSize: { allow: ["3", "5"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("value rule on a missing path is a no-op", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { text: "hi" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "channelId.value": { allow: ["#general"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("regex path rule selects nested leaves", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "hi", iconEmoji: ":wave:" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: { "/additionalFields\\.(fallback|iconEmoji)/": { allow: ["hi", ":wave:"] } },
+        },
+      },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("a rule with both allow and pattern reports each violated constraint", () => {
+    const wf = makeNode("HTTP", "n8n-nodes-base.httpRequest", { url: "http://evil.com" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": {
+          values: {
+            url: { allow: ["https://allowed.example"], pattern: "^https://", match: "regex" },
+          },
+        },
+      },
+    });
+    expect(violations.length).toBe(2);
+  });
+
+  test("allowParams supports glob patterns over the key", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "hi" },
+      resource: "message",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { allowParams: ["additional*", "resource"] } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("broad expressions deny still applies under a narrower allow rule", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "={{ $json.x }}" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: {
+            "additionalFields.*": { expressions: "deny" },
+            "additionalFields.fallback": { allow: ["hi"] },
+          },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain("expressions are not allowed");
+  });
+
+  test("broad allow still applies under a narrower expressions rule", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { fallback: "other" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          values: {
+            "additionalFields.*": { allow: ["hi"] },
+            "additionalFields.fallback": { expressions: "deny" },
+          },
+        },
+      },
+    });
+    // "other" fails the broad allow; it is not an expression, so the specific
+    // expressions rule is silent.
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('"additionalFields.fallback"');
+    expect(violations[0]!.message).toContain('"other"');
+  });
+});
+
+describe("banned-node: expressions policy", () => {
+  test("default allow permits expressions", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { text: "={{ $json.field }}" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": {} },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("node expressions deny flags '=' expressions", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { text: "={{ $json.field }}" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { expressions: "deny" } },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('parameter "text"');
+  });
+
+  test("node expressions deny flags bare {{ }} expressions", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", { text: "Hello {{ $json.name }}" });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { expressions: "deny" } },
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("node expressions deny with path-level allow override", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      text: "={{ $json.field }}",
+      channelId: { value: "=dynamic" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          expressions: "deny",
+          values: { text: { expressions: "allow" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('"channelId.value"');
+  });
+
+  test("node expressions deny with path-level deny override", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      text: "={{ $json.field }}",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          expressions: "allow",
+          values: { text: { expressions: "deny" } },
+        },
+      },
+    });
+    expect(violations.length).toBe(1);
+  });
+
+  test("code parameters are exempt from expression checks", () => {
+    const wf = makeNode("Code", "n8n-nodes-base.code", {
+      jsCode: "const x = {{ 1 + 1 }}; return [x];",
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.code": { expressions: "deny" } },
+    });
+    expect(violations.length).toBe(0);
+  });
+
+  test("nested expression values are detected", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      additionalFields: { iconEmoji: "={{ $json.emoji }}" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "n8n-nodes-base.slack": { expressions: "deny" } },
+    });
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.message).toContain('"additionalFields.iconEmoji"');
+  });
+});
+
+describe("banned-node: config validation", () => {
+  test("invalid regex in params key produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "Slack", type: "n8n-nodes-base.slack" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "/[/": { denyParams: ["resource"] } },
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+    expect(violations[0]!.message).toContain("Invalid regex");
+  });
+
+  test("invalid regex in value pattern produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": { values: { url: { pattern: "(", match: "regex" } } },
+      },
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+  });
+
+  test("invalid regex in deny matcher produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "(", match: "regex" }],
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+  });
+
+  test("invalid match value produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ pattern: "x", match: "fuzzy" }],
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+  });
+
+  test("invalid matcher (neither type nor pattern) produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ reason: "no type" }],
+    });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("matcher with both type and pattern produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: [{ type: "n8n-nodes-base.httpRequest", pattern: "http*" }],
+    });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("deny entries that are not objects produce error violations", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      deny: ["n8n-nodes-base.httpRequest"],
+    });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("params not an object produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: "nope",
+    });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("allow not an array produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      allow: "nope",
+    });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("invalid expressions value produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: { "*": { expressions: "sometimes" } },
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+  });
+
+  test("value rule with match but no pattern produces an error violation", () => {
+    const wf = makeWorkflow([{ name: "HTTP", type: "n8n-nodes-base.httpRequest" }]);
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.httpRequest": { values: { url: { match: "regex" } } },
+      },
+    });
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.severity).toBe("error");
+  });
+
+  test("valid config with params does not emit config errors", () => {
+    const wf = makeNode("Slack", "n8n-nodes-base.slack", {
+      channelId: { value: "#general" },
+    });
+    const violations = bannedNodeRule.check(wf, "", {
+      params: {
+        "n8n-nodes-base.slack": {
+          allowParams: ["channelId"],
+          values: { "channelId.value": { allow: ["#general"] } },
+        },
+      },
+    });
+    expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Extends the `banned-node` lint rule from a flat exact-match deny list into a composable node/parameter policy. The existing `nodes` option keeps working (now an alias for `deny`), so this is fully backward compatible.

## Motivation

Teams need to say more than "this node is banned". The driving use case is _allow Slack notifications, but only to an approved set of channels, and only with literal values (no variable embedding)_. The rule should express allow/deny at the node level and flexible value/expression constraints at the parameter level, aware that each node type has a different parameter shape.

## What changed

- **Node matchers** (`deny` / `allow`): exact (`type`), glob, or regex (`pattern` + `match`). A non-empty `allow` switches the rule into allowlist mode, banning every node outside the list. `deny` wins over `allow`.
- **Parameter policies** (`params`), keyed by a node-type matcher (exact, `*`-glob, or `/regex/`), merged in order of specificity so a broad default like `"*"` composes with narrower per-node overrides:
  - `allowParams` / `denyParams` restrict which **top-level** parameter names may appear.
  - `values` applies value-level rules (exact `allow` list, or glob/regex `pattern`) at dot paths (`channelId.value`, `additionalFields.*`). Each field (`allow`, `pattern`, `expressions`) resolves independently to the most specific rule, so a broad rule and a narrow rule compose instead of shadowing one another.
  - `expressions` sets the node's default policy for expression values (`=...` / `{{ ... }}`), with per-path overrides in `values`.
- Expression values skip literal `allow`/`pattern` checks (they're dynamic); the expression policy decides them instead.
- Invalid matchers, regexes, and option values are reported as `error`-severity config violations. Code-bearing params (`jsCode`, `inputSchema`) are exempt from expression checks.

## Example

```jsonc
{
  "rules": {
    "banned-node": ["error", {
      "deny": [{ "type": "n8n-nodes-base.executeCommand", "reason": "arbitrary command execution" }],
      "allow": [
        { "type": "n8n-nodes-base.slack" },
        { "type": "n8n-nodes-base.httpRequest" }
      ],
      "params": {
        "*": { "expressions": "deny" },
        "n8n-nodes-base.slack": {
          "allowParams": ["resource", "operation", "channelId", "text"],
          "values": {
            "channelId.value": { "allow": ["#general", "#ops"] },
            "text": { "expressions": "allow" }
          }
        },
        "n8n-nodes-base.httpRequest": {
          "values": { "url": { "pattern": "^https://", "match": "regex" } }
        }
      }
    }]
  }
}
```

## Testing

- Expanded `tests/lint/rules/banned-node.test.ts` to 71 unit tests covering deny/allow, allowlist mode, specificity merging, value rules (exact/glob/regex, nested paths, resource locators), expression policy precedence, config validation, and backward compatibility.
- Added `tests/fixtures/lint-node-policy.yaml` plus three CLI integration cases in `tests/cli/lint-integration.test.ts`.
- `make quality-gate` passes (typecheck, lint, check-third-party-licenses, full test suite).