### PR TITLE
fix(proxy): populate identity on workflow GET and MCP reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,8 +1095,11 @@ n8n-cli proxy [options]
 
 - `POST /api/v1/workflows` (create)
 - `PUT /api/v1/workflows/:id` (update)
+- `GET /api/v1/workflows/:id` (read — runs the body-less middleware chain, so lint is skipped but identity and authorization gates still apply)
 
-All other paths (including the n8n editor's internal `/rest/*` routes) are forwarded transparently. The `X-N8N-API-KEY` header is passed through as-is.
+All other paths (including the n8n editor's internal `/rest/*` routes and workflow *list* GETs) are forwarded transparently. The `X-N8N-API-KEY` header is passed through as-is.
+
+Body-less routes share one pipeline with writes: `oauth-verify` and `impersonator-verify` populate `ctx.identity`, then later gates such as `project-role` read it. A GET that skipped that chain would see an empty identity even when the caller sent a valid impersonator token.
 
 When project-scoped lint rules are configured, updates are matched to the
 owner Project ID read from the stored upstream workflow. Creates do not carry
@@ -1254,6 +1257,8 @@ It must be named in `--mcp-allow-tools` rather than merely permitted by an empty
 **Deliberately not options.** The endpoint path is fixed at `/mcp-server/`, because n8n fixes it and a flag would only be a way to point the gate at the wrong path and quietly stop gating. And the gate does not re-check `settings.availableInMCP`: n8n already refuses `execute_workflow` and `get_workflow_details` for a workflow without it, so the check would add configuration and no enforcement. Use the tag for what n8n's toggle cannot give you — a decision that shows up in review.
 
 **Which tools take a workflow id.** A built-in table covers the workflow-scoped tools — `execute_workflow`, `test_workflow`, `prepare_workflow_pin_data`, `get_workflow_details`, `get_workflow_history`, `get_workflow_version`, `restore_workflow_version`, `update_workflow`, `publish_workflow`, `unpublish_workflow`, `archive_workflow` — reading `workflowId` and then `id`. It is not configurable and it is not the only check: the gate separately scans **every** argument value, nested ones included, against the set of workflow ids that exist upstream. So a tool n8n renames, a parameter this release read wrong, or a tool it has never heard of cannot carry a forbidden workflow id past the gate — the table only decides how precise the refusal message is, and whether a call that names no workflow at all is refused.
+
+Those same workflow-scoped calls then run the body-less server-middleware chain (the same one `GET /api/v1/workflows/:id` uses), so `oauth-verify` / `impersonator-verify` can populate caller identity before `project-role` reads it.
 
 > **Build `--mcp-allow-tools` from a real `tools/list` against your own instance.** n8n renames these tools between versions — a 2.32.5 instance serves `list_tags`, `get_execution`, `search_executions` and `prepare_test_pin_data`, where later code renames them to `list_workflow_tags`, `get_workflow_execution`, `search_workflow_executions` and `prepare_workflow_pin_data`. Neither the documentation nor a checkout of n8n's default branch tells you which set *your* server publishes. A name that does not exist costs nothing; a real tool missing from the allowlist is silently withheld, so listing both spellings is the safe move.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -18,10 +18,12 @@
  * server-to-client `GET` stream, session teardown — is forwarded untouched.
  */
 
-import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
+import type { Workflow } from "@/api/types.ts";
 import { mcpToolAccessLevel } from "@/middleware/builtin/project-role/mcp-tools.ts";
+import type { ServerMiddleware } from "@/middleware/types.ts";
 import type { EnforceLevel } from "../config.ts";
 import type { Logger } from "../logging.ts";
+import { evaluateBodylessPipeline } from "../rest/read-gate.ts";
 import { forwardRequest } from "../upstream.ts";
 import {
   ENTRY_TOOL_DEFINITION,
@@ -57,8 +59,14 @@ export interface McpGateDeps {
   logger: Logger;
   timeoutMs?: number;
   clientMiddlewares?: import("@/middleware/types.ts").ClientMiddleware[];
-  /** When set, workflow-scoped tool calls also require n8n project membership. */
-  projectRoleChecker?: ProjectRoleChecker | null;
+  /**
+   * The same server-middleware chain the REST write path runs. Workflow-scoped
+   * tool calls go through the body-less subset (oauth-verify, impersonator-verify,
+   * project-role, ...) so identity is populated before authorization.
+   */
+  middlewares?: ServerMiddleware[];
+  /** Stored-workflow lookup for middlewares that must not trust the tool args. */
+  fetchStoredWorkflow?: (id: string, apiKey: string | null) => Promise<Workflow | null>;
 }
 
 /**
@@ -353,29 +361,32 @@ async function refuse(
     );
   }
 
-  if (deps.projectRoleChecker && target !== undefined) {
+  if (deps.middlewares && deps.middlewares.length > 0 && target !== undefined) {
     const level = mcpToolAccessLevel(tool);
     if (level) {
       const facts = sets.facts.get(target);
-      const projectId = facts?.projectId ?? "";
-      const email = deps.projectRoleChecker.resolveEmail({
+      const verdict = await evaluateBodylessPipeline(deps.middlewares, {
         workflow: null,
         request: req,
         mode: "proxy",
+        action: level === "write" ? "update" : "read",
+        workflowId: target,
+        projectId: facts?.projectId || undefined,
+        fetchStoredWorkflow: deps.fetchStoredWorkflow
+          ? (id) => deps.fetchStoredWorkflow!(id, req.headers.get("x-n8n-api-key"))
+          : undefined,
       });
-      if (!email) {
-        log(deps, pathname, "project-role: missing identity", tool);
-        return toolErrorResult(
-          message.id,
-          "This proxy could not resolve the caller identity required for n8n project authorization.",
+      if (verdict.block) {
+        log(
+          deps,
+          pathname,
+          `middleware denied: ${verdict.blockedBy ?? "pipeline"}: ${verdict.denial?.message ?? verdict.violations[0]?.message ?? "blocked"}`,
+          tool,
         );
-      }
-      const verdict = await deps.projectRoleChecker.check({ email, projectId, level });
-      if (!verdict.allowed) {
-        log(deps, pathname, `project-role denied: ${verdict.reason ?? verdict.rule}`, tool);
         return toolErrorResult(
           message.id,
-          verdict.reason ?? "This caller lacks the n8n project role required for that tool.",
+          verdict.denial?.message ??
+            "This proxy refused that tool call under its middleware policy.",
         );
       }
     }

--- a/src/proxy/rest/read-gate.ts
+++ b/src/proxy/rest/read-gate.ts
@@ -1,63 +1,26 @@
-import type { Workflow } from "@/api/types.ts";
-import { workflowProjectId } from "@/common/project-id.ts";
-import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
-import type { PipelineVerdict } from "@/middleware/types.ts";
-
-export interface ReadGateDeps {
-  checker: ProjectRoleChecker;
-  fetchStoredWorkflow: (id: string, apiKey: string | null) => Promise<Workflow | null>;
-}
+import { runPipeline } from "@/middleware/pipeline.ts";
+import type {
+  PipelineVerdict,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
 
 /**
- * Runs the project-role checker for a GET /api/v1/workflows/:id request.
- * Returns a pipeline-shaped denial when the caller lacks viewer access.
+ * Runs the body-less middleware chain against a request that names one
+ * workflow (GET /workflows/:id, MCP tool calls).
+ *
+ * Same filter as tags / delete / activate: lint stays out because there is
+ * no definition to judge. oauth-verify and impersonator-verify still run, so
+ * they can populate `ctx.identity` before project-role reads it.
+ *
+ * Identity is left unset on `ctx` here — each middleware resolves or writes
+ * it. That is the same contract the write path uses.
  */
-export async function evaluateWorkflowReadGate(
-  req: Request,
-  workflowId: string,
-  deps: ReadGateDeps,
-): Promise<PipelineVerdict | null> {
-  const checker = deps.checker;
-  if (!checker.shouldApplyToAction("read")) return null;
-
-  const ctx = {
-    workflow: null,
-    request: req,
-    mode: "proxy" as const,
-    action: "read",
-    workflowId,
-    fetchStoredWorkflow: (id: string) =>
-      deps.fetchStoredWorkflow(id, req.headers.get("x-n8n-api-key")),
-  };
-
-  const email = checker.resolveEmail(ctx);
-  if (!email) {
-    return denial("project-role-missing-identity", "Actor identity could not be resolved");
-  }
-
-  let stored: Workflow | null;
-  try {
-    stored = await deps.fetchStoredWorkflow(workflowId, req.headers.get("x-n8n-api-key"));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return denial("project-role-stored-lookup-error", message);
-  }
-
-  const projectId = workflowProjectId(stored);
-  const verdict = await checker.check({ email, projectId, level: "read" });
-  if (verdict.allowed) return null;
-  return denial(verdict.rule, verdict.reason ?? "Project role check failed");
-}
-
-function denial(rule: string, message: string): PipelineVerdict {
-  return {
-    block: true,
-    blockedBy: "project-role",
-    violations: [{ rule, severity: "error", message }],
-    denial: {
-      status: 403,
-      error: "workflow_project_role_denied",
-      message,
-    },
-  };
+export async function evaluateBodylessPipeline(
+  middlewares: ServerMiddleware[],
+  ctx: ServerMiddlewareContext,
+): Promise<PipelineVerdict> {
+  const applicable = middlewares.filter((m) => !m.readsWorkflowBody);
+  if (applicable.length === 0) return { block: false, violations: [] };
+  return runPipeline(applicable, ctx);
 }

--- a/src/proxy/rest/read-router.ts
+++ b/src/proxy/rest/read-router.ts
@@ -12,7 +12,8 @@ const READ_PATTERN = /^\/api\/v1\/workflows\/([^/]+)$/;
 
 /**
  * Matches GET requests for a single workflow by id. List endpoints and
- * unrelated paths return null and are forwarded without a project-role check.
+ * unrelated paths return null and are forwarded without the body-less
+ * middleware chain (oauth-verify, project-role, ...).
  */
 export function matchWorkflowRead(method: string, pathname: string): WorkflowRead | null {
   if (method.toUpperCase() !== "GET") return null;

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,8 +1,6 @@
 import { PROJECT_ID_HEADER, STALE_WRITE_WARNING_HEADER } from "@/api/headers.ts";
 import type { Workflow } from "@/api/types.ts";
 import { hasAllTags } from "@/common/tags.ts";
-import type { ProjectRoleChecker } from "@/middleware/builtin/project-role/checker.ts";
-import { extractProjectRoleChecker } from "@/middleware/builtin/project-role/middleware.ts";
 import { STALE_WRITE_RULE } from "@/middleware/builtin/stale-write/middleware.ts";
 import { buildClientMiddlewares } from "@/middleware/client-registry.ts";
 import {
@@ -24,7 +22,7 @@ import {
   buildDuplicateResponse,
   buildErrorResponse,
 } from "./response.ts";
-import { evaluateWorkflowReadGate } from "./rest/read-gate.ts";
+import { evaluateBodylessPipeline } from "./rest/read-gate.ts";
 import { matchWorkflowRead } from "./rest/read-router.ts";
 import { matchWorkflowMutation, type WorkflowMutation } from "./rest/router.ts";
 import { forwardRequest } from "./upstream.ts";
@@ -56,7 +54,6 @@ interface HandlerDeps {
   readiness: ReadinessState;
   /** Built when the operator configured an MCP policy; absent otherwise. */
   mcp: McpGateDeps | null;
-  projectRoleChecker: ProjectRoleChecker | null;
 }
 
 /** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
@@ -114,8 +111,6 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     cliOpts: legacyCliOpts,
   });
 
-  const projectRoleChecker = extractProjectRoleChecker(middlewares);
-
   const mcpSettings = config.mcp ?? null;
   const mcp: McpGateDeps | null = mcpSettings
     ? {
@@ -134,7 +129,13 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
         logger,
         timeoutMs: config.upstreamTimeoutMs,
         clientMiddlewares,
-        projectRoleChecker,
+        middlewares,
+        fetchStoredWorkflow: (id, apiKey) =>
+          lookupStoredWorkflow(id, apiKey, {
+            upstream,
+            timeoutMs: config.upstreamTimeoutMs,
+            clientMiddlewares,
+          }),
       }
     : null;
 
@@ -195,7 +196,6 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     clientMiddlewares,
     readiness,
     mcp,
-    projectRoleChecker,
   };
 
   const server = Bun.serve({
@@ -305,21 +305,26 @@ async function handleTransparentForward(
   deps: HandlerDeps,
 ): Promise<Response> {
   const read = matchWorkflowRead(req.method, pathname);
-  if (read && deps.projectRoleChecker) {
+  if (read) {
     try {
-      const denial = await evaluateWorkflowReadGate(req, read.id, {
-        checker: deps.projectRoleChecker,
-        fetchStoredWorkflow: (id, apiKey) => fetchStoredWorkflow(id, apiKey, deps),
+      const verdict = await evaluateBodylessPipeline(deps.middlewares, {
+        workflow: null,
+        request: req,
+        mode: "proxy",
+        action: "read",
+        workflowId: read.id,
+        fetchStoredWorkflow: (id) =>
+          fetchStoredWorkflow(id, req.headers.get("x-n8n-api-key"), deps),
       });
-      if (denial?.block) {
+      if (verdict.block) {
         deps.logger.log({
           action: "block",
           method: req.method,
           path: pathname,
-          status: denial.denial?.status ?? 403,
-          message: denial.denial?.message,
+          status: verdict.denial?.status ?? 403,
+          message: verdict.denial?.message,
         });
-        return buildDenialResponse(denial);
+        return buildDenialResponse(verdict);
       }
     } catch (err) {
       return reportError(err, req, pathname, deps);
@@ -393,22 +398,21 @@ async function handleWorkflowMutation(
   // its own spec; the proxy doesn't need to know which middleware needs
   // identity or which header it lives on.
   // Middleware that judges the definition must not run where there is none.
-  const applicable = mutation.bodyIsWorkflow
-    ? deps.middlewares
-    : deps.middlewares.filter((m) => !m.readsWorkflowBody);
-
-  const verdict = await runPipeline(applicable, {
+  const pipelineCtx = {
     workflow,
     // Middleware that reads a body only makes sense where one exists.
     rawJSON: mutation.bodyIsWorkflow ? rawJSON : undefined,
     request: req,
-    mode: "proxy",
+    mode: "proxy" as const,
     action: mutation.action,
     workflowId: mutation.id,
     projectId:
       mutation.action === "create" ? (req.headers.get(PROJECT_ID_HEADER) ?? undefined) : undefined,
-    fetchStoredWorkflow: (id) => fetchStoredWorkflow(id, apiKey, deps),
-  });
+    fetchStoredWorkflow: (id: string) => fetchStoredWorkflow(id, apiKey, deps),
+  };
+  const verdict = mutation.bodyIsWorkflow
+    ? await runPipeline(deps.middlewares, pipelineCtx)
+    : await evaluateBodylessPipeline(deps.middlewares, pipelineCtx);
 
   const workflowName = workflow?.name;
 
@@ -519,21 +523,27 @@ async function handleWorkflowMutation(
  * anything else so the caller can apply its own fail-open/closed policy rather
  * than mistaking an outage for "no ACL".
  */
-async function fetchStoredWorkflow(
+interface StoredWorkflowLookup {
+  upstream: string;
+  timeoutMs?: number;
+  clientMiddlewares: ClientMiddleware[];
+}
+
+async function lookupStoredWorkflow(
   id: string,
   apiKey: string | null,
-  deps: HandlerDeps,
+  lookup: StoredWorkflowLookup,
 ): Promise<Workflow | null> {
-  const url = `${deps.upstream}/api/v1/workflows/${encodeURIComponent(id)}`;
+  const url = `${lookup.upstream}/api/v1/workflows/${encodeURIComponent(id)}`;
   const headers = new Headers({ accept: "application/json" });
   if (apiKey) headers.set("x-n8n-api-key", apiKey);
   const { response } = await forwardRequest(
     new Request(url, { method: "GET", headers }),
-    deps.upstream,
+    lookup.upstream,
     undefined,
     {
-      timeoutMs: deps.config.upstreamTimeoutMs,
-      clientMiddlewares: deps.clientMiddlewares,
+      timeoutMs: lookup.timeoutMs,
+      clientMiddlewares: lookup.clientMiddlewares,
     },
   );
   if (response.status === 404) return null;
@@ -541,6 +551,18 @@ async function fetchStoredWorkflow(
     throw new Error(`upstream returned HTTP ${response.status} for workflow ${id}`);
   }
   return (await response.json()) as Workflow;
+}
+
+async function fetchStoredWorkflow(
+  id: string,
+  apiKey: string | null,
+  deps: HandlerDeps,
+): Promise<Workflow | null> {
+  return lookupStoredWorkflow(id, apiKey, {
+    upstream: deps.upstream,
+    timeoutMs: deps.config.upstreamTimeoutMs,
+    clientMiddlewares: deps.clientMiddlewares,
+  });
 }
 
 function reportError(err: unknown, req: Request, pathname: string, deps: HandlerDeps): Response {

--- a/tests/proxy/proxy.gated-routes.test.ts
+++ b/tests/proxy/proxy.gated-routes.test.ts
@@ -149,6 +149,13 @@ describe("proxy: every gated route", () => {
       expectStatus: 200,
     },
     {
+      label: "read",
+      method: "GET",
+      path: "/api/v1/workflows/wf1",
+      action: "read",
+      expectStatus: 200,
+    },
+    {
       label: "deactivate",
       method: "POST",
       path: "/api/v1/workflows/wf1/deactivate",
@@ -278,7 +285,6 @@ describe("proxy: what each route hands to middleware", () => {
 describe("proxy: ungated paths are untouched", () => {
   const passthrough: Array<[string, string]> = [
     ["GET", "/api/v1/workflows"],
-    ["GET", "/api/v1/workflows/wf1"],
     ["GET", "/api/v1/tags"],
     ["POST", "/api/v1/tags"],
     ["GET", "/api/v1/executions"],

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerFactory } from "@/middleware/registry.ts";
+import type { ServerMiddleware, ServerMiddlewareFactory } from "@/middleware/types.ts";
 import type { EnforceLevel } from "@/proxy/config.ts";
 import type { McpPolicy } from "@/proxy/mcp/policy.ts";
 import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
@@ -184,7 +186,14 @@ function policy(overrides: Partial<McpPolicy> = {}): McpPolicy {
 let upstream: ReturnType<typeof startMockUpstream>;
 let proxy: ProxyHandle;
 
-function start(mcpPolicy: McpPolicy, enforce: EnforceLevel = "error"): void {
+function start(
+  mcpPolicy: McpPolicy,
+  enforce: EnforceLevel = "error",
+  extra: {
+    middlewares?: string[];
+    middlewareCliOptions?: Record<string, unknown>;
+  } = {},
+): void {
   proxy = startProxy({
     listen: "127.0.0.1:0",
     upstream: `http://127.0.0.1:${upstream.port}`,
@@ -193,13 +202,18 @@ function start(mcpPolicy: McpPolicy, enforce: EnforceLevel = "error"): void {
     logFormat: "json",
     allowDuplicates: true,
     mcp: { enforce, policy: mcpPolicy, cacheTtlMs: 60_000 },
+    ...extra,
   });
 }
 
-async function call(method: string, params?: unknown): Promise<Record<string, unknown>> {
+async function call(
+  method: string,
+  params?: unknown,
+  headers: Record<string, string> = {},
+): Promise<Record<string, unknown>> {
   const res = await fetch(`http://127.0.0.1:${proxy.port}/mcp-server/http`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
   });
   const text = await res.text();
@@ -892,5 +906,56 @@ describe("MCP gate: what it leaves alone", () => {
     start(policy({ denyTools: ["*"] }));
     const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows`);
     expect(res.status).toBe(200);
+  });
+});
+
+function identityStubFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "identity-stub",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "identity-stub",
+      evaluate(ctx) {
+        const email = ctx.request?.headers.get("x-impersonator-email");
+        if (email) {
+          ctx.identity = email;
+          ctx.auth = { effective: { email, layer: "impersonator" } };
+        }
+        return { block: false, violations: [] };
+      },
+    }),
+  };
+}
+
+describe("MCP gate: body-less middleware chain", () => {
+  test("get_workflow_details is refused when project-role cannot resolve identity", async () => {
+    start(policy({ allowTools: ["get_workflow_details"], workflowTags: ["mcp"] }), "error", {
+      middlewares: ["project-role"],
+      middlewareCliOptions: { projectRoleEnforce: "error" },
+    });
+    const reply = await call("tools/call", {
+      name: "get_workflow_details",
+      arguments: { workflowId: "wf-open" },
+    });
+    const result = reply.result as { isError?: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Actor identity could not be resolved");
+    expect(upstream.captured.some((c) => c.pathname === "/mcp-server/http")).toBe(false);
+  });
+
+  test("get_workflow_details proceeds when a prior middleware populated identity", async () => {
+    registerFactory(identityStubFactory());
+    start(policy({ allowTools: ["get_workflow_details"], workflowTags: ["mcp"] }), "error", {
+      middlewares: ["identity-stub", "project-role"],
+      middlewareCliOptions: { projectRoleEnforce: "error" },
+    });
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-open" } },
+      { "x-impersonator-email": "viewer@example.com" },
+    );
+    expect((reply.result as { isError?: boolean }).isError).toBeUndefined();
+    expect(upstream.captured.some((c) => c.pathname === "/mcp-server/http")).toBe(true);
   });
 });

--- a/tests/proxy/proxy.project-role.test.ts
+++ b/tests/proxy/proxy.project-role.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerFactory } from "@/middleware/registry.ts";
+import type { ServerMiddleware, ServerMiddlewareFactory } from "@/middleware/types.ts";
 import { matchWorkflowRead } from "@/proxy/rest/read-router.ts";
 import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
 
@@ -188,5 +190,97 @@ describe("proxy project-role enforcement", () => {
     });
     expect(res.status).toBe(200);
     expect(upstream.captured.some((c) => c.method === "PUT")).toBe(true);
+  });
+});
+
+/**
+ * Stands in for oauth-verify / impersonator-verify: writes a verified email
+ * onto ctx so a later project-role with identity.source=none can see it.
+ * The production bug was GET skipping that chain, so identity stayed empty.
+ */
+function identityStubFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "identity-stub",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "identity-stub",
+      evaluate(ctx) {
+        const email = ctx.request?.headers.get("x-impersonator-email");
+        if (email) {
+          ctx.identity = email;
+          ctx.auth = { effective: { email, layer: "impersonator" } };
+        }
+        return { block: false, violations: [] };
+      },
+    }),
+  };
+}
+
+function startProxyWithVerifiedIdentity(): ProxyHandle {
+  registerFactory(identityStubFactory());
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "off",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    middlewares: ["identity-stub", "project-role"],
+    middlewareCliOptions: {
+      projectRoleEnforce: "error",
+    },
+  });
+  return proxy;
+}
+
+describe("proxy project-role identity from earlier middleware", () => {
+  test("GET succeeds when a prior middleware populated ctx.identity", async () => {
+    startProxyWithVerifiedIdentity();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      headers: { "x-impersonator-email": "viewer@example.com" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("GET is denied when identity source is none and nothing populated ctx.identity", async () => {
+    proxy = startProxy({
+      listen: "127.0.0.1:0",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      enforce: "off",
+      disableRules: [],
+      logFormat: "json",
+      allowDuplicates: true,
+      middlewares: ["project-role"],
+      middlewareCliOptions: {
+        projectRoleEnforce: "error",
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as {
+      error: string;
+      violations: Array<{ rule: string }>;
+    };
+    expect(body.error).toBe("workflow_project_role_denied");
+    expect(body.violations[0]?.rule).toBe("project-role-missing-identity");
+  });
+
+  test("PUT also sees identity populated by a prior middleware", async () => {
+    upstream.server.stop(true);
+    upstream = startMockUpstream({
+      members: [{ email: "editor@example.com", role: "project:editor" }],
+      workflows: { wf1: STORED_WORKFLOW },
+    });
+    startProxyWithVerifiedIdentity();
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/api/v1/workflows/wf1`, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "x-impersonator-email": "editor@example.com",
+      },
+      body: JSON.stringify({ name: "Demo", active: false, nodes: [], connections: {} }),
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

- `GET /api/v1/workflows/:id` and workflow-scoped MCP tool calls now run the same body-less server-middleware chain as other non-definition routes (tags / delete / activate).
- That lets `oauth-verify` and `impersonator-verify` populate `ctx.identity` before `project-role` reads it. Previously those reads called the project-role checker on an empty context while `identity.source` defaulted to `none`, so every GET failed with `Actor identity could not be resolved` even when a valid impersonator token was present.
- Lint still stays out of these routes (`readsWorkflowBody`). If verify middlewares are not in the chain, project-role keeps its existing fallback: header/env identity, or fail-closed when source is `none`.
- Bump to 2.17.0.

## Test plan

- [x] `make quality-gate` (generate-schemas, typecheck, lint, third-party licenses, `bun test`)
- [x] GET succeeds when an earlier middleware populates `ctx.identity` and `project-role` identity source is `none`
- [x] GET still returns 403 `project-role-missing-identity` when nothing populated identity
- [x] PUT still sees identity from the same prior middleware
- [x] MCP `get_workflow_details` is refused without identity and proceeds when a prior middleware populated it
- [x] `GET /api/v1/workflows/:id` is judged with `action=read`; list GET remains ungated


Made with [Cursor](https://cursor.com)