### PR TITLE
feat(proxy): structured request logging with correlation and opt-in identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ src/generated/
 # Temporary files
 *.tmp
 .cache/
+
+# Local tool worktrees
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -1073,6 +1073,7 @@ n8n-cli proxy [options]
 | `--enforce <level>` | `off`, `warn`, or `error` (default: `error`) |
 | `--disable-rule <rules...>` | Disable specific rules (can be repeated) |
 | `--log-format <fmt>` | Log format: `text` or `json` (default: `text`) |
+| `--log-identity` | Include caller identity (email) in log lines. Off by default because emails are PII; see [Logging](#proxy-logging). env: `N8N_PROXY_LOG_IDENTITY` |
 | `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default) |
 | `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
 | `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
@@ -1134,6 +1135,62 @@ Clients then point at `http://proxy-host:8080` instead of n8n directly. From the
 **Apply-style safety checks:** beyond lint, the proxy mirrors the same default-on duplicate-name safety that `apply` enforces. On every `POST /api/v1/workflows` the proxy fetches the upstream workflow list (cached for `--duplicate-ttl` milliseconds) and rejects creates that collide with an existing remote name. Under `--enforce error` this returns 409; under `--enforce warn` an `X-N8n-Duplicate-Warning` header is attached to the forwarded response. Pass `--allow-duplicates` to disable the check entirely (e.g. during a one-off bulk import). Lookups run under the caller's own `X-N8N-API-KEY` so duplicate detection never escalates privileges.
 
 **Rollout tip:** start with `--enforce warn` to audit the violation distribution in production logs, then flip to `--enforce error` once the team has cleaned up existing violations.
+
+#### Logging
+
+<a id="proxy-logging"></a>
+
+Every request the proxy handles produces one structured log line on stdout, and every line shares a fixed `logger: "n8n-cli-proxy"` field so the whole stream can be selected with a single filter — Cloud Logging: `jsonPayload.logger == "n8n-cli-proxy"`, jq: `. | select(.logger == "n8n-cli-proxy")`. With `--log-format json` each line is a single JSON object:
+
+```json
+{
+  "ts": "2026-08-18T12:00:00.000Z",
+  "logger": "n8n-cli-proxy",
+  "level": "error",
+  "event": "request",
+  "requestId": "9f6d…",
+  "surface": "rest-write",
+  "operation": "create",
+  "action": "block",
+  "method": "POST",
+  "path": "/api/v1/workflows",
+  "status": 422,
+  "upstreamMs": 3,
+  "workflowId": "wf-1",
+  "workflowName": "payroll export",
+  "projectId": "proj-1",
+  "violations": [
+    { "rule": "required-fields", "severity": "error", "message": "Missing required field: \"name\"" }
+  ],
+  "identity": "user@example.com",
+  "identitySource": "oauth-verify",
+  "identityVerified": true,
+  "message": "blocked by middleware lint"
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `logger` | Fixed marker (`n8n-cli-proxy`) — the batch filter key. |
+| `level` | Derived from the outcome: `info` (pass/forward), `warn` (warn), `error` (block/error). |
+| `event` | `request` = the terminal access-log line; `policy` = a supplementary policy detail (e.g. the MCP gate narrowing a listing) emitted under the same request. |
+| `requestId` | Correlation id, also returned to the client in the `x-n8n-cli-request-id` response header. Every line of one request shares it. |
+| `surface` | `rest-write`, `rest-read`, `mcp`, or `transparent`. |
+| `operation` | The route action being performed: `create`, `update`, `delete`, `activate`, `tags`, `read`. |
+| `action` | The outcome: `pass`, `block`, `warn`, `forward`, `error`. |
+| `violations` | Middleware findings (rule / severity / message), when any. |
+| `tool` / `rpc` | MCP tool name and JSON-RPC method, on MCP lines. |
+
+Identity fields (`identity`, `identitySource`, `identityVerified`) are emitted **only when `--log-identity` is set** (or `N8N_PROXY_LOG_IDENTITY`). They are PII, so the proxy leaves them out by default. When enabled, the best identity the request offers is logged, tagged by how it was obtained:
+
+| `identitySource` | Meaning |
+|------------------|---------|
+| `oauth-verify` | `Authorization: Bearer` id_token verified against Google tokeninfo (`identityVerified: true`). |
+| `impersonator-verify` | The `X-Impersonator-Id-Token` side header verified on behalf of a trusted principal (`identityVerified: true`). |
+| `middleware` | Some middleware wrote `ctx.identity` (source ambiguity kept; unverified). |
+| `iap-header` | The ambient `X-Goog-Authenticated-User-Email` header injected by an authenticating gateway (GCP IAP / GLB) in front of the proxy. **Ambient, not verified** — trust it only when direct access to the proxy is blocked at the network level. |
+
+Known limitation: middleware short-circuits at the first blocker, so a request blocked by an early middleware (e.g. `lint`) never reaches the identity-verifying middleware that follows it in the chain — its log line may carry no identity beyond the ambient IAP header. This is a property of the chain order the operator configured, not a logging bug.
 
 #### Stale-write guard
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -14,6 +14,7 @@ interface ProxyOptions extends McpCliOptions {
   enforce: string;
   disableRule?: string[];
   logFormat: string;
+  logIdentity?: boolean;
   allowDuplicates?: boolean;
   duplicateTtl?: string;
   upstreamTimeout?: string;
@@ -112,6 +113,12 @@ export function registerProxyCommand(program: Command): void {
     .option("--enforce <level>", "Enforcement level for workflow saves: off, warn, error", "error")
     .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
     .option("--log-format <fmt>", "Log format: text, json", "text")
+    .option(
+      "--log-identity",
+      "Include caller identity (email) in log lines. Off by default because emails are PII; " +
+        "when enabled the proxy logs the best identity it can resolve (verified token claims " +
+        "first, then the GCP IAP X-Goog-Authenticated-User-Email header). env: N8N_PROXY_LOG_IDENTITY",
+    )
     .option(
       "--allow-duplicates",
       "Skip the upstream duplicate-name check on POST /api/v1/workflows (the check is on by default; under enforce=error a match returns 409, under enforce=warn a header is attached)",
@@ -432,6 +439,7 @@ export function registerProxyCommand(program: Command): void {
         enforce,
         disableRules: opts.disableRule ?? [],
         logFormat,
+        logIdentity: opts.logIdentity,
         allowDuplicates: !!opts.allowDuplicates,
         duplicateTtlMs,
         upstreamTimeoutMs,

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -18,6 +18,18 @@ export interface ProxyConfig {
   /** Log format */
   logFormat: "text" | "json";
   /**
+   * Whether to include caller identity (email) in log lines. Default false:
+   * emails are PII and opt-in. When enabled, the proxy resolves the best
+   * identity it can — verified (oauth-verify / impersonator-verify) first,
+   * then the ambient GCP IAP header.
+   */
+  logIdentity?: boolean;
+  /**
+   * Write target for log lines. Defaults to process.stdout; injectable so
+   * tests can capture structured output without touching a global.
+   */
+  logWriter?: (line: string) => void;
+  /**
    * When true, skip the upstream duplicate-name check on workflow creation.
    *
    * Default false (check ON): on every `POST /api/v1/workflows` the proxy

--- a/src/proxy/logging.ts
+++ b/src/proxy/logging.ts
@@ -1,17 +1,71 @@
 import type { Violation } from "@/lint/rules/violation.ts";
+import type { AuthContext } from "@/middleware/types.ts";
 
 /** Action taken on a request, used in audit logs. */
 export type LogAction = "pass" | "block" | "warn" | "forward" | "error";
 
+/** Severity level, derived from `action`. */
+export type LogLevel = "info" | "warn" | "error";
+
+/** Which surface of the proxy a request hit. */
+export type LogSurface = "rest-write" | "rest-read" | "mcp" | "transparent";
+
+/**
+ * Event kind. `request` is the single terminal access-log line per request;
+ * `policy` is a supplementary line (e.g. the MCP gate narrowing a listing
+ * after the request was already logged as forwarded). Lines of one request
+ * share the same `requestId`.
+ */
+export type LogEvent = "request" | "policy";
+
+/**
+ * Fixed marker carried by every n8n-cli proxy log line. This is the key a
+ * log-aggregation filter matches to select the whole batch at once, e.g.
+ * Cloud Logging: `jsonPayload.logger == "n8n-cli-proxy"`.
+ */
+export const LOGGER_NAME = "n8n-cli-proxy";
+
+/**
+ * How `identity` was resolved. `oauth-verify` / `impersonator-verify` are
+ * cryptographically verified; `middleware` (some middleware wrote
+ * `ctx.identity`) and `iap-header` (the ambient GCP IAP header) are not.
+ */
+export type IdentitySource = "oauth-verify" | "impersonator-verify" | "middleware" | "iap-header";
+
+export interface ResolvedLogIdentity {
+  identity: string;
+  identitySource: IdentitySource;
+  identityVerified: boolean;
+}
+
 export interface LogEntry {
   ts: string;
+  logger: typeof LOGGER_NAME;
+  level: LogLevel;
   action: LogAction;
-  method: string;
-  path: string;
   status: number;
+  /** Pinned by the request-scoped child logger; present on every line in practice. */
+  event?: LogEvent;
+  method?: string;
+  path?: string;
+  /** Correlation id shared by every log line produced while handling one request. */
+  requestId?: string;
+  surface?: LogSurface;
+  /** Route action ("create", "update", "read", ...), the thing being done. */
+  operation?: string;
   upstreamMs?: number;
-  violations?: Array<Pick<Violation, "rule" | "severity" | "message">>;
+  workflowId?: string;
+  projectId?: string;
   workflowName?: string;
+  /** MCP tool name, e.g. "execute_workflow". */
+  tool?: string;
+  /** MCP JSON-RPC method, e.g. "tools/call". */
+  rpc?: string;
+  violations?: Array<Pick<Violation, "rule" | "severity" | "message">>;
+  /** Caller identity. Only emitted when identity logging is enabled. */
+  identity?: string;
+  identitySource?: IdentitySource;
+  identityVerified?: boolean;
   message?: string;
 }
 
@@ -28,21 +82,126 @@ export function redactHeaders(headers: Headers): Record<string, string> {
 
 export type LogFormat = "text" | "json";
 
-export class Logger {
-  constructor(private format: LogFormat = "text") {}
+/** Fields a child logger inherits and pins onto every line it emits. */
+export interface LogBase {
+  event?: LogEvent;
+  requestId?: string;
+  surface?: LogSurface;
+  method?: string;
+  path?: string;
+  operation?: string;
+  workflowId?: string;
+  projectId?: string;
+}
 
-  log(entry: Omit<LogEntry, "ts">): void {
-    const full: LogEntry = { ts: new Date().toISOString(), ...entry };
+function levelForAction(action: LogAction): LogLevel {
+  if (action === "warn") return "warn";
+  if (action === "block" || action === "error") return "error";
+  return "info";
+}
+
+const DEFAULT_WRITE = (line: string): void => {
+  process.stdout.write(line);
+};
+
+/**
+ * Structured request logger for the proxy.
+ *
+ * Writes one JSON object per line to stdout in `json` mode, or a compact
+ * key=value line in `text` mode. Every line carries `logger: "n8n-cli-proxy"`
+ * plus a `level` derived from the outcome `action`, so the whole stream can be
+ * filtered as a batch regardless of which code path produced it.
+ *
+ * `child()` returns a bound logger that pins shared per-request fields
+ * (`requestId`, `surface`, `operation`, ...), so call sites only pass what is
+ * specific to the line they emit. The writer is injectable for tests.
+ */
+export class Logger {
+  constructor(
+    private readonly format: LogFormat = "text",
+    private readonly write: (line: string) => void = DEFAULT_WRITE,
+    private readonly base: LogBase = {},
+  ) {}
+
+  /** Returns a logger that merges `fields` into every line it emits. */
+  child(fields: LogBase): Logger {
+    return new Logger(this.format, this.write, { ...this.base, ...fields });
+  }
+
+  log(entry: Omit<LogEntry, "ts" | "logger" | "level">): void {
+    const full: LogEntry = {
+      ts: new Date().toISOString(),
+      logger: LOGGER_NAME,
+      level: levelForAction(entry.action),
+      event: entry.event ?? this.base.event ?? "request",
+      ...this.base,
+      ...entry,
+    };
     if (this.format === "json") {
-      process.stdout.write(`${JSON.stringify(full)}\n`);
-    } else {
-      const v = full.violations?.length ? ` violations=${full.violations.length}` : "";
-      const ms = full.upstreamMs !== undefined ? ` upstreamMs=${full.upstreamMs}` : "";
-      const wf = full.workflowName ? ` workflow="${full.workflowName}"` : "";
-      const msg = full.message ? ` msg="${full.message}"` : "";
-      process.stdout.write(
-        `${full.ts} ${full.action.toUpperCase()} ${full.method} ${full.path} ${full.status}${ms}${wf}${v}${msg}\n`,
-      );
+      this.write(`${JSON.stringify(full)}\n`);
+      return;
+    }
+
+    const surface = full.surface ? ` surface=${full.surface}` : "";
+    const operation = full.operation ? ` operation=${full.operation}` : "";
+    const event = full.event && full.event !== "request" ? ` event=${full.event}` : "";
+    const rid = full.requestId ? ` requestId=${full.requestId}` : "";
+    const ms = full.upstreamMs !== undefined ? ` upstreamMs=${full.upstreamMs}` : "";
+    const wf = full.workflowName ? ` workflow="${full.workflowName}"` : "";
+    const wid = full.workflowId ? ` workflowId=${full.workflowId}` : "";
+    const ident = full.identity ? ` identity=${full.identity}` : "";
+    const v = full.violations?.length ? ` violations=${full.violations.length}` : "";
+    const msg = full.message ? ` msg="${full.message}"` : "";
+    this.write(
+      `${full.ts} ${full.action.toUpperCase()} ${full.method} ${full.path} ${full.status}${surface}${operation}${event}${rid}${ms}${wid}${wf}${ident}${v}${msg}\n`,
+    );
+  }
+}
+
+/**
+ * Resolves the best caller identity for a request log.
+ *
+ * Priority:
+ *   1. `pipeline.auth.effective` — verified by oauth-verify / impersonator-verify.
+ *   2. `pipeline.identity` — written by some middleware (source ambiguity kept).
+ *   3. `X-Goog-Authenticated-User-Email` — injected by an authenticating gateway
+ *      (GCP IAP / GLB) in front of the proxy. Ambient: trusted only when direct
+ *      access to the proxy is blocked at the network level.
+ *
+ * Returns undefined when nothing is resolvable. Callers gate this on the
+ * `--log-identity` opt-in so emails never reach logs by default.
+ */
+const IAP_USER_EMAIL_HEADER = "x-goog-authenticated-user-email";
+const IAP_EMAIL_PREFIX = "accounts.google.com:";
+
+export function resolveLogIdentity(
+  req: Request | undefined,
+  pipeline?: { auth?: AuthContext; identity?: string },
+): ResolvedLogIdentity | undefined {
+  if (!req) return undefined;
+
+  const effective = pipeline?.auth?.effective;
+  if (effective) {
+    return {
+      identity: effective.email,
+      identitySource: effective.layer === "impersonator" ? "impersonator-verify" : "oauth-verify",
+      identityVerified: true,
+    };
+  }
+
+  if (pipeline?.identity) {
+    return { identity: pipeline.identity, identitySource: "middleware", identityVerified: false };
+  }
+
+  const iapEmail = req.headers.get(IAP_USER_EMAIL_HEADER);
+  if (iapEmail) {
+    const email = iapEmail.startsWith(IAP_EMAIL_PREFIX)
+      ? iapEmail.slice(IAP_EMAIL_PREFIX.length)
+      : iapEmail;
+    if (email !== "") {
+      return { identity: email, identitySource: "iap-header", identityVerified: false };
     }
   }
+
+  return undefined;
 }

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -20,9 +20,14 @@
 
 import type { Workflow } from "@/api/types.ts";
 import { mcpToolAccessLevel } from "@/middleware/builtin/project-role/mcp-tools.ts";
-import type { ServerMiddleware } from "@/middleware/types.ts";
+import type { ServerMiddleware, ServerMiddlewareContext } from "@/middleware/types.ts";
 import type { EnforceLevel } from "../config.ts";
-import type { Logger } from "../logging.ts";
+import {
+  type LogEvent,
+  type Logger,
+  type ResolvedLogIdentity,
+  resolveLogIdentity,
+} from "../logging.ts";
 import { evaluateBodylessPipeline } from "../rest/read-gate.ts";
 import { forwardRequest } from "../upstream.ts";
 import {
@@ -56,7 +61,6 @@ export interface McpGateDeps {
   policy: McpPolicy;
   enforce: EnforceLevel;
   index: AllowedWorkflowIndex;
-  logger: Logger;
   timeoutMs?: number;
   clientMiddlewares?: import("@/middleware/types.ts").ClientMiddleware[];
   /**
@@ -67,6 +71,8 @@ export interface McpGateDeps {
   middlewares?: ServerMiddleware[];
   /** Stored-workflow lookup for middlewares that must not trust the tool args. */
   fetchStoredWorkflow?: (id: string, apiKey: string | null) => Promise<Workflow | null>;
+  /** Whether caller identity may be included in log lines (opt-in). */
+  logIdentity: boolean;
 }
 
 /**
@@ -90,40 +96,42 @@ export function isMcpPath(pathname: string): boolean {
  * small batch), not a stream, so there is nothing to lose by buffering it, and
  * the decision needs the whole thing.
  */
-export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise<Response> {
-  const pathname = new URL(req.url).pathname;
-
+export async function handleMcpRequest(
+  req: Request,
+  deps: McpGateDeps,
+  reqLog: Logger,
+): Promise<Response> {
   // `off` keeps the route registered — so the path still forwards — while the
   // policy stops applying. Useful to switch the gate out without redeploying a
   // different route table.
   if (deps.enforce === "off") {
-    return forward(req, undefined, pathname, deps);
+    return forward(req, undefined, deps, reqLog);
   }
 
   // Only a POST carries a JSON-RPC request. GET (the server-to-client SSE
   // stream) and DELETE (session teardown) are pure transport.
   if (req.method !== "POST") {
-    return forward(req, undefined, pathname, deps);
+    return forward(req, undefined, deps, reqLog);
   }
 
   const rawJSON = await req.text();
   const parsed = parseJsonRpc(rawJSON);
   if (!parsed) {
     // Not something we can reason about; n8n can reject it on its own terms.
-    return forward(req, rawJSON, pathname, deps);
+    return forward(req, rawJSON, deps, reqLog);
   }
 
   // Answered here, never forwarded: n8n has no such tool. Before the refusal
   // pass, because the same workflow scope decides both and this needs the facts
   // rather than a yes/no.
   if (deps.enforce === "error" && publishesEntryTool(deps.policy)) {
-    const answered = await answerEntryTool(parsed, pathname, deps);
+    const answered = await answerEntryTool(parsed, deps, reqLog);
     if (answered) return answered;
   }
 
   const refusals: JsonRpcMessage[] = [];
   for (const message of parsed.messages) {
-    const refusal = await refuse(message, pathname, deps, req);
+    const refusal = await refuse(message, deps, req, reqLog);
     if (refusal) refusals.push(refusal);
   }
 
@@ -157,7 +165,7 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
     return jsonRpcResponse(refusals, parsed.isBatch);
   }
 
-  const response = await forward(req, narrowedJSON ?? rawJSON, pathname, deps);
+  const response = await forward(req, narrowedJSON ?? rawJSON, deps, reqLog);
 
   // Under `warn` nothing is rewritten: the point of warn is to find out what
   // the policy would break, and a client that never sees a tool or a workflow
@@ -172,7 +180,7 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
     : new Set<string | number>();
   if (!tools && searchIds.size === 0) return response;
 
-  return filterResponse(response, deps, pathname, { tools, searchIds });
+  return filterResponse(response, deps, { tools, searchIds }, reqLog);
 }
 
 /**
@@ -186,8 +194,8 @@ export async function handleMcpRequest(req: Request, deps: McpGateDeps): Promise
  */
 async function answerEntryTool(
   parsed: { messages: JsonRpcMessage[]; isBatch: boolean },
-  pathname: string,
   deps: McpGateDeps,
+  reqLog: Logger,
 ): Promise<Response | null> {
   if (!parsed.messages.every((m) => toolCallName(m) === ENTRY_TOOL_NAME)) return null;
 
@@ -196,7 +204,10 @@ async function answerEntryTool(
     sets = await deps.index.sets();
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    log(deps, pathname, `workflow index unavailable: ${reason}`, ENTRY_TOOL_NAME);
+    log(reqLog, deps, `workflow index unavailable: ${reason}`, {
+      tool: ENTRY_TOOL_NAME,
+      rpc: "tools/call",
+    });
     return jsonRpcResponse(
       parsed.messages.map((m) =>
         toolErrorResult(
@@ -215,7 +226,11 @@ async function answerEntryTool(
         return toolErrorResult(message.id, `${ENTRY_TOOL_NAME} requires a workflowId.`);
       }
       if (!sets.allowed.has(id)) {
-        log(deps, pathname, `workflow out of MCP scope: ${id}`, ENTRY_TOOL_NAME);
+        log(reqLog, deps, `workflow out of MCP scope: ${id}`, {
+          tool: ENTRY_TOOL_NAME,
+          rpc: "tools/call",
+          workflowId: id,
+        });
         return toolErrorResult(
           message.id,
           `Not available over MCP: ${id} (${explainRefusal(deps.policy, sets.facts.get(id))}).`,
@@ -294,15 +309,19 @@ function filtersTools(policy: McpPolicy): boolean {
  */
 async function refuse(
   message: JsonRpcMessage,
-  pathname: string,
   deps: McpGateDeps,
   req: Request,
+  reqLog: Logger,
 ): Promise<JsonRpcMessage | null> {
   const tool = toolCallName(message);
   if (tool === null) return null;
+  const rpc = typeof message.method === "string" ? message.method : undefined;
 
   if (!isToolAllowed(deps.policy, tool)) {
-    log(deps, pathname, `tool "${tool}" is not exposed by this proxy`, tool);
+    log(reqLog, deps, `tool "${tool}" is not exposed by this proxy`, {
+      tool,
+      rpc,
+    });
     // The tool was never listed, so a client calling it is off-protocol. Say so
     // as a protocol error rather than as a tool result the model will retry.
     return protocolError(message.id, INVALID_PARAMS, `Unknown tool: ${tool}`);
@@ -317,7 +336,7 @@ async function refuse(
   // is malformed rather than broad. Refused: waving it through would mean the
   // one call the gate cannot reason about is also the one it lets past.
   if (target === null) {
-    log(deps, pathname, `tool "${tool}" named no workflow`, tool);
+    log(reqLog, deps, `tool "${tool}" named no workflow`, { tool, rpc });
     return toolErrorResult(
       message.id,
       `This proxy only allows ${tool} against a workflow it can identify, and this call named none.`,
@@ -329,7 +348,11 @@ async function refuse(
     sets = await deps.index.sets();
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    log(deps, pathname, `workflow index unavailable: ${reason}`, tool);
+    log(reqLog, deps, `workflow index unavailable: ${reason}`, {
+      tool,
+      rpc,
+      workflowId: target,
+    });
     // Fail closed. A gate that opens during an upstream outage is not a gate,
     // and an operator who wants the calls through has `--mcp-enforce warn`.
     return toolErrorResult(
@@ -352,7 +375,11 @@ async function refuse(
       .map((id) => `${id} (${explainRefusal(deps.policy, sets.facts.get(id))})`)
       .join("; ");
 
-    log(deps, pathname, `workflow out of MCP scope: ${detail}`, tool);
+    log(reqLog, deps, `workflow out of MCP scope: ${detail}`, {
+      tool,
+      rpc,
+      workflowId: target,
+    });
     return toolErrorResult(
       message.id,
       `Not available over MCP: ${detail}. Note that every workflow id anywhere in the arguments is ` +
@@ -365,7 +392,7 @@ async function refuse(
     const level = mcpToolAccessLevel(tool);
     if (level) {
       const facts = sets.facts.get(target);
-      const verdict = await evaluateBodylessPipeline(deps.middlewares, {
+      const pipelineCtx: ServerMiddlewareContext = {
         workflow: null,
         request: req,
         mode: "proxy",
@@ -375,13 +402,19 @@ async function refuse(
         fetchStoredWorkflow: deps.fetchStoredWorkflow
           ? (id) => deps.fetchStoredWorkflow!(id, req.headers.get("x-n8n-api-key"))
           : undefined,
-      });
+      };
+      const verdict = await evaluateBodylessPipeline(deps.middlewares, pipelineCtx);
       if (verdict.block) {
         log(
+          reqLog,
           deps,
-          pathname,
           `middleware denied: ${verdict.blockedBy ?? "pipeline"}: ${verdict.denial?.message ?? verdict.violations[0]?.message ?? "blocked"}`,
-          tool,
+          {
+            tool,
+            rpc,
+            workflowId: target,
+            identity: deps.logIdentity ? resolveLogIdentity(req, pipelineCtx) : undefined,
+          },
         );
         return toolErrorResult(
           message.id,
@@ -417,8 +450,8 @@ async function refuse(
 async function filterResponse(
   response: Response,
   deps: McpGateDeps,
-  pathname: string,
   plan: { tools: boolean; searchIds: Set<string | number> },
+  reqLog: Logger,
 ): Promise<Response> {
   // By now `refuse()` has already resolved the index for any workflow-scoped
   // call in this request, so this is a cache read. It can still fail on a
@@ -429,7 +462,9 @@ async function filterResponse(
       allowed = (await deps.index.sets()).allowed;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      log(deps, pathname, `workflow index unavailable, withholding search results: ${reason}`);
+      log(reqLog, deps, `workflow index unavailable, withholding search results: ${reason}`, {
+        event: "policy",
+      });
     }
   }
 
@@ -471,9 +506,17 @@ async function filterResponse(
     });
   });
 
-  if (removedTools > 0) log(deps, pathname, `withheld ${removedTools} tool(s) from tools/list`);
+  if (removedTools > 0) {
+    log(reqLog, deps, `withheld ${removedTools} tool(s) from tools/list`, {
+      event: "policy",
+      rpc: "tools/list",
+    });
+  }
   if (removedWorkflows > 0) {
-    log(deps, pathname, `withheld ${removedWorkflows} workflow(s) from search_workflows`);
+    log(reqLog, deps, `withheld ${removedWorkflows} workflow(s) from search_workflows`, {
+      event: "policy",
+      rpc: "search_workflows",
+    });
   }
 
   const headers = new Headers(response.headers);
@@ -588,21 +631,27 @@ function jsonRpcResponse(messages: JsonRpcMessage[], isBatch: boolean): Response
 async function forward(
   req: Request,
   body: string | undefined,
-  pathname: string,
   deps: McpGateDeps,
+  reqLog: Logger,
 ): Promise<Response> {
   const { response, elapsedMs } = await forwardRequest(req, deps.upstream, body, {
     timeoutMs: deps.timeoutMs,
     clientMiddlewares: deps.clientMiddlewares,
   });
-  deps.logger.log({
+  reqLog.log({
     action: "forward",
-    method: req.method,
-    path: pathname,
     status: response.status,
     upstreamMs: elapsedMs,
   });
   return response;
+}
+
+interface McpLogOpts {
+  tool?: string;
+  rpc?: string;
+  workflowId?: string;
+  event?: LogEvent;
+  identity?: ResolvedLogIdentity;
 }
 
 /**
@@ -611,13 +660,20 @@ async function forward(
  * `status` is 200 even for a refusal: the refusal travels as a JSON-RPC reply,
  * so that is genuinely what the client received, and logging a 403 nobody sent
  * would send an operator hunting for an HTTP error in their gateway logs.
+ *
+ * Refusals are the request's terminal line (`event: "request"`); lines that
+ * merely detail a policy already logged as forwarded (`event: "policy"`) share
+ * the same `requestId` so both can be reassembled per request.
  */
-function log(deps: McpGateDeps, pathname: string, message: string, tool?: string): void {
-  deps.logger.log({
+function log(reqLog: Logger, deps: McpGateDeps, message: string, opts: McpLogOpts = {}): void {
+  reqLog.log({
     action: deps.enforce === "error" ? "block" : "warn",
-    method: "POST",
-    path: pathname,
+    event: opts.event ?? "request",
     status: 200,
-    message: `mcp: ${message}${tool ? ` (tool=${tool})` : ""}`,
+    tool: opts.tool,
+    rpc: opts.rpc,
+    workflowId: opts.workflowId,
+    ...(opts.identity ?? {}),
+    message: `mcp: ${message}`,
   });
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -9,11 +9,15 @@ import {
 } from "@/middleware/client-wiring.ts";
 import { runPipeline } from "@/middleware/pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "@/middleware/registry.ts";
-import type { ClientMiddleware, ServerMiddleware } from "@/middleware/types.ts";
+import type {
+  ClientMiddleware,
+  ServerMiddleware,
+  ServerMiddlewareContext,
+} from "@/middleware/types.ts";
 import { DEFAULT_SERVER_MIDDLEWARE_CHAIN, registerBuiltins } from "@/middleware/wiring.ts";
 import { normalizeUpstream, type ProxyConfig, parseListenAddr } from "./config.ts";
 import { DuplicateChecker } from "./duplicate.ts";
-import { Logger } from "./logging.ts";
+import { Logger, type ResolvedLogIdentity, resolveLogIdentity } from "./logging.ts";
 import { handleMcpRequest, isMcpPath, type McpGateDeps } from "./mcp/gate.ts";
 import { AllowedWorkflowIndex } from "./mcp/workflow-index.ts";
 import {
@@ -29,6 +33,9 @@ import { forwardRequest } from "./upstream.ts";
 
 const SERVER_MIDDLEWARES_ENV_VAR = "N8N_SERVER_MIDDLEWARES";
 const CLIENT_MIDDLEWARES_ENV_VAR = "N8N_CLIENT_MIDDLEWARES";
+
+/** Response header carrying the per-request correlation id to the client. */
+const REQUEST_ID_HEADER = "x-n8n-cli-request-id";
 
 /**
  * Tracks whether middleware `prepare()` has finished so `/readyz` can flip
@@ -54,6 +61,8 @@ interface HandlerDeps {
   readiness: ReadinessState;
   /** Built when the operator configured an MCP policy; absent otherwise. */
   mcp: McpGateDeps | null;
+  /** Whether caller identity may be included in log lines (opt-in). */
+  logIdentity: boolean;
 }
 
 /** Starts the proxy server. Returns a handle so tests can stop it cleanly. */
@@ -65,7 +74,8 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
 
   const { host, port } = parseListenAddr(config.listen);
   const upstream = normalizeUpstream(config.upstream);
-  const logger = new Logger(config.logFormat);
+  const logger = new Logger(config.logFormat, config.logWriter);
+  const logIdentity = config.logIdentity ?? envBool(process.env.N8N_PROXY_LOG_IDENTITY);
 
   // Decide which server middlewares to run. Precedence: explicit config (set
   // by the CLI from --server-middleware) > N8N_SERVER_MIDDLEWARES env var >
@@ -126,7 +136,6 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
           },
           mcpSettings.cacheTtlMs,
         ),
-        logger,
         timeoutMs: config.upstreamTimeoutMs,
         clientMiddlewares,
         middlewares,
@@ -136,6 +145,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
             timeoutMs: config.upstreamTimeoutMs,
             clientMiddlewares,
           }),
+        logIdentity,
       }
     : null;
 
@@ -196,6 +206,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     clientMiddlewares,
     readiness,
     mcp,
+    logIdentity,
   };
 
   const server = Bun.serve({
@@ -234,23 +245,48 @@ async function handle(req: Request, deps: HandlerDeps): Promise<Response> {
     return handleProbe(req.method, pathname, deps);
   }
 
+  // Per-request correlation id: pinned on every log line this request emits
+  // and echoed to the client on the response header, so a caller can tie its
+  // own records to the proxy's view of the same call.
+  const requestId = crypto.randomUUID();
+  const reqLog = deps.logger.child({ requestId, method: req.method, path: pathname });
+
   // MCP policy, when one is configured. Checked before the workflow-mutation
   // table because the two surfaces are disjoint: n8n's MCP endpoint speaks
   // JSON-RPC on its own path and never looks like a public-API write.
   if (deps.mcp && isMcpPath(pathname)) {
+    const mcpLog = reqLog.child({ surface: "mcp" });
     try {
-      return await handleMcpRequest(req, deps.mcp);
+      return attachRequestId(await handleMcpRequest(req, deps.mcp, mcpLog), requestId);
     } catch (err) {
-      return reportError(err, req, pathname, deps);
+      return attachRequestId(reportError(err, req, deps, mcpLog), requestId);
     }
   }
 
   const mutation = matchWorkflowMutation(req.method, pathname, deps.config.routes);
   if (mutation) {
-    return handleWorkflowMutation(req, mutation, pathname, deps);
+    return attachRequestId(
+      await handleWorkflowMutation(
+        req,
+        mutation,
+        pathname,
+        deps,
+        reqLog.child({ surface: "rest-write" }),
+      ),
+      requestId,
+    );
   }
 
-  return handleTransparentForward(req, pathname, deps);
+  return attachRequestId(
+    await handleTransparentForward(req, pathname, deps, reqLog.child({ surface: "transparent" })),
+    requestId,
+  );
+}
+
+/** Attaches the correlation header to a response so the caller can match it to the log. */
+function attachRequestId(response: Response, requestId: string): Response {
+  response.headers.set(REQUEST_ID_HEADER, requestId);
+  return response;
 }
 
 function isProbeRequest(method: string, pathname: string): boolean {
@@ -303,31 +339,36 @@ async function handleTransparentForward(
   req: Request,
   pathname: string,
   deps: HandlerDeps,
+  reqLog: Logger,
 ): Promise<Response> {
   const read = matchWorkflowRead(req.method, pathname);
+  const log = read
+    ? reqLog.child({ surface: "rest-read", operation: "read", workflowId: read.id })
+    : reqLog;
+  let pipelineCtx: ServerMiddlewareContext | undefined;
+
   if (read) {
+    pipelineCtx = {
+      workflow: null,
+      request: req,
+      mode: "proxy",
+      action: "read",
+      workflowId: read.id,
+      fetchStoredWorkflow: (id) => fetchStoredWorkflow(id, req.headers.get("x-n8n-api-key"), deps),
+    };
     try {
-      const verdict = await evaluateBodylessPipeline(deps.middlewares, {
-        workflow: null,
-        request: req,
-        mode: "proxy",
-        action: "read",
-        workflowId: read.id,
-        fetchStoredWorkflow: (id) =>
-          fetchStoredWorkflow(id, req.headers.get("x-n8n-api-key"), deps),
-      });
+      const verdict = await evaluateBodylessPipeline(deps.middlewares, pipelineCtx);
       if (verdict.block) {
-        deps.logger.log({
+        log.log({
           action: "block",
-          method: req.method,
-          path: pathname,
           status: verdict.denial?.status ?? 403,
           message: verdict.denial?.message,
+          ...logIdentityFor(req, deps, pipelineCtx),
         });
         return buildDenialResponse(verdict);
       }
     } catch (err) {
-      return reportError(err, req, pathname, deps);
+      return reportError(err, req, deps, log);
     }
   }
 
@@ -336,16 +377,15 @@ async function handleTransparentForward(
       timeoutMs: deps.config.upstreamTimeoutMs,
       clientMiddlewares: deps.clientMiddlewares,
     });
-    deps.logger.log({
+    log.log({
       action: "forward",
-      method: req.method,
-      path: pathname,
       status: response.status,
       upstreamMs: elapsedMs,
+      ...logIdentityFor(req, deps, pipelineCtx),
     });
     return response;
   } catch (err) {
-    return reportError(err, req, pathname, deps);
+    return reportError(err, req, deps, log);
   }
 }
 
@@ -354,9 +394,11 @@ async function handleWorkflowMutation(
   mutation: WorkflowMutation,
   pathname: string,
   deps: HandlerDeps,
+  reqLog: Logger,
 ): Promise<Response> {
   const rawJSON = await req.text();
   const apiKey = req.headers.get("x-n8n-api-key");
+  const log = reqLog.child({ operation: mutation.action, workflowId: mutation.id });
 
   // Only some routes carry a workflow definition. Tag assignment, delete and
   // activate carry something else (or nothing), so parsing their body as a
@@ -370,12 +412,11 @@ async function handleWorkflowMutation(
       workflow = JSON.parse(rawJSON) as Workflow;
     } catch (parseErr) {
       const message = parseErr instanceof Error ? parseErr.message : String(parseErr);
-      deps.logger.log({
+      log.log({
         action: "block",
-        method: req.method,
-        path: pathname,
         status: 400,
         message: `invalid JSON: ${message}`,
+        ...logIdentityFor(req, deps),
       });
       return buildBadJSONResponse(message);
     }
@@ -390,7 +431,7 @@ async function handleWorkflowMutation(
   // upstream, not in the request — so they always go through the pipeline.
   const filterTags = deps.config.filterByTags ?? [];
   if (mutation.bodyIsWorkflow && filterTags.length > 0 && !hasAllTags(workflow?.tags, filterTags)) {
-    return handleSkippedMutation(req, rawJSON, pathname, workflow, filterTags, deps);
+    return handleSkippedMutation(req, rawJSON, workflow, filterTags, deps, log);
   }
 
   // Middleware pipeline (lint + authz + future policies).
@@ -417,18 +458,18 @@ async function handleWorkflowMutation(
   const workflowName = workflow?.name;
 
   if (verdict.block) {
-    deps.logger.log({
+    log.log({
       action: "block",
-      method: req.method,
-      path: pathname,
       status: verdict.denial?.status ?? 422,
       workflowName,
+      projectId: pipelineCtx.projectId,
       violations: verdict.violations.map((v) => ({
         rule: v.rule,
         severity: v.severity,
         message: v.message,
       })),
       message: verdict.blockedBy ? `blocked by middleware ${verdict.blockedBy}` : undefined,
+      ...logIdentityFor(req, deps, pipelineCtx),
     });
     return buildDenialResponse(verdict);
   }
@@ -442,13 +483,12 @@ async function handleWorkflowMutation(
       // Treat lookup failure as "no duplicate" — see DuplicateChecker for rationale.
     }
     if (duplicateMatches.length > 0 && deps.config.enforce === "error") {
-      deps.logger.log({
+      log.log({
         action: "block",
-        method: req.method,
-        path: pathname,
         status: 409,
         workflowName,
         message: `duplicate name: ${duplicateMatches.length} match(es)`,
+        ...logIdentityFor(req, deps, pipelineCtx),
       });
       return buildDuplicateResponse(workflow.name, duplicateMatches);
     }
@@ -485,13 +525,12 @@ async function handleWorkflowMutation(
       );
     }
     const action = verdict.violations.length > 0 || duplicateMatches.length > 0 ? "warn" : "pass";
-    deps.logger.log({
+    log.log({
       action,
-      method: req.method,
-      path: pathname,
       status: response.status,
       upstreamMs: elapsedMs,
       workflowName,
+      projectId: pipelineCtx.projectId,
       violations: verdict.violations.length
         ? verdict.violations.map((v) => ({
             rule: v.rule,
@@ -503,10 +542,11 @@ async function handleWorkflowMutation(
         duplicateMatches.length > 0
           ? `duplicate name: ${duplicateMatches.length} upstream match(es)`
           : undefined,
+      ...logIdentityFor(req, deps, pipelineCtx),
     });
     return response;
   } catch (err) {
-    return reportError(err, req, pathname, deps);
+    return reportError(err, req, deps, log);
   }
 }
 
@@ -565,9 +605,14 @@ async function fetchStoredWorkflow(
   });
 }
 
-function reportError(err: unknown, req: Request, pathname: string, deps: HandlerDeps): Response {
+function reportError(err: unknown, req: Request, deps: HandlerDeps, reqLog: Logger): Response {
   const message = err instanceof Error ? err.message : String(err);
-  deps.logger.log({ action: "error", method: req.method, path: pathname, status: 502, message });
+  reqLog.log({
+    action: "error",
+    status: 502,
+    message,
+    ...logIdentityFor(req, deps),
+  });
   return buildErrorResponse(message);
 }
 
@@ -579,27 +624,46 @@ function reportError(err: unknown, req: Request, pathname: string, deps: Handler
 async function handleSkippedMutation(
   req: Request,
   rawJSON: string,
-  pathname: string,
   workflow: Workflow | null,
   filterTags: string[],
   deps: HandlerDeps,
+  reqLog: Logger,
 ): Promise<Response> {
   try {
     const { response, elapsedMs } = await forwardRequest(req, deps.upstream, rawJSON, {
       timeoutMs: deps.config.upstreamTimeoutMs,
       clientMiddlewares: deps.clientMiddlewares,
     });
-    deps.logger.log({
+    reqLog.log({
       action: "forward",
-      method: req.method,
-      path: pathname,
       status: response.status,
       upstreamMs: elapsedMs,
       workflowName: workflow?.name,
       message: `skipped by tag filter (requires: ${filterTags.join(", ")})`,
+      ...logIdentityFor(req, deps),
     });
     return response;
   } catch (err) {
-    return reportError(err, req, pathname, deps);
+    return reportError(err, req, deps, reqLog);
   }
+}
+
+/**
+ * Resolves caller identity for a log line, honoring the `--log-identity`
+ * opt-in. Returns an empty object when disabled so call sites can spread it
+ * unconditionally.
+ */
+function logIdentityFor(
+  req: Request,
+  deps: HandlerDeps,
+  pipeline?: ServerMiddlewareContext,
+): ResolvedLogIdentity | Record<string, never> {
+  if (!deps.logIdentity) return {};
+  return resolveLogIdentity(req, pipeline) ?? {};
+}
+
+/** Parses an env boolean ("1" / "true" / "yes" are true). */
+function envBool(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return value === "1" || value === "true" || value === "yes";
 }

--- a/tests/proxy/logging.test.ts
+++ b/tests/proxy/logging.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { LOGGER_NAME, type LogEntry, Logger, resolveLogIdentity } from "@/proxy/logging.ts";
+
+function capture(format: "json" | "text" = "json"): { lines: string[]; logger: Logger } {
+  const lines: string[] = [];
+  const logger = new Logger(format, (line) => lines.push(line));
+  return { lines, logger };
+}
+
+function parse(line: string): LogEntry {
+  return JSON.parse(line) as LogEntry;
+}
+
+describe("Logger: json format", () => {
+  test("every line carries the fixed logger marker and a derived level", () => {
+    const { lines, logger } = capture("json");
+    logger.log({ action: "forward", method: "GET", path: "/api/v1/workflows", status: 200 });
+    const entry = parse(lines[0]!);
+    expect(entry.logger).toBe(LOGGER_NAME);
+    expect(entry.event).toBe("request");
+    expect(entry.level).toBe("info");
+  });
+
+  test("level follows action: warn -> warn, block/error -> error", () => {
+    const { lines, logger } = capture("json");
+    logger.log({ action: "warn", status: 200 });
+    logger.log({ action: "block", status: 422 });
+    logger.log({ action: "error", status: 502 });
+    logger.log({ action: "pass", status: 200 });
+    expect(parse(lines[0]!).level).toBe("warn");
+    expect(parse(lines[1]!).level).toBe("error");
+    expect(parse(lines[2]!).level).toBe("error");
+    expect(parse(lines[3]!).level).toBe("info");
+  });
+
+  test("child pins shared fields onto every line and can override event", () => {
+    const { lines, logger } = capture("json");
+    const req = logger.child({
+      requestId: "req-1",
+      surface: "mcp",
+      method: "POST",
+      path: "/mcp-server/http",
+    });
+    req.log({ action: "forward", status: 200 });
+    req.log({ action: "warn", status: 200, event: "policy", message: "withheld 1 tool(s)" });
+
+    const forward = parse(lines[0]!);
+    expect(forward.requestId).toBe("req-1");
+    expect(forward.surface).toBe("mcp");
+    expect(forward.method).toBe("POST");
+    expect(forward.path).toBe("/mcp-server/http");
+    expect(forward.event).toBe("request");
+
+    const policy = parse(lines[1]!);
+    expect(policy.requestId).toBe("req-1");
+    expect(policy.event).toBe("policy");
+  });
+
+  test("ts is ISO-8601 and identity fields round-trip when supplied", () => {
+    const { lines, logger } = capture("json");
+    logger.log({
+      action: "block",
+      status: 401,
+      identity: "user@example.com",
+      identitySource: "oauth-verify",
+      identityVerified: true,
+    });
+    const entry = parse(lines[0]!);
+    expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(entry.identity).toBe("user@example.com");
+    expect(entry.identitySource).toBe("oauth-verify");
+    expect(entry.identityVerified).toBe(true);
+  });
+});
+
+describe("Logger: text format", () => {
+  test("renders a compact key=value line with the new fields", () => {
+    const { lines, logger } = capture("text");
+    logger.child({ requestId: "req-1", surface: "rest-write", operation: "create" }).log({
+      action: "pass",
+      method: "POST",
+      path: "/api/v1/workflows",
+      status: 200,
+      upstreamMs: 3,
+      workflowName: "wf",
+    });
+    expect(lines[0]).toContain("PASS POST /api/v1/workflows 200");
+    expect(lines[0]).toContain("surface=rest-write");
+    expect(lines[0]).toContain("operation=create");
+    expect(lines[0]).toContain("requestId=req-1");
+    expect(lines[0]).toContain("upstreamMs=3");
+    expect(lines[0]).toContain('workflow="wf"');
+  });
+});
+
+describe("resolveLogIdentity", () => {
+  function requestWith(headers: Record<string, string>): Request {
+    return new Request("http://localhost/x", { headers });
+  }
+
+  test("verified bearer identity wins over everything", () => {
+    const req = requestWith({
+      "x-goog-authenticated-user-email": "accounts.google.com:other@example.com",
+    });
+    const got = resolveLogIdentity(req, {
+      identity: "ctx@example.com",
+      auth: { effective: { email: "bearer@example.com", layer: "bearer" } },
+    });
+    expect(got).toEqual({
+      identity: "bearer@example.com",
+      identitySource: "oauth-verify",
+      identityVerified: true,
+    });
+  });
+
+  test("impersonator effective identity is labelled accordingly", () => {
+    const got = resolveLogIdentity(requestWith({}), {
+      auth: { effective: { email: "human@example.com", layer: "impersonator" } },
+    });
+    expect(got).toEqual({
+      identity: "human@example.com",
+      identitySource: "impersonator-verify",
+      identityVerified: true,
+    });
+  });
+
+  test("a bare middleware identity is kept with verified=false", () => {
+    const got = resolveLogIdentity(requestWith({}), { identity: "ctx@example.com" });
+    expect(got).toEqual({
+      identity: "ctx@example.com",
+      identitySource: "middleware",
+      identityVerified: false,
+    });
+  });
+
+  test("the ambient IAP header is used as a fallback", () => {
+    const got = resolveLogIdentity(
+      requestWith({ "x-goog-authenticated-user-email": "accounts.google.com:user@example.com" }),
+    );
+    expect(got).toEqual({
+      identity: "user@example.com",
+      identitySource: "iap-header",
+      identityVerified: false,
+    });
+  });
+
+  test("an IAP header without the accounts.google.com: prefix is kept as-is", () => {
+    const got = resolveLogIdentity(
+      requestWith({ "x-goog-authenticated-user-email": "user@example.com" }),
+    );
+    expect(got?.identity).toBe("user@example.com");
+  });
+
+  test("returns undefined when nothing is resolvable", () => {
+    expect(resolveLogIdentity(requestWith({}))).toBeUndefined();
+    expect(resolveLogIdentity(undefined)).toBeUndefined();
+    expect(resolveLogIdentity(requestWith({}), { auth: {} })).toBeUndefined();
+  });
+});

--- a/tests/proxy/proxy.logging.test.ts
+++ b/tests/proxy/proxy.logging.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerFactory } from "@/middleware/registry.ts";
+import type { ServerMiddleware, ServerMiddlewareFactory } from "@/middleware/types.ts";
+import type { McpPolicy } from "@/proxy/mcp/policy.ts";
+import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
+
+/**
+ * Structured request logging, end to end.
+ *
+ * The proxy emits one terminal line per request plus optional supplementary
+ * `policy` lines (MCP listing narrowing), all sharing a requestId that is also
+ * echoed to the client on `x-n8n-cli-request-id`. Identity fields appear only
+ * under the `logIdentity` opt-in.
+ */
+
+interface Captured {
+  method: string;
+  pathname: string;
+  body: string;
+}
+
+interface LogEntryJson {
+  ts: string;
+  logger: string;
+  level: string;
+  event?: string;
+  action: string;
+  method?: string;
+  path?: string;
+  requestId?: string;
+  surface?: string;
+  operation?: string;
+  workflowId?: string;
+  workflowName?: string;
+  tool?: string;
+  rpc?: string;
+  status?: number;
+  upstreamMs?: number;
+  violations?: Array<{ rule: string; severity: string }>;
+  identity?: string;
+  identitySource?: string;
+  identityVerified?: boolean;
+  message?: string;
+}
+
+const MCP_TOOLS = [
+  { name: "search_workflows", description: "Find workflows" },
+  { name: "execute_workflow", description: "Run a workflow" },
+  { name: "archive_workflow", description: "Archive a workflow" },
+];
+
+function startMockUpstream() {
+  const captured: Captured[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = await req.text();
+      captured.push({ method: req.method, pathname: url.pathname, body });
+
+      if (req.method === "POST" && url.pathname === "/mcp-server/http") {
+        const request = JSON.parse(body) as { id: number; method: string };
+        if (request.method === "tools/list") {
+          return new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { tools: MCP_TOOLS } }),
+            {
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: { content: [{ type: "text", text: "ok" }] },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { server, port: server.port as number, captured };
+}
+
+const CLEAN_WORKFLOW = JSON.stringify({
+  name: "Clean WF",
+  active: false,
+  nodes: [],
+  connections: {},
+});
+const VIOLATING_WORKFLOW = JSON.stringify({ active: true, nodes: [], connections: {} });
+
+function mcpPolicy(overrides: Partial<McpPolicy> = {}): McpPolicy {
+  return { allowTools: [], denyTools: [], workflowTags: [], ...overrides };
+}
+
+/**
+ * Stands in for oauth-verify / impersonator-verify: writes a verified identity
+ * onto the pipeline context so the logging path can pick it up.
+ */
+function identityStubFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "identity-stub",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "identity-stub",
+      evaluate(ctx) {
+        const email = ctx.request?.headers.get("x-verified-email");
+        if (email) {
+          ctx.identity = email;
+          ctx.auth = { effective: { email, layer: "impersonator" } };
+        }
+        return { block: false, violations: [] };
+      },
+    }),
+  };
+}
+
+let upstream: ReturnType<typeof startMockUpstream>;
+let proxy: ProxyHandle;
+let lines: string[];
+
+function start(extra: Partial<Parameters<typeof startProxy>[0]> = {}): ProxyHandle {
+  proxy = startProxy({
+    listen: "127.0.0.1:0",
+    upstream: `http://127.0.0.1:${upstream.port}`,
+    enforce: "error",
+    disableRules: [],
+    logFormat: "json",
+    allowDuplicates: true,
+    logWriter: (line) => lines.push(line),
+    ...extra,
+  });
+  return proxy;
+}
+
+function url(p: string): string {
+  return `http://127.0.0.1:${proxy.port}${p}`;
+}
+
+function logs(): LogEntryJson[] {
+  return lines.map((l) => JSON.parse(l) as LogEntryJson);
+}
+
+function headerId(res: Response): string | undefined {
+  return res.headers.get("x-n8n-cli-request-id") ?? undefined;
+}
+
+beforeEach(() => {
+  upstream = startMockUpstream();
+  lines = [];
+});
+
+afterEach(async () => {
+  await proxy?.stop();
+  upstream.server.stop(true);
+});
+
+describe("proxy structured logging: REST mutation", () => {
+  test("a clean create logs pass with operation/surface and a matching requestId header", async () => {
+    start();
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-n8n-api-key": "k" },
+      body: CLEAN_WORKFLOW,
+    });
+    expect(res.status).toBe(200);
+
+    const requestId = headerId(res);
+    expect(requestId).toBeTruthy();
+    const entry = logs().find((l) => l.action === "pass");
+    expect(entry?.logger).toBe("n8n-cli-proxy");
+    expect(entry?.level).toBe("info");
+    expect(entry?.event).toBe("request");
+    expect(entry?.surface).toBe("rest-write");
+    expect(entry?.operation).toBe("create");
+    expect(entry?.requestId).toBe(requestId);
+    expect(entry?.path).toBe("/api/v1/workflows");
+  });
+
+  test("a lint block logs error with violations and still carries the requestId header", async () => {
+    start();
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING_WORKFLOW,
+    });
+    expect(res.status).toBe(422);
+
+    const entry = logs().find((l) => l.action === "block");
+    expect(entry?.level).toBe("error");
+    expect(entry?.surface).toBe("rest-write");
+    expect(entry?.operation).toBe("create");
+    expect(entry?.violations?.length).toBeGreaterThan(0);
+    expect(headerId(res)).toBe(entry?.requestId);
+  });
+
+  test("warn-mode forward logs level=warn with violations", async () => {
+    start({ enforce: "warn" });
+    const res = await fetch(url("/api/v1/workflows"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: VIOLATING_WORKFLOW,
+    });
+    expect(res.status).toBe(200);
+
+    const entry = logs().find((l) => l.action === "warn");
+    expect(entry?.level).toBe("warn");
+    expect(entry?.operation).toBe("create");
+    expect(entry?.violations?.length).toBeGreaterThan(0);
+  });
+});
+
+describe("proxy structured logging: transparent paths", () => {
+  test("a list GET logs surface=transparent without an operation", async () => {
+    start();
+    const res = await fetch(url("/api/v1/workflows"), { headers: { "x-n8n-api-key": "k" } });
+    expect(res.status).toBe(200);
+
+    const entry = logs().find((l) => l.action === "forward");
+    expect(entry?.surface).toBe("transparent");
+    expect(entry?.operation).toBeUndefined();
+    expect(entry?.requestId).toBe(headerId(res));
+  });
+
+  test("a single-workflow read logs surface=rest-read with workflowId", async () => {
+    start();
+    await fetch(url("/api/v1/workflows/wf-1"), { headers: { "x-n8n-api-key": "k" } });
+
+    const entry = logs().find((l) => l.action === "forward");
+    expect(entry?.surface).toBe("rest-read");
+    expect(entry?.operation).toBe("read");
+    expect(entry?.workflowId).toBe("wf-1");
+  });
+
+  test("probes are not logged", async () => {
+    start();
+    await fetch(url("/healthz"));
+    await fetch(url("/livez"));
+    await fetch(url("/readyz"));
+    expect(logs()).toHaveLength(0);
+  });
+});
+
+describe("proxy structured logging: identity (opt-in)", () => {
+  test("identity is resolved from a verified middleware and excluded by default", async () => {
+    registerFactory(identityStubFactory());
+    // Default: logIdentity off -> no identity fields even though verified.
+    start({ middlewares: ["identity-stub"] });
+    await fetch(url("/api/v1/workflows/wf-1"), {
+      headers: { "x-n8n-api-key": "k", "x-verified-email": "user@example.com" },
+    });
+    expect(logs()[0]?.identity).toBeUndefined();
+    await proxy.stop();
+
+    // Opt-in: verified impersonator identity is attached.
+    lines = [];
+    start({
+      logIdentity: true,
+      middlewares: ["identity-stub"],
+    });
+    await fetch(url("/api/v1/workflows/wf-1"), {
+      headers: { "x-n8n-api-key": "k", "x-verified-email": "user@example.com" },
+    });
+    const entry = logs()[0];
+    expect(entry?.identity).toBe("user@example.com");
+    expect(entry?.identitySource).toBe("impersonator-verify");
+    expect(entry?.identityVerified).toBe(true);
+  });
+
+  test("the ambient IAP header is used when logIdentity is on and no verified identity exists", async () => {
+    start({ logIdentity: true });
+    await fetch(url("/api/v1/workflows"), {
+      headers: {
+        "x-n8n-api-key": "k",
+        "x-goog-authenticated-user-email": "accounts.google.com:user@example.com",
+      },
+    });
+    const entry = logs()[0];
+    expect(entry?.identity).toBe("user@example.com");
+    expect(entry?.identitySource).toBe("iap-header");
+    expect(entry?.identityVerified).toBe(false);
+  });
+
+  test("identity is never logged when the opt-in is off, even from the IAP header", async () => {
+    start();
+    await fetch(url("/api/v1/workflows"), {
+      headers: {
+        "x-n8n-api-key": "k",
+        "x-goog-authenticated-user-email": "accounts.google.com:user@example.com",
+      },
+    });
+    expect(logs()[0]?.identity).toBeUndefined();
+  });
+});
+
+describe("proxy structured logging: MCP gate", () => {
+  async function call(params: unknown): Promise<Response> {
+    return fetch(url("/mcp-server/http"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params }),
+    });
+  }
+
+  test("a refused tool call logs tool/rpc/surface and a matching requestId", async () => {
+    start({
+      mcp: {
+        enforce: "error",
+        policy: mcpPolicy({ denyTools: ["archive_workflow"] }),
+        cacheTtlMs: 60_000,
+      },
+    });
+    const res = await call({ name: "archive_workflow", arguments: {} });
+    expect(res.status).toBe(200);
+
+    const entry = logs().find((l) => l.action === "block");
+    expect(entry?.surface).toBe("mcp");
+    expect(entry?.tool).toBe("archive_workflow");
+    expect(entry?.rpc).toBe("tools/call");
+    expect(entry?.level).toBe("error");
+    expect(entry?.requestId).toBe(headerId(res));
+  });
+
+  test("a forwarded tools/list that is narrowed emits a request line plus a policy line sharing requestId", async () => {
+    start({
+      mcp: {
+        enforce: "error",
+        policy: mcpPolicy({ denyTools: ["archive_workflow"] }),
+        cacheTtlMs: 60_000,
+      },
+    });
+    const res = await fetch(url("/mcp-server/http"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(200);
+    expect(upstream.captured.some((c) => c.body.includes("tools/list"))).toBe(true);
+
+    const requestId = headerId(res);
+    const request = logs().find((l) => l.event === "request" && l.action === "forward");
+    const policy = logs().find((l) => l.event === "policy");
+    expect(request?.surface).toBe("mcp");
+    expect(request?.requestId).toBe(requestId);
+    expect(policy?.requestId).toBe(requestId);
+    expect(policy?.message).toContain("withheld 1 tool(s)");
+  });
+});

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -185,6 +185,7 @@ function policy(overrides: Partial<McpPolicy> = {}): McpPolicy {
 
 let upstream: ReturnType<typeof startMockUpstream>;
 let proxy: ProxyHandle;
+let proxyLogLines: string[];
 
 function start(
   mcpPolicy: McpPolicy,
@@ -192,8 +193,10 @@ function start(
   extra: {
     middlewares?: string[];
     middlewareCliOptions?: Record<string, unknown>;
+    logIdentity?: boolean;
   } = {},
 ): void {
+  proxyLogLines = [];
   proxy = startProxy({
     listen: "127.0.0.1:0",
     upstream: `http://127.0.0.1:${upstream.port}`,
@@ -201,6 +204,7 @@ function start(
     disableRules: [],
     logFormat: "json",
     allowDuplicates: true,
+    logWriter: (line) => proxyLogLines.push(line),
     mcp: { enforce, policy: mcpPolicy, cacheTtlMs: 60_000 },
     ...extra,
   });
@@ -957,5 +961,71 @@ describe("MCP gate: body-less middleware chain", () => {
     );
     expect((reply.result as { isError?: boolean }).isError).toBeUndefined();
     expect(upstream.captured.some((c) => c.pathname === "/mcp-server/http")).toBe(true);
+  });
+});
+
+/**
+ * A middleware that writes a verified identity (when the request carries the
+ * header) and then blocks, so the middleware-denied MCP path can be exercised
+ * with identity present.
+ */
+function blockingIdentityFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "blocking-identity",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "blocking-identity",
+      evaluate(ctx) {
+        const email = ctx.request?.headers.get("x-impersonator-email");
+        if (email) {
+          ctx.identity = email;
+          ctx.auth = { effective: { email, layer: "impersonator" } };
+        }
+        return {
+          block: true,
+          violations: [],
+          denial: { status: 403, error: "blocked", message: "blocked for test" },
+        };
+      },
+    }),
+  };
+}
+
+describe("MCP gate: identity logging opt-in", () => {
+  function blockLine(): { identity?: string; identitySource?: string; identityVerified?: boolean } {
+    const entries = proxyLogLines.map((l) => JSON.parse(l) as Record<string, unknown>);
+    const line = entries.find((e) => e.action === "block");
+    return line as { identity?: string; identitySource?: string; identityVerified?: boolean };
+  }
+
+  test("a middleware-denied tool call never logs identity unless --log-identity is on", async () => {
+    registerFactory(blockingIdentityFactory());
+    start(policy({ allowTools: ["get_workflow_details"], workflowTags: ["mcp"] }), "error", {
+      middlewares: ["blocking-identity"],
+    });
+    await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-open" } },
+      { "x-impersonator-email": "user@example.com" },
+    );
+    expect(blockLine().identity).toBeUndefined();
+  });
+
+  test("with --log-identity the verified identity is attached to the denial line", async () => {
+    registerFactory(blockingIdentityFactory());
+    start(policy({ allowTools: ["get_workflow_details"], workflowTags: ["mcp"] }), "error", {
+      middlewares: ["blocking-identity"],
+      logIdentity: true,
+    });
+    await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-open" } },
+      { "x-impersonator-email": "user@example.com" },
+    );
+    const line = blockLine();
+    expect(line.identity).toBe("user@example.com");
+    expect(line.identitySource).toBe("impersonator-verify");
+    expect(line.identityVerified).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the proxys ad-hoc per-call logs with a single structured request log, so the whole stream can be filtered as a batch for both audit and operations.

- Every line carries a fixed `logger: "n8n-cli-proxy"` marker plus a `level` derived from the outcome, so Cloud Logging (`jsonPayload.logger == "n8n-cli-proxy"`) or jq can select the entire stream in one filter.
- Added `requestId` (a UUID pinned on every line of a request and echoed to the client on the `x-n8n-cli-request-id` response header), plus `surface` (`rest-write` / `rest-read` / `mcp` / `transparent`), `operation`, `workflowId`, `projectId`, and `violations`.
- MCP logs are now structured with `tool` / `rpc` / `workflowId` instead of a `mcp: ...` message string; listing-narrowing details are emitted as `event: "policy"` under the same `requestId`.
- Caller identity is captured only under the new `--log-identity` opt-in (env `N8N_PROXY_LOG_IDENTITY`). When enabled, the best identity the request offers is logged with its source and verification flag: `oauth-verify` / `impersonator-verify` (verified), `middleware`, or the ambient `X-Goog-Authenticated-User-Email` IAP header (`iap-header`). Emails are PII, so they are off by default — including on MCP denials.
- Text format is preserved and extended with the new fields; the writer is injectable for tests.

## Motivation

The proxy currently drops a lot of information it already has: the route action, the workflow/project ids, and — when an authenticating middleware or an IAP front runs — the caller identity. Those are exactly what an audit log needs, and without a common marker they could not be extracted as one set.

## Test plan

- [x] `make quality-gate` (generate-schemas, typecheck, lint, check-third-party-licenses, `bun test`)
- [x] `make build`
- [x] Logger unit tests: fixed marker / level derivation / `child()` pinning / text format
- [x] `resolveLogIdentity` unit tests: verified > middleware > IAP header priority, prefix stripping
- [x] Integration: mutation pass/block/warn fields, transparent + read surfaces, `x-n8n-cli-request-id` header matches the log
- [x] Integration: identity opt-in/opt-out on REST paths
- [x] MCP: block/forward lines carry `tool`/`rpc`, `policy` events share the requestId, and a middleware-denied call never logs identity unless `--log-identity` is on