### PR TITLE
feat(config): all-in-one .n8nctlrc.json configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,18 +1140,18 @@ n8n-cli proxy [options]
 
 | Option | Description |
 |--------|-------------|
-| `--listen <addr>` | Address to bind, e.g. `:8080` or `127.0.0.1:8080` (default: `:8080`) |
-| `--upstream <url>` | Upstream n8n base URL (env: `N8N_API_URL`) |
+| `--listen <addr>` | Address to bind, e.g. `:8080` or `127.0.0.1:8080` (default: `:8080`; config: `proxy.listen`) |
+| `--upstream <url>` | Upstream n8n base URL (env: `N8N_API_URL`; config: `proxy.upstream` or `api.url`) |
 | `-c, --lint-config <path>` | Path to `.n8nlintrc.json` (auto-discovered if omitted) |
-| `--enforce <level>` | `off`, `warn`, or `error` (default: `error`) |
-| `--disable-rule <rules...>` | Disable specific rules (can be repeated) |
-| `--log-format <fmt>` | Log format: `text` or `json` (default: `text`) |
-| `--log-identity` | Include caller identity (email) in log lines. Off by default because emails are PII; see [Logging](#proxy-logging). env: `N8N_PROXY_LOG_IDENTITY` |
-| `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default) |
-| `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000) |
-| `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables) |
-| `--server-middleware <list>` | Comma-separated server-middleware chain (default: `lint`; env: `N8N_SERVER_MIDDLEWARES`). Example: `lint,authz` |
-| `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`). Non-matching saves are forwarded transparently |
+| `--enforce <level>` | `off`, `warn`, or `error` (default: `error`; config: `proxy.enforce`) |
+| `--disable-rule <rules...>` | Disable specific rules (can be repeated; config: `proxy.disableRules`) |
+| `--log-format <fmt>` | Log format: `text` or `json` (default: `text`; config: `proxy.logFormat`) |
+| `--log-identity` | Include caller identity (email) in log lines. Off by default because emails are PII; see [Logging](#proxy-logging). env: `N8N_PROXY_LOG_IDENTITY`; config: `proxy.logIdentity` |
+| `--allow-duplicates` | Skip the upstream duplicate-name check (the check is on by default; config: `proxy.allowDuplicates`) |
+| `--duplicate-ttl <ms>` | TTL for the cached upstream workflow-name index (default: 60000; config: `proxy.duplicateTtlMs`) |
+| `--upstream-timeout <ms>` | Per-request upstream timeout in milliseconds (default: 30000, 0 disables; config: `proxy.upstreamTimeoutMs`) |
+| `--server-middleware <list>` | Comma-separated server-middleware chain (default: `lint`; env: `N8N_SERVER_MIDDLEWARES`; config: `proxy.serverMiddlewares` or `middlewares.server`). Example: `lint,authz` |
+| `--tags <tags>` | Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: `PROXY_FILTER_BY_TAGS`; config: `proxy.tags`). Non-matching saves are forwarded transparently |
 | `--stale-write-enforce <level>` | Stale-write guard: `off` (default), `warn`, or `error`. Requires `stale-write` in the middleware chain |
 | `--stale-write-on-missing-base <mode>` | Callers that declare no base revision: `allow` (default) or `deny` |
 | `--stale-write-on-error <mode>` | When the stored workflow cannot be read: `deny` (default) or `allow` |
@@ -1427,6 +1427,86 @@ n8n-cli version
 | `--api-key <key>` | n8n API key (env: `N8N_API_KEY`) |
 | `--timeout <duration>` | Request timeout, e.g. `30s`, `5m` (env: `N8N_API_TIMEOUT`) |
 | `-o, --output <format>` | Output format: `json`, `table` (default: `json`) |
+| `--config <path>` | Path to the all-in-one config file (env: `N8NCTL_CONFIG`; replaces project-level discovery — see [Configuration file](#configuration-file-n8nctlrcjson)) |
+
+## Configuration file (`.n8nctlrc.json`)
+
+Beyond environment variables, n8n-cli reads one all-in-one configuration file
+that covers API connection, lint, middleware, and proxy settings. The filename
+is chosen to survive the planned `n8nctl` rename.
+
+**Placements** (both are read and merged):
+
+| Placement | Path | Purpose |
+|-----------|------|---------|
+| User-level | `$XDG_CONFIG_HOME/n8nctl/config.json` (default `~/.config/n8nctl/config.json`) | Personal settings — the right home for API keys |
+| Project-level | `.n8nctlrc.json` discovered by walking up from the working directory | Team settings committed to the repository |
+
+**Precedence** (lowest → highest):
+
+```
+built-in defaults < user file < project file < environment variables < CLI flags
+```
+
+Environment variables keep winning over files, so an existing direnv- or
+CI-driven setup behaves exactly as before. An explicit file (`--config` /
+`N8NCTL_CONFIG`) replaces the project layer and wins over the user file.
+
+String values support `${ENV_VAR}` interpolation — secrets stay in the
+environment while everything else is versioned. Referencing an undefined
+variable is an error, not a silent empty string.
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/ubie-oss/n8n-cli/main/schemas/n8nctlrc.schema.json",
+  "api": {
+    "url": "https://n8n.example.com",
+    "apiKey": "${N8N_API_KEY}",
+    "timeout": "30s"
+  },
+  "lint": {
+    "rules": { "orphaned-node": "warning" }
+  },
+  "middlewares": {
+    "client": ["iap-auth", "api-key-inject"],
+    "options": {
+      "iap-auth": {
+        "audience": "${N8N_API_URL}",
+        "tokenSourceKind": "adc-impersonate",
+        "impersonateServiceAccount": "gate-caller@example.iam.gserviceaccount.com"
+      }
+    }
+  },
+  "proxy": {
+    "enforce": "error",
+    "logFormat": "json"
+  }
+}
+```
+
+Add the `$schema` line for editor completion and validation.
+
+Notes:
+
+- `middlewares.options.<name>` keys mirror the camelCase CLI flag names of each
+  middleware (documented under [proxy](#proxy)). Secret-carrying options keep
+  their restrictions: `api-key-inject` accepts only an env-var reference, never
+  a raw key.
+- A literal `api.apiKey` in a **project-level** file triggers a warning —
+  secrets committed to git leak through history. Use `${ENV_VAR}` or move the
+  key to the user-level file.
+- **Migration:** the legacy `.n8nlintrc.json` keeps working unchanged. When a
+  directory contains both, `.n8nctlrc.json` wins; the legacy file's whole
+  content is treated as its `lint` section. To migrate, move the content under
+  a `lint` key.
+
+Inspect the merged result without touching the API:
+
+```bash
+n8n-cli config check   # validate files: JSON syntax, shape, ${VAR} resolution — CI-safe
+n8n-cli config show    # effective merged config with sources; secrets masked
+n8n-cli config show --reveal-secrets
+```
 
 ## TypeScript workflow definitions
 
@@ -1602,8 +1682,13 @@ check.
 
 ### Environment Variables
 
+See [Configuration file (`.n8nctlrc.json`)](#configuration-file-n8nctlrcjson) —
+an all-in-one alternative to the environment variables below, with precedence
+`defaults < user file < project file < environment variables < CLI flags`.
+
 | Variable | Description |
 |----------|-------------|
+| `N8NCTL_CONFIG` | Path to the all-in-one config file (same as `--config`) |
 | `N8N_API_URL` | n8n instance API URL (required) |
 | `N8N_API_KEY` | n8n API key (required, unless an egress chain supplies credentials — see below) |
 | `N8N_API_TIMEOUT` | Request timeout in milliseconds |

--- a/README.md
+++ b/README.md
@@ -1337,12 +1337,12 @@ Everything else on the path — `initialize`, notifications, the server-to-clien
 
 | Flag | Env | Description |
 |------|-----|-------------|
-| `--mcp-enforce <level>` | `N8N_MCP_ENFORCE` | `off`, `warn`, `error`. **Required to enable the gate** — without it `/mcp-server/` is forwarded unfiltered, so upgrading changes nothing |
-| `--mcp-allow-tools <list>` | `N8N_MCP_ALLOW_TOOLS` | Comma-separated `*`-globs; only these **verbs** are visible and callable. Empty means all |
-| `--mcp-deny-tools <list>` | `N8N_MCP_DENY_TOOLS` | Globs to withhold, applied after the allowlist |
-| `--mcp-workflow-tags <tags>` | `N8N_MCP_WORKFLOW_TAGS` | A reachable workflow must carry **all** of these tags. Also narrows `search_workflows` |
-| `--mcp-entry-path-pattern <glob>` | `N8N_MCP_ENTRY_PATH_PATTERN` | A reachable workflow's **entry trigger** must declare a path matching this glob (see below) |
-| `--mcp-cache-ttl-ms <ms>` | `N8N_MCP_CACHE_TTL_MS` | Workflow-facts cache lifetime (default `60000`) |
+| `--mcp-enforce <level>` | `N8N_MCP_ENFORCE` | `off`, `warn`, `error`. **Required to enable the gate** — without it `/mcp-server/` is forwarded unfiltered, so upgrading changes nothing. config: `proxy.mcp.enforce` |
+| `--mcp-allow-tools <list>` | `N8N_MCP_ALLOW_TOOLS` | Comma-separated `*`-globs; only these **verbs** are visible and callable. Empty means all. config: `proxy.mcp.allowTools` |
+| `--mcp-deny-tools <list>` | `N8N_MCP_DENY_TOOLS` | Globs to withhold, applied after the allowlist. config: `proxy.mcp.denyTools` |
+| `--mcp-workflow-tags <tags>` | `N8N_MCP_WORKFLOW_TAGS` | A reachable workflow must carry **all** of these tags. Also narrows `search_workflows`. config: `proxy.mcp.workflowTags` |
+| `--mcp-entry-path-pattern <glob>` | `N8N_MCP_ENTRY_PATH_PATTERN` | A reachable workflow's **entry trigger** must declare a path matching this glob (see below). config: `proxy.mcp.entryPathPattern` |
+| `--mcp-cache-ttl-ms <ms>` | `N8N_MCP_CACHE_TTL_MS` | Workflow-facts cache lifetime (default `60000`). config: `proxy.mcp.cacheTtlMs` |
 
 ### The entry trigger
 
@@ -1479,7 +1479,12 @@ variable is an error, not a silent empty string.
   },
   "proxy": {
     "enforce": "error",
-    "logFormat": "json"
+    "logFormat": "json",
+    "mcp": {
+      "enforce": "error",
+      "allowTools": ["search_workflows", "get_workflow_details"],
+      "workflowTags": ["mcp"]
+    }
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/schemas/n8nctlrc.schema.json
+++ b/schemas/n8nctlrc.schema.json
@@ -148,6 +148,42 @@
           "type": "number",
           "minimum": 0,
           "description": "Per-request upstream timeout in ms; 0 disables (flag: --upstream-timeout)."
+        },
+        "mcp": {
+          "type": "object",
+          "description": "MCP gate policy applied to n8n's instance-level MCP endpoint (flag family: --mcp-*). The gate stays off unless enforce is set — a policy without enforce makes the proxy refuse to start, mirroring the orphan-policy check on the flags.",
+          "additionalProperties": false,
+          "properties": {
+            "enforce": {
+              "type": "string",
+              "enum": ["off", "warn", "error"],
+              "description": "Gate enforcement level (flag: --mcp-enforce)."
+            },
+            "allowTools": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Glob patterns for the only tools clients may see (flag: --mcp-allow-tools)."
+            },
+            "denyTools": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Glob patterns for tools to withhold, applied after allowTools (flag: --mcp-deny-tools)."
+            },
+            "workflowTags": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Workflow tags required for workflow-scoped tool calls, AND condition (flag: --mcp-workflow-tags)."
+            },
+            "entryPathPattern": {
+              "type": "string",
+              "description": "Entry-trigger path glob a workflow must match (flag: --mcp-entry-path-pattern)."
+            },
+            "cacheTtlMs": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Cached workflow allowlist lifetime in ms (flag: --mcp-cache-ttl-ms)."
+            }
+          }
         }
       }
     }

--- a/schemas/n8nctlrc.schema.json
+++ b/schemas/n8nctlrc.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/ubie-oss/n8n-cli/main/schemas/n8nctlrc.schema.json",
+  "title": "n8n-cli all-in-one configuration (.n8nctlrc.json)",
+  "description": "All-in-one configuration for n8n-cli. Place as .n8nctlrc.json in the project directory (discovered by walking up) or as config.json under $XDG_CONFIG_HOME/n8nctl/ (default ~/.config/n8nctl/config.json). Project settings win over user settings; environment variables and CLI flags win over both. String values support ${ENV_VAR} interpolation; referencing an undefined variable is an error.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Pointer to this schema for editor support."
+    },
+    "api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "n8n API URL (env: N8N_API_URL, flag: --api-url)."
+        },
+        "apiKey": {
+          "type": "string",
+          "description": "n8n API key. Prefer \"${ENV_VAR}\" interpolation over a literal value; a literal key in a project-level file triggers a warning."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Request timeout, e.g. \"30s\", \"5m\" or plain milliseconds (env: N8N_API_TIMEOUT, flag: --timeout)."
+        },
+        "output": {
+          "type": "string",
+          "enum": ["json", "table"],
+          "description": "Default output format (flag: --output)."
+        }
+      }
+    },
+    "lint": {
+      "type": "object",
+      "description": "Lint configuration. Same shape as the legacy .n8nlintrc.json, nested under this section.",
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "object",
+          "description": "Rule configs keyed by rule name. Values: true/false, \"error\"/\"warning\"/\"off\", or [\"error\"|\"warning\", { options }].",
+          "additionalProperties": true
+        },
+        "projects": {
+          "type": "object",
+          "description": "Per-project rule overrides keyed by n8n project ID.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "rules": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "middlewares": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "client": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Client middleware chain, e.g. [\"iap-auth\", \"api-key-inject\"] (env: N8N_CLIENT_MIDDLEWARES, proxy flag: --client-middleware)."
+        },
+        "server": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Server middleware chain, e.g. [\"lint\", \"authz\"] (env: N8N_SERVER_MIDDLEWARES, proxy flag: --server-middleware)."
+        },
+        "options": {
+          "type": "object",
+          "description": "Per-middleware options keyed by middleware name. Keys mirror the camelCase CLI flag names of each middleware. Secret values must come from env-var references.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "type": "object",
+      "description": "Defaults for the `proxy` command. CLI flags and environment variables override these.",
+      "additionalProperties": false,
+      "properties": {
+        "listen": {
+          "type": "string",
+          "description": "Address to bind, e.g. \":8080\" or \"127.0.0.1:8080\" (flag: --listen)."
+        },
+        "upstream": {
+          "type": "string",
+          "description": "Upstream n8n base URL. Falls back to api.url when omitted (env: N8N_API_URL, flag: --upstream)."
+        },
+        "enforce": {
+          "type": "string",
+          "enum": ["off", "warn", "error"],
+          "description": "Enforcement level for workflow saves (flag: --enforce)."
+        },
+        "logFormat": {
+          "type": "string",
+          "enum": ["text", "json"],
+          "description": "Log format (flag: --log-format)."
+        },
+        "logIdentity": {
+          "type": "boolean",
+          "description": "Include caller identity (email) in log lines (flag: --log-identity)."
+        },
+        "allowDuplicates": {
+          "type": "boolean",
+          "description": "Skip the upstream duplicate-name check on workflow creation (flag: --allow-duplicates)."
+        },
+        "disableRules": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Rule names to disable (flag: --disable-rule)."
+        },
+        "serverMiddlewares": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Proxy-scoped server middleware chain. Takes precedence over middlewares.server for the proxy command."
+        },
+        "clientMiddlewares": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Proxy-scoped client middleware chain. Takes precedence over middlewares.client for the proxy command."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tag-based scope filter (AND condition) (flag: --tags)."
+        },
+        "routes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Route table lines, same format as --routes."
+        },
+        "duplicateTtlMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "TTL (ms) for the cached upstream workflow-name index (flag: --duplicate-ttl)."
+        },
+        "upstreamTimeoutMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Per-request upstream timeout in ms; 0 disables (flag: --upstream-timeout)."
+        }
+      }
+    }
+  }
+}

--- a/src/apply/executor.ts
+++ b/src/apply/executor.ts
@@ -3,6 +3,7 @@ import { isAlreadyOwnedError, isNotFoundError } from "../api/errors.ts";
 import type { TagService } from "../api/tag-service.ts";
 import type { Workflow, WorkflowInput } from "../api/types.ts";
 import type { WorkflowService } from "../api/workflow-service.ts";
+import { loadRc } from "../config/rc.ts";
 import { compareWorkflows } from "../diff/engine.ts";
 import { ContentRetriever, ErrFileNotExist } from "../git/content.ts";
 import type { Violation } from "../lint/rules/violation.ts";
@@ -75,10 +76,14 @@ export class Executor {
     // `src/cli/commands/apply.ts` is responsible for catching the typed error
     // and printing a friendly message.
     registerBuiltins();
+    // The all-in-one config file supplies the chain and per-middleware
+    // options below env/CLI precedence (flags and env vars still win).
+    const rc = loadRc();
     const enabled = resolveEnabledList({
       cliValue: opts.middlewares.join(","),
       env: process.env,
       envVar: "N8N_SERVER_MIDDLEWARES",
+      fileValue: rc.config.middlewares?.server,
       fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
     });
     const filtered = opts.noLint ? enabled.filter((n) => n !== "lint") : enabled;
@@ -95,6 +100,7 @@ export class Executor {
       enabled: filtered,
       env: process.env,
       cliOpts: legacyCliOpts,
+      fileOptions: rc.config.middlewares?.options,
     });
 
     // Eagerly run prepare() on every middleware whose prepare() is

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,86 @@
+import type { Command } from "commander";
+import { resolveConfig } from "@/cli/root.ts";
+import { loadRc } from "@/config/rc.ts";
+
+/**
+ * `config` — inspect the all-in-one configuration without touching the n8n
+ * API. Complements `--config` / N8NCTL_CONFIG with the two questions every
+ * operator eventually asks: "what does the CLI actually see?" (show) and
+ * "is my config file well-formed?" (check).
+ */
+export function registerConfigCommand(program: Command): void {
+  const config = program
+    .command("config")
+    .description(
+      "Inspect the all-in-one configuration (.n8nctlrc.json, ~/.config/n8nctl/config.json)",
+    );
+
+  const configFlag = () => (program.opts() as { config?: string }).config;
+
+  config
+    .command("show")
+    .description("Print the effective merged configuration (secrets masked)")
+    .option("--reveal-secrets", "Print api.apiKey unmasked (default: masked as ***)")
+    .action((opts: { revealSecrets?: boolean }) => {
+      let rc: ReturnType<typeof loadRc>;
+      let effective: ReturnType<typeof resolveConfig>;
+      try {
+        rc = loadRc({ configPath: configFlag() });
+        effective = resolveConfig(program);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+      const mask = (key: string) => (key ? (opts.revealSecrets ? key : "***") : "");
+      console.log(
+        JSON.stringify(
+          {
+            sources: rc.sources,
+            effective: {
+              apiURL: effective.apiURL,
+              apiKey: mask(effective.apiKey),
+              timeoutMs: effective.timeoutMs,
+              output: effective.output,
+              middlewares: rc.config.middlewares ?? {},
+              proxy: rc.config.proxy ?? {},
+            },
+            file: {
+              ...rc.config,
+              api: rc.config.api
+                ? { ...rc.config.api, apiKey: mask(rc.config.api.apiKey ?? "") }
+                : undefined,
+            },
+          },
+          null,
+          2,
+        ),
+      );
+    });
+
+  config
+    .command("check")
+    .description(
+      "Validate configuration files: JSON syntax, section shape, ${ENV_VAR} resolution. " +
+        "Exit code 0 when usable, 1 when not — safe for CI.",
+    )
+    .action(() => {
+      try {
+        const rc = loadRc({ configPath: configFlag() });
+        const loaded: string[] = [];
+        if (rc.sources.explicit) loaded.push(`explicit: ${rc.sources.explicit}`);
+        if (rc.sources.user) loaded.push(`user: ${rc.sources.user}`);
+        if (rc.sources.project) loaded.push(`project: ${rc.sources.project}`);
+        if (loaded.length === 0) {
+          console.log("No configuration file found (defaults in effect). OK");
+          return;
+        }
+        for (const line of loaded) console.log(`OK ${line}`);
+        if (rc.config.api?.apiKey) {
+          console.log("OK api.apiKey resolves (value not printed)");
+        }
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1,5 +1,7 @@
 import type { Command } from "commander";
+import { loadMergedRc } from "@/cli/root.ts";
 import { parseTagFilter } from "@/common/tags.ts";
+import type { LoadedRc } from "@/config/rc.ts";
 import { parseMiddlewareList } from "@/middleware/registry.ts";
 import { parseEnforceLevel } from "@/proxy/config.ts";
 import { type McpCliOptions, parseMcpSettings } from "@/proxy/mcp/config.ts";
@@ -8,12 +10,12 @@ import { parseRoutes } from "@/proxy/rest/router.ts";
 import { startProxy } from "@/proxy/server.ts";
 
 interface ProxyOptions extends McpCliOptions {
-  listen: string;
+  listen?: string;
   upstream?: string;
   lintConfig?: string;
-  enforce: string;
+  enforce?: string;
   disableRule?: string[];
-  logFormat: string;
+  logFormat?: string;
   logIdentity?: boolean;
   allowDuplicates?: boolean;
   duplicateTtl?: string;
@@ -107,12 +109,21 @@ export function registerProxyCommand(program: Command): void {
     .description(
       "Run a transparent HTTP proxy that intercepts n8n public-API workflow saves and runs middleware (lint, authz, ...)",
     )
-    .option("--listen <addr>", "Address to bind (host:port or :port)", ":8080")
-    .option("--upstream <url>", "Upstream n8n base URL (env: N8N_API_URL)")
+    .option("--listen <addr>", "Address to bind (host:port or :port; config: proxy.listen)")
+    .option(
+      "--upstream <url>",
+      "Upstream n8n base URL (env: N8N_API_URL; config: proxy.upstream or api.url)",
+    )
     .option("-c, --lint-config <path>", "Path to .n8nlintrc.json (auto-discovered if omitted)")
-    .option("--enforce <level>", "Enforcement level for workflow saves: off, warn, error", "error")
-    .option("--disable-rule <rules...>", "Disable specific rules (can be repeated)")
-    .option("--log-format <fmt>", "Log format: text, json", "text")
+    .option(
+      "--enforce <level>",
+      "Enforcement level for workflow saves: off, warn, error (config: proxy.enforce)",
+    )
+    .option(
+      "--disable-rule <rules...>",
+      "Disable specific rules (can be repeated; config: proxy.disableRules)",
+    )
+    .option("--log-format <fmt>", "Log format: text, json (config: proxy.logFormat)")
     .option(
       "--log-identity",
       "Include caller identity (email) in log lines. Off by default because emails are PII; " +
@@ -121,21 +132,23 @@ export function registerProxyCommand(program: Command): void {
     )
     .option(
       "--allow-duplicates",
-      "Skip the upstream duplicate-name check on POST /api/v1/workflows (the check is on by default; under enforce=error a match returns 409, under enforce=warn a header is attached)",
+      "Skip the upstream duplicate-name check on POST /api/v1/workflows (the check is on by default; under enforce=error a match returns 409, under enforce=warn a header is attached). config: proxy.allowDuplicates",
     )
-    .option("--duplicate-ttl <ms>", "TTL (ms) for the cached upstream workflow-name index", "60000")
+    .option(
+      "--duplicate-ttl <ms>",
+      "TTL (ms) for the cached upstream workflow-name index (config: proxy.duplicateTtlMs)",
+    )
     .option(
       "--upstream-timeout <ms>",
-      "Per-request upstream timeout in milliseconds (0 disables)",
-      "30000",
+      "Per-request upstream timeout in milliseconds (0 disables; config: proxy.upstreamTimeoutMs)",
     )
     .option(
       "--server-middleware <list>",
-      "Comma-separated server-middleware chain (default: lint; env: N8N_SERVER_MIDDLEWARES). Example: lint,authz",
+      "Comma-separated server-middleware chain (default: lint; env: N8N_SERVER_MIDDLEWARES; config: proxy.serverMiddlewares or middlewares.server). Example: lint,authz",
     )
     .option(
       "--client-middleware <list>",
-      "Comma-separated client-middleware chain run on outgoing upstream requests (default: empty; env: N8N_CLIENT_MIDDLEWARES). Example: iap-auth,api-key-inject",
+      "Comma-separated client-middleware chain run on outgoing upstream requests (default: empty; env: N8N_CLIENT_MIDDLEWARES; config: proxy.clientMiddlewares or middlewares.client). Example: iap-auth,api-key-inject",
     )
     // iap-auth options — only meaningful when "iap-auth" is in the client-middleware chain.
     .option(
@@ -207,12 +220,12 @@ export function registerProxyCommand(program: Command): void {
     )
     .option(
       "--tags <tags>",
-      "Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: PROXY_FILTER_BY_TAGS). Non-matching saves are forwarded transparently.",
+      "Only run middleware against workflow saves whose tags contain ALL of the listed names (AND condition; env: PROXY_FILTER_BY_TAGS; config: proxy.tags). Non-matching saves are forwarded transparently.",
     )
     .option(
       "--routes <table>",
       "Endpoints to treat as policy-relevant, one per line or comma-separated: " +
-        '"METHOD /path/:id -> action [body=workflow]" (env: N8N_PROXY_ROUTES). ' +
+        '"METHOD /path/:id -> action [body=workflow]" (env: N8N_PROXY_ROUTES; config: proxy.routes). ' +
         "Defaults to workflow create/update/tags/delete/activate.",
     )
     // MCP gate — policy applied to n8n's instance-level MCP endpoint. Off
@@ -405,23 +418,49 @@ export function registerProxyCommand(program: Command): void {
       "Behavior on token-fetch failure: throw (default) or skip",
     )
     .action((opts: ProxyOptions) => {
-      const upstream = opts.upstream ?? process.env.N8N_API_URL;
+      // The all-in-one config file supplies proxy defaults below env/CLI
+      // precedence: defaults < config file < env < CLI flags. --config is a
+      // program-level option, so it lives on program.opts(), not this
+      // command's opts bag.
+      let rc: LoadedRc;
+      try {
+        rc = loadMergedRc((program.opts() as { config?: string }).config);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+      const rcProxy = rc.config.proxy ?? {};
+
+      const listen = opts.listen ?? rcProxy.listen ?? ":8080";
+      const upstream =
+        opts.upstream ?? process.env.N8N_API_URL ?? rcProxy.upstream ?? rc.config.api?.url;
       if (!upstream) {
         console.error(
-          "Error: --upstream is required (or set N8N_API_URL). Example: --upstream https://n8n.example.com",
+          "Error: --upstream is required (or set N8N_API_URL, proxy.upstream / api.url in " +
+            ".n8nctlrc.json). Example: --upstream https://n8n.example.com",
         );
         process.exit(1);
       }
 
-      const logFormat = opts.logFormat === "json" ? "json" : "text";
-      const enforce = parseEnforceLevel(opts.enforce);
-      const duplicateTtlMs = parsePositiveInt(opts.duplicateTtl, "--duplicate-ttl");
-      const upstreamTimeoutMs = parsePositiveInt(opts.upstreamTimeout, "--upstream-timeout");
+      const logFormat = opts.logFormat ?? rcProxy.logFormat ?? "text";
+      const logFormatResolved = logFormat === "json" ? "json" : "text";
+      const enforce = parseEnforceLevel(opts.enforce ?? rcProxy.enforce ?? "error");
+      const duplicateTtlMs =
+        parsePositiveInt(opts.duplicateTtl, "--duplicate-ttl") ?? rcProxy.duplicateTtlMs;
+      const upstreamTimeoutMs =
+        parsePositiveInt(opts.upstreamTimeout, "--upstream-timeout") ?? rcProxy.upstreamTimeoutMs;
 
       const middlewares = parseMiddlewareList(opts.serverMiddleware);
       const clientMiddlewares = parseMiddlewareList(opts.clientMiddleware);
-      const filterByTags = parseTagFilter(opts.tags ?? process.env.PROXY_FILTER_BY_TAGS);
-      const routes = parseRoutes(opts.routes ?? process.env.N8N_PROXY_ROUTES);
+      // Proxy-scoped chains win over the global middlewares section.
+      const serverFileList = rcProxy.serverMiddlewares ?? rc.config.middlewares?.server;
+      const clientFileList = rcProxy.clientMiddlewares ?? rc.config.middlewares?.client;
+      const middlewareFileOptions = rc.config.middlewares?.options;
+
+      const tagSource = opts.tags ?? process.env.PROXY_FILTER_BY_TAGS ?? rcProxy.tags?.join(",");
+      const filterByTags = parseTagFilter(tagSource);
+      const routeSource = opts.routes ?? process.env.N8N_PROXY_ROUTES ?? rcProxy.routes?.join("\n");
+      const routes = parseRoutes(routeSource);
 
       let mcp: ReturnType<typeof parseMcpSettings>;
       try {
@@ -433,20 +472,24 @@ export function registerProxyCommand(program: Command): void {
 
       const handle = startProxy({
         routes,
-        listen: opts.listen,
+        listen,
         upstream,
         lintConfigPath: opts.lintConfig,
         enforce,
-        disableRules: opts.disableRule ?? [],
-        logFormat,
-        logIdentity: opts.logIdentity,
-        allowDuplicates: !!opts.allowDuplicates,
+        disableRules: opts.disableRule ?? rcProxy.disableRules ?? [],
+        logFormat: logFormatResolved,
+        logIdentity: opts.logIdentity ?? rcProxy.logIdentity,
+        allowDuplicates: opts.allowDuplicates ?? rcProxy.allowDuplicates,
         duplicateTtlMs,
         upstreamTimeoutMs,
         middlewares,
         middlewareCliOptions: extractMiddlewareCliOpts(opts),
+        middlewareFileOptions,
+        middlewareFileList: serverFileList,
         clientMiddlewares: clientMiddlewares.length > 0 ? clientMiddlewares : undefined,
         clientMiddlewareCliOptions: extractClientMiddlewareCliOpts(opts),
+        clientMiddlewareFileOptions: middlewareFileOptions,
+        clientMiddlewareFileList: clientFileList,
         filterByTags: filterByTags.length > 0 ? filterByTags : undefined,
         mcp: mcp ?? undefined,
       });
@@ -458,14 +501,16 @@ export function registerProxyCommand(program: Command): void {
       // "(env/default)" to avoid lying about an empty chain.
       const mwDisplay = middlewares.length
         ? middlewares.join(",")
-        : (process.env.N8N_SERVER_MIDDLEWARES ?? "lint (default)");
+        : (process.env.N8N_SERVER_MIDDLEWARES ??
+          (serverFileList?.length ? serverFileList.join(",") : "lint (default)"));
       const clientMwDisplay = clientMiddlewares.length
         ? clientMiddlewares.join(",")
-        : (process.env.N8N_CLIENT_MIDDLEWARES ?? "(none)");
+        : (process.env.N8N_CLIENT_MIDDLEWARES ??
+          (clientFileList?.length ? clientFileList.join(",") : "(none)"));
       const tagsDisplay = filterByTags.length > 0 ? `, tags=${filterByTags.join(",")}` : "";
       const mcpDisplay = mcp ? `, mcp=${mcp.enforce} on ${MCP_PATH_PREFIX}` : "";
       console.error(
-        `n8n-cli proxy listening on ${opts.listen} → ${upstream} (enforce=${enforce}, server-middlewares=${mwDisplay}, client-middlewares=${clientMwDisplay}${tagsDisplay}${mcpDisplay})`,
+        `n8n-cli proxy listening on ${listen} → ${upstream} (enforce=${enforce}, server-middlewares=${mwDisplay}, client-middlewares=${clientMwDisplay}${tagsDisplay}${mcpDisplay})`,
       );
 
       const shutdown = async (signal: string) => {

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { loadMergedRc } from "@/cli/root.ts";
 import { parseTagFilter } from "@/common/tags.ts";
-import type { LoadedRc } from "@/config/rc.ts";
+import type { LoadedRc, RcMcpSection } from "@/config/rc.ts";
 import { parseMiddlewareList } from "@/middleware/registry.ts";
 import { parseEnforceLevel } from "@/proxy/config.ts";
 import { type McpCliOptions, parseMcpSettings } from "@/proxy/mcp/config.ts";
@@ -464,7 +464,7 @@ export function registerProxyCommand(program: Command): void {
 
       let mcp: ReturnType<typeof parseMcpSettings>;
       try {
-        mcp = parseMcpSettings(opts, process.env);
+        mcp = parseMcpSettings(resolveMcpCliOptions(opts, process.env, rcProxy.mcp), process.env);
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);
@@ -602,6 +602,43 @@ export function extractClientMiddlewareCliOpts(opts: ProxyOptions): Record<strin
   copy("impersonatorTokenEnvVar");
   copy("impersonatorTokenOnError");
   return out;
+}
+
+/**
+ * Folds the config-file `proxy.mcp` section into the CLI options bag at the
+ * lowest precedence (CLI flag > env var > file) so `parseMcpSettings` — which
+ * merges CLI over env internally — sees one flat bag. The env var names are
+ * repeated here on purpose: parseMcpSettings stays the single place that
+ * validates and interprets the values (including the orphan-policy check);
+ * this only decides who wins. Exported for unit tests.
+ */
+export function resolveMcpCliOptions(
+  cli: McpCliOptions,
+  env: NodeJS.ProcessEnv,
+  file: RcMcpSection | undefined,
+): McpCliOptions {
+  const pick = (cliValue: string | undefined, envName: string, fileValue: string | undefined) =>
+    cliValue ?? env[envName] ?? fileValue;
+  return {
+    mcpEnforce: pick(cli.mcpEnforce, "N8N_MCP_ENFORCE", file?.enforce),
+    mcpAllowTools: pick(cli.mcpAllowTools, "N8N_MCP_ALLOW_TOOLS", file?.allowTools?.join(",")),
+    mcpDenyTools: pick(cli.mcpDenyTools, "N8N_MCP_DENY_TOOLS", file?.denyTools?.join(",")),
+    mcpWorkflowTags: pick(
+      cli.mcpWorkflowTags,
+      "N8N_MCP_WORKFLOW_TAGS",
+      file?.workflowTags?.join(","),
+    ),
+    mcpEntryPathPattern: pick(
+      cli.mcpEntryPathPattern,
+      "N8N_MCP_ENTRY_PATH_PATTERN",
+      file?.entryPathPattern,
+    ),
+    mcpCacheTtlMs: pick(
+      cli.mcpCacheTtlMs,
+      "N8N_MCP_CACHE_TTL_MS",
+      file?.cacheTtlMs !== undefined ? String(file.cacheTtlMs) : undefined,
+    ),
+  };
 }
 
 function parsePositiveInt(value: string | undefined, flag: string): number | undefined {

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -12,6 +12,7 @@ import {
   loadFromEnv,
   validate,
 } from "../config/config.ts";
+import { applyRcApiSection, type LoadedRc, loadRc, warnLiteralSecretsInRc } from "../config/rc.ts";
 import { buildClientMiddlewares } from "../middleware/client-registry.ts";
 import {
   DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
@@ -39,28 +40,30 @@ export interface GlobalContext {
 }
 
 /**
- * Builds the egress middleware chain for the API client from
- * `N8N_CLIENT_MIDDLEWARES`. Empty by default, which keeps the direct-to-n8n
- * path byte-identical to before — nothing is registered, nothing runs.
- *
- * Deliberately knows no middleware by name: each factory reads its own
- * configuration off the environment, so authentication stays an opt-in
- * extension rather than something the core request path carries.
+ * Builds the egress middleware chain for the API client. The chain list and
+ * per-middleware options come from (lowest first) `.n8nctlrc.json` files,
+ * then environment variables; CLI flags for the global commands don't carry
+ * middleware options, so no CLI layer exists here.
  */
-function buildEgressChain(): ClientMiddleware[] {
+function buildEgressChain(rc: LoadedRc): ClientMiddleware[] {
   const enabled = resolveEnabledList({
     env: process.env,
     envVar: "N8N_CLIENT_MIDDLEWARES",
+    fileValue: rc.config.middlewares?.client,
     fallback: DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
   });
   if (enabled.length === 0) return [];
 
   registerClientBuiltins();
-  return buildClientMiddlewares({ enabled, env: process.env });
+  return buildClientMiddlewares({
+    enabled,
+    env: process.env,
+    fileOptions: rc.config.middlewares?.options,
+  });
 }
 
-function createContext(config: Config): GlobalContext {
-  const clientMiddlewares = buildEgressChain();
+function createContext(config: Config, rc: LoadedRc): GlobalContext {
+  const clientMiddlewares = buildEgressChain(rc);
   const client = new Client(config.apiURL, config.apiKey, config.timeoutMs, clientMiddlewares);
   return {
     config,
@@ -84,7 +87,12 @@ export function createProgram(): Command {
     .option("--api-url <url>", "n8n API URL (env: N8N_API_URL)")
     .option("--api-key <key>", "n8n API key (env: N8N_API_KEY)")
     .option("--timeout <duration>", "Request timeout (default: 30s, env: N8N_API_TIMEOUT)")
-    .option("-o, --output <format>", "Output format: json, table", "json");
+    .option("-o, --output <format>", "Output format: json, table", "json")
+    .option(
+      "--config <path>",
+      "Path to the all-in-one config file (.n8nctlrc.json); replaces project-level " +
+        "discovery. User-level defaults to ~/.config/n8nctl/config.json (env: N8NCTL_CONFIG)",
+    );
 
   // version command (does not require API config)
   program
@@ -98,12 +106,28 @@ export function createProgram(): Command {
 }
 
 /**
- * Resolve config from global options + env vars.
+ * Loads the merged configuration files for this invocation. Shared by
+ * resolveConfig / middleware wiring / lint discovery so every consumer sees
+ * the same user < project merge.
+ */
+export function loadMergedRc(configPath?: string): LoadedRc {
+  const rc = loadRc({ configPath });
+  warnLiteralSecretsInRc(rc);
+  return rc;
+}
+
+/**
+ * Resolve config from global options + config files + env vars.
+ * Precedence: built-in defaults < config files (user < project) < env < CLI flags.
  * Call this inside commands that need API access.
  */
 export function resolveConfig(program: Command): Config {
   const opts = program.opts();
   const config = defaultConfig();
+
+  const rc = loadMergedRc(opts.config);
+  applyRcApiSection(config, rc.config.api);
+
   loadFromEnv(config);
 
   // CLI flags override env vars
@@ -138,7 +162,8 @@ export function resolveContext(program: Command): GlobalContext {
     }
     throw e;
   }
-  return createContext(config);
+  const rc = loadMergedRc(program.opts().config);
+  return createContext(config, rc);
 }
 
 /**

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -69,7 +69,8 @@ export function validate(config: Config, env: NodeJS.ProcessEnv = process.env): 
     throw new ConfigError(
       "api-url",
       "API URL is required",
-      "Set N8N_API_URL environment variable or use --api-url flag",
+      "Set N8N_API_URL environment variable, use --api-url flag, or set api.url in " +
+        ".n8nctlrc.json (or ~/.config/n8nctl/config.json)",
     );
   }
   const hasEgressChain = (env.N8N_CLIENT_MIDDLEWARES ?? "").trim().length > 0;
@@ -77,8 +78,9 @@ export function validate(config: Config, env: NodeJS.ProcessEnv = process.env): 
     throw new ConfigError(
       "api-key",
       "API key is required",
-      "Set N8N_API_KEY environment variable or use --api-key flag " +
-        "(not needed when N8N_CLIENT_MIDDLEWARES supplies credentials)",
+      "Set N8N_API_KEY environment variable, use --api-key flag, or set api.apiKey " +
+        '(e.g. "${MY_KEY}") in .n8nctlrc.json — not needed when N8N_CLIENT_MIDDLEWARES ' +
+        "supplies credentials",
     );
   }
 }

--- a/src/config/rc.ts
+++ b/src/config/rc.ts
@@ -81,6 +81,21 @@ export interface RcMiddlewaresSection {
   options?: Record<string, Record<string, unknown>>;
 }
 
+export interface RcMcpSection {
+  /** MCP gate enforcement level (flag: --mcp-enforce). */
+  enforce?: "off" | "warn" | "error";
+  /** Glob patterns for the only tools clients may see (flag: --mcp-allow-tools). */
+  allowTools?: string[];
+  /** Glob patterns for tools to withhold, applied after allowTools (flag: --mcp-deny-tools). */
+  denyTools?: string[];
+  /** Workflow tags required for workflow-scoped tool calls (flag: --mcp-workflow-tags). */
+  workflowTags?: string[];
+  /** Entry-trigger path glob a workflow must match (flag: --mcp-entry-path-pattern). */
+  entryPathPattern?: string;
+  /** Cached workflow allowlist lifetime in ms (flag: --mcp-cache-ttl-ms). */
+  cacheTtlMs?: number;
+}
+
 export interface RcProxySection {
   listen?: string;
   /** Upstream n8n base URL. Falls back to api.url when omitted. */
@@ -101,6 +116,8 @@ export interface RcProxySection {
   routes?: string[];
   duplicateTtlMs?: number;
   upstreamTimeoutMs?: number;
+  /** MCP gate policy (flag family: --mcp-*). */
+  mcp?: RcMcpSection;
 }
 
 /** The all-in-one configuration file shape. Every section is optional. */
@@ -269,6 +286,31 @@ function asRc(raw: Record<string, unknown>, source: string): N8nCtlRc {
       if (v !== undefined && (typeof v !== "number" || !Number.isFinite(v) || v < 0)) {
         throw new RcError(
           `Invalid proxy.${numKey}${at(source)}: expected a non-negative number`,
+          source,
+        );
+      }
+    }
+    if (proxy.mcp !== undefined) {
+      if (!isPlainObject(proxy.mcp)) {
+        throw new RcError(`Invalid "proxy.mcp" section${at(source)}: expected an object`, source);
+      }
+      const mcp = proxy.mcp;
+      for (const listKey of ["allowTools", "denyTools", "workflowTags"]) {
+        if (mcp[listKey] !== undefined) {
+          assertStringArray(mcp[listKey], `proxy.mcp.${listKey}`, source);
+        }
+      }
+      const enforce = mcp.enforce;
+      if (enforce !== undefined && enforce !== "off" && enforce !== "warn" && enforce !== "error") {
+        throw new RcError(
+          `Invalid proxy.mcp.enforce${at(source)}: expected off, warn, or error`,
+          source,
+        );
+      }
+      const ttl = mcp.cacheTtlMs;
+      if (ttl !== undefined && (typeof ttl !== "number" || !Number.isFinite(ttl) || ttl < 0)) {
+        throw new RcError(
+          `Invalid proxy.mcp.cacheTtlMs${at(source)}: expected a non-negative number`,
           source,
         );
       }

--- a/src/config/rc.ts
+++ b/src/config/rc.ts
@@ -1,0 +1,450 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * `.n8nctlrc.json` — the all-in-one configuration file for n8n-cli (and the
+ * future `n8nctl` rename; the filename is chosen with that in mind).
+ *
+ * Two placements are supported and merged, project winning on conflict:
+ *
+ *   1. User-level:   `$XDG_CONFIG_HOME/n8nctl/config.json`
+ *                    (default `~/.config/n8nctl/config.json`) — the right
+ *                    home for personal values such as API keys.
+ *   2. Project-level: `.n8nctlrc.json` discovered by walking up from the
+ *                    working directory — the right home for shared settings
+ *                    a team commits to the repository. The legacy lint-only
+ *                    `.n8nlintrc.json` is still discovered and treated as if
+ *                    its whole content were the `lint` section.
+ *
+ * Precedence across all sources:
+ *
+ *   built-in defaults < user file < project file < environment < CLI flags
+ *
+ * so environment variables (direnv, CI) keep winning over files, and CLI
+ * flags keep winning over everything — same contract as before this file
+ * existed. String values support `${ENV_VAR}` interpolation so secrets can
+ * stay in the environment while the rest of the configuration is versioned;
+ * referencing an undefined variable is an error, not a silent empty string.
+ */
+
+/** Name of the all-in-one project-level config file. */
+export const PROJECT_RC_FILENAME = ".n8nctlrc.json";
+/** Legacy lint-only config file, still discovered as a fallback. */
+export const LEGACY_LINT_RC_FILENAME = ".n8nlintrc.json";
+/** Directory (under XDG_CONFIG_HOME) holding the user-level config file. */
+export const USER_RC_DIR = "n8nctl";
+/** User-level config filename. */
+export const USER_RC_FILENAME = "config.json";
+
+/** Overrides for the `N8NCTL_CONFIG` / `XDG_CONFIG_HOME` / `HOME` lookups. */
+export interface LoadRcEnv {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  /** Explicit config path (--config flag); replaces the project layer. */
+  configPath?: string;
+}
+
+export interface RcApiSection {
+  /** n8n API URL. Same value as N8N_API_URL / --api-url. */
+  url?: string;
+  /**
+   * API key. Supports `${ENV_VAR}` interpolation; a literal key in a
+   * project-level file triggers a warning (secrets don't belong in git).
+   */
+  apiKey?: string;
+  /** Request timeout, e.g. "30s", "5m", or plain milliseconds. */
+  timeout?: string;
+  /** Default output format. */
+  output?: "json" | "table";
+}
+
+export interface RcLintSection {
+  /** Rule configs keyed by rule name — same format as `.n8nlintrc.json`. */
+  rules?: Record<string, unknown>;
+  /** Per-project rule overrides keyed by n8n project ID. */
+  projects?: Record<string, { rules?: Record<string, unknown> }>;
+}
+
+export interface RcMiddlewaresSection {
+  /** Client middleware chain, e.g. ["iap-auth", "api-key-inject"]. */
+  client?: string[];
+  /** Server middleware chain, e.g. ["lint", "authz"]. */
+  server?: string[];
+  /**
+   * Per-middleware options keyed by middleware name. Keys mirror the
+   * camelCase CLI flag names (e.g. "iap-auth": { "audience": ... } uses the
+   * schema option names; each factory's documented CLI option keys are
+   * accepted). Secret-carrying options keep their CLI restrictions: a raw
+   * key is only ever accepted via an env-var reference.
+   */
+  options?: Record<string, Record<string, unknown>>;
+}
+
+export interface RcProxySection {
+  listen?: string;
+  /** Upstream n8n base URL. Falls back to api.url when omitted. */
+  upstream?: string;
+  enforce?: "off" | "warn" | "error";
+  logFormat?: "text" | "json";
+  logIdentity?: boolean;
+  allowDuplicates?: boolean;
+  /** Rule names to disable. */
+  disableRules?: string[];
+  /** Server middleware chain (alias of middlewares.server, proxy-scoped). */
+  serverMiddlewares?: string[];
+  /** Client middleware chain (alias of middlewares.client, proxy-scoped). */
+  clientMiddlewares?: string[];
+  /** Tag-based scope filter (AND condition). */
+  tags?: string[];
+  /** Route table lines, same format as --routes. */
+  routes?: string[];
+  duplicateTtlMs?: number;
+  upstreamTimeoutMs?: number;
+}
+
+/** The all-in-one configuration file shape. Every section is optional. */
+export interface N8nCtlRc {
+  api?: RcApiSection;
+  lint?: RcLintSection;
+  middlewares?: RcMiddlewaresSection;
+  proxy?: RcProxySection;
+}
+
+/** Where each layer of the merged configuration came from. */
+export interface RcSources {
+  /** Explicitly requested file (--config / N8NCTL_CONFIG), if any. */
+  explicit?: string;
+  user?: string;
+  project?: string;
+}
+
+export interface LoadedRc {
+  /** user < project merged, interpolated, unvalidated beyond shape. */
+  config: N8nCtlRc;
+  sources: RcSources;
+}
+
+/** Thrown for a malformed or unresolvable configuration file. */
+export class RcError extends Error {
+  constructor(
+    message: string,
+    public readonly source?: string,
+  ) {
+    super(message);
+    this.name = "RcError";
+  }
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+const INTERPOLATION_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+/** Non-global variant for membership tests (global regexes carry lastIndex). */
+const INTERPOLATION_REF = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/;
+
+/**
+ * Recursively expands `${ENV_VAR}` references inside string values. An
+ * undefined variable is an error: a silent empty string would quietly
+ * produce an empty API URL or header, and the failure the user would see
+ * downstream ("API URL is required") would no longer point at the file that
+ * caused it.
+ */
+export function interpolateEnvStrings(
+  value: unknown,
+  env: NodeJS.ProcessEnv,
+  source?: string,
+): unknown {
+  if (typeof value === "string") {
+    return value.replace(INTERPOLATION_PATTERN, (_whole, name: string) => {
+      const resolved = env[name];
+      if (resolved === undefined) {
+        const where = source ? ` (${source})` : "";
+        throw new RcError(
+          `Configuration references undefined environment variable \${${name}}${where}`,
+          source,
+        );
+      }
+      return resolved;
+    });
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateEnvStrings(item, env, source));
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value)) {
+      out[key] = interpolateEnvStrings(v, env, source);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Deep-merges two configuration objects: plain objects merge recursively,
+ * arrays and scalars replace wholesale (a CLI/project list overrides the
+ * lower layer's list — matching how the existing middleware option merge
+ * treats arrays).
+ */
+export function deepMergeRc(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...base };
+  for (const [key, ovValue] of Object.entries(override)) {
+    if (ovValue === undefined) continue;
+    const baseValue = out[key];
+    if (isPlainObject(baseValue) && isPlainObject(ovValue)) {
+      out[key] = deepMergeRc(baseValue, ovValue);
+    } else {
+      out[key] = ovValue;
+    }
+  }
+  return out;
+}
+
+function assertSectionObject(raw: Record<string, unknown>, key: string, source: string): void {
+  if (raw[key] !== undefined && !isPlainObject(raw[key])) {
+    throw new RcError(`Invalid "${key}" section${at(source)}: expected an object`, source);
+  }
+}
+
+function assertStringArray(value: unknown, label: string, source: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+    throw new RcError(`Invalid ${label}${at(source)}: expected an array of strings`, source);
+  }
+  return value as string[];
+}
+
+function at(source?: string): string {
+  return source ? ` in ${source}` : "";
+}
+
+function asRc(raw: Record<string, unknown>, source: string): N8nCtlRc {
+  assertSectionObject(raw, "api", source);
+  assertSectionObject(raw, "lint", source);
+  assertSectionObject(raw, "middlewares", source);
+  assertSectionObject(raw, "proxy", source);
+
+  const rc: N8nCtlRc = raw as N8nCtlRc;
+  if (rc.middlewares) {
+    const mw = rc.middlewares as Record<string, unknown>;
+    assertStringArray(mw.client, "middlewares.client", source);
+    assertStringArray(mw.server, "middlewares.server", source);
+    if (mw.options !== undefined && !isPlainObject(mw.options)) {
+      throw new RcError(
+        `Invalid "middlewares.options" section in ${source}: expected an object keyed by middleware name`,
+        source,
+      );
+    }
+    if (isPlainObject(mw.options)) {
+      for (const [name, section] of Object.entries(mw.options)) {
+        if (!isPlainObject(section)) {
+          throw new RcError(
+            `Invalid middlewares.options["${name}"] in ${source}: expected an object`,
+            source,
+          );
+        }
+      }
+    }
+  }
+  if (rc.proxy) {
+    const proxy = rc.proxy as Record<string, unknown>;
+    for (const listKey of [
+      "disableRules",
+      "serverMiddlewares",
+      "clientMiddlewares",
+      "tags",
+      "routes",
+    ]) {
+      if (proxy[listKey] !== undefined) {
+        assertStringArray(proxy[listKey], `proxy.${listKey}`, source);
+      }
+    }
+    for (const numKey of ["duplicateTtlMs", "upstreamTimeoutMs"]) {
+      const v = proxy[numKey];
+      if (v !== undefined && (typeof v !== "number" || !Number.isFinite(v) || v < 0)) {
+        throw new RcError(
+          `Invalid proxy.${numKey}${at(source)}: expected a non-negative number`,
+          source,
+        );
+      }
+    }
+  }
+  return rc;
+}
+
+function parseRcJson(data: string, source: string): Record<string, unknown> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new RcError(`Failed to parse configuration file ${source}: ${message}`, source);
+  }
+  if (!isPlainObject(raw)) {
+    throw new RcError(`Configuration file ${source} must contain a JSON object`, source);
+  }
+  return raw;
+}
+
+/**
+ * Reads one config file and returns its N8nCtlRc view. A legacy
+ * `.n8nlintrc.json` is accepted anywhere a project config is expected: its
+ * whole content is the `lint` section, so an existing file keeps working
+ * unchanged.
+ */
+export function parseRcFile(filePath: string, env: NodeJS.ProcessEnv): N8nCtlRc {
+  let data: string;
+  try {
+    data = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    throw new RcError(`Cannot read configuration file: ${filePath}`, filePath);
+  }
+  const raw = parseRcJson(data, filePath);
+  const interpolated = interpolateEnvStrings(raw, env, filePath) as Record<string, unknown>;
+  if (path.basename(filePath) === LEGACY_LINT_RC_FILENAME) {
+    return { lint: interpolated as RcLintSection };
+  }
+  return asRc(interpolated, filePath);
+}
+
+/**
+ * Walks up from startDir looking for `.n8nctlrc.json` (preferred) or the
+ * legacy `.n8nlintrc.json`. Within one directory the all-in-one name wins;
+ * the nearest directory that contains either file wins overall.
+ */
+export function findProjectRcFile(startDir: string): string | undefined {
+  let dir = path.resolve(startDir);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    for (const name of [PROJECT_RC_FILENAME, LEGACY_LINT_RC_FILENAME]) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/** Resolves the user-level config path: $XDG_CONFIG_HOME/n8nctl/config.json. */
+export function findUserRcFile(env: NodeJS.ProcessEnv): string {
+  const configHome = env.XDG_CONFIG_HOME || path.join(env.HOME || os.homedir(), ".config");
+  return path.join(configHome, USER_RC_DIR, USER_RC_FILENAME);
+}
+
+/**
+ * Loads and merges the user-level and project-level configuration files.
+ * Pure: reads the filesystem each call (a couple of small JSON reads per
+ * CLI invocation — cheaper than the memoization bugs a cache would invite
+ * with changing cwd/env across call sites).
+ *
+ * Precedence: user file < project file. `configPath` (from --config or
+ * N8NCTL_CONFIG) replaces the project layer and wins over both files.
+ */
+export function loadRc(options: LoadRcEnv = {}): LoadedRc {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const sources: RcSources = {};
+
+  const explicit = options.configPath ?? env.N8NCTL_CONFIG;
+  let config: Record<string, unknown> = {};
+
+  const userPath = findUserRcFile(env);
+  if (fs.existsSync(userPath)) {
+    const user = parseRcFile(userPath, env);
+    config = deepMergeRc(config, user as Record<string, unknown>);
+    sources.user = userPath;
+  }
+
+  if (explicit) {
+    if (!fs.existsSync(explicit)) {
+      throw new RcError(
+        `Configuration file not found: ${explicit} (set via --config or N8NCTL_CONFIG)`,
+        explicit,
+      );
+    }
+    const explicitRc = parseRcFile(explicit, env);
+    config = deepMergeRc(config, explicitRc as Record<string, unknown>);
+    sources.explicit = explicit;
+  } else {
+    const projectPath = findProjectRcFile(cwd);
+    if (projectPath) {
+      const project = parseRcFile(projectPath, env);
+      config = deepMergeRc(config, project as Record<string, unknown>);
+      sources.project = projectPath;
+    }
+  }
+
+  return { config: config as N8nCtlRc, sources };
+}
+
+/**
+ * Warns when a project-level (committed-to-git) config file carries a
+ * literal API key. `${ENV_VAR}` values are fine — the secret stays in the
+ * environment. The warning goes to stderr and never blocks.
+ */
+const warnedSecretSources = new Set<string>();
+export function warnLiteralSecretsInRc(loaded: LoadedRc): void {
+  const source = loaded.sources.project ?? loaded.sources.explicit;
+  if (!source) return;
+  if (path.basename(source) === LEGACY_LINT_RC_FILENAME) return;
+  if (!loaded.config.api?.apiKey) return;
+  if (warnedSecretSources.has(source)) return; // loadRc runs per consumer; warn once.
+  let raw: unknown;
+  try {
+    raw = (JSON.parse(fs.readFileSync(source, "utf-8")) as Record<string, unknown>).api;
+  } catch {
+    return; // Malformed JSON is reported by loadRc.
+  }
+  const rawApiKey = isPlainObject(raw) ? raw.apiKey : undefined;
+  if (typeof rawApiKey === "string" && !INTERPOLATION_REF.test(rawApiKey)) {
+    warnedSecretSources.add(source);
+    console.error(
+      `Warning: ${source} contains a literal api.apiKey. Secrets in project files tend to leak ` +
+        'through git history — use "${ENV_VAR}" interpolation or move the key to ' +
+        `${findUserRcFile(process.env)} instead.`,
+    );
+  }
+}
+
+/**
+ * Applies the `api` section of the merged config to a Config. Called from
+ * `resolveConfig` with defaults < file < env < flags ordering intact.
+ */
+export function applyRcApiSection(
+  config: { apiURL: string; apiKey: string; timeoutMs: number; output: "json" | "table" },
+  api: RcApiSection | undefined,
+): void {
+  if (!api) return;
+  if (api.url) config.apiURL = api.url;
+  if (api.apiKey) config.apiKey = api.apiKey;
+  if (api.timeout) {
+    const ms = parseRcDuration(api.timeout);
+    if (ms !== null) config.timeoutMs = ms;
+  }
+  if (api.output === "json" || api.output === "table") config.output = api.output;
+}
+
+/** Parses "30s" / "5m" / "1000" (ms) — mirrors cli/root.ts parseDuration. */
+export function parseRcDuration(s: string): number | null {
+  const trimmed = s.trim();
+  if (/^\d+$/.test(trimmed)) return Number.parseInt(trimmed, 10);
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)(ms|s|m)$/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]!);
+  switch (match[2]) {
+    case "ms":
+      return value;
+    case "s":
+      return value * 1000;
+    case "m":
+      return value * 60 * 1000;
+    default:
+      return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { registerApplyCommand } from "./cli/commands/apply.ts";
+import { registerConfigCommand } from "./cli/commands/config.ts";
 import { registerConvertCommand } from "./cli/commands/convert.ts";
 import { registerCredentialCommand } from "./cli/commands/credential.ts";
 import { registerDataTableCommand } from "./cli/commands/data-table.ts";
@@ -41,6 +42,7 @@ registerTestCommand(program);
 registerTraceCommand(program);
 registerWebhookCommand(program);
 registerProxyCommand(program);
+registerConfigCommand(program);
 
 try {
   await program.parseAsync(process.argv);

--- a/src/lint/config.ts
+++ b/src/lint/config.ts
@@ -1,18 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
+import { loadRc, PROJECT_RC_FILENAME } from "@/config/rc.ts";
 
 const CONFIG_FILENAME = ".n8nlintrc.json";
 
 /**
- * Searches for a config file by walking up from startDir to the filesystem root.
- * Returns the first `.n8nlintrc.json` found, or undefined if none exists.
+ * Searches for a config file by walking up from startDir to the filesystem
+ * root. Returns the first config found — `.n8nctlrc.json` (all-in-one, whose
+ * `lint` section is used) is preferred over the legacy `.n8nlintrc.json`
+ * within the same directory. Returns undefined if none exists.
  */
 export function findConfigFile(startDir: string): string | undefined {
   let dir = path.resolve(startDir);
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const candidate = path.join(dir, CONFIG_FILENAME);
-    if (fs.existsSync(candidate)) return candidate;
+    for (const name of [PROJECT_RC_FILENAME, CONFIG_FILENAME]) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -105,27 +110,36 @@ function parseRulesConfig(rawRules: Record<string, unknown> | undefined): Map<st
   return rulesConfig;
 }
 
-/** Load reads and parses a lint config file. Auto-discovers from CWD if no path given. */
-export function loadLintConfig(configPath?: string): LintConfig {
-  const defaultConfig: LintConfig = {
-    rulesConfig: new Map(),
-    projectRulesConfig: new Map(),
-  };
-
-  if (!configPath) {
-    configPath = findConfigFile(process.cwd());
-    if (!configPath) return defaultConfig;
-  }
-
+/** Loads and parses a lint config file (legacy or all-in-one shape). */
+function loadLintConfigFromFile(configPath: string): LintConfig {
   let data: string;
   try {
     data = fs.readFileSync(configPath, "utf-8");
   } catch {
     // File doesn't exist or can't be read - return defaults
-    return defaultConfig;
+    return { rulesConfig: new Map(), projectRulesConfig: new Map() };
   }
 
-  const raw = JSON.parse(data) as RawLintConfig;
+  const raw = JSON.parse(data) as Record<string, unknown>;
+  // An all-in-one .n8nctlrc.json carries lint settings in its `lint`
+  // section; a legacy .n8nlintrc.json (or an ad-hoc --lint-config file) IS
+  // the lint section.
+  const lintSection = (
+    path.basename(configPath) === PROJECT_RC_FILENAME
+      ? isPlainObject(raw.lint)
+        ? raw.lint
+        : {}
+      : raw
+  ) as RawLintConfig;
+  return lintConfigFromRaw(lintSection);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Builds a LintConfig from a raw lint section (rules + projects). */
+function lintConfigFromRaw(raw: RawLintConfig): LintConfig {
   const rulesConfig = parseRulesConfig(raw.rules);
   const projectRulesConfig = new Map<string, Map<string, RuleConfig>>();
 
@@ -139,6 +153,30 @@ export function loadLintConfig(configPath?: string): LintConfig {
   }
 
   return { rulesConfig, projectRulesConfig };
+}
+
+/**
+ * Load reads and parses a lint config file.
+ *
+ * With an explicit path the file is read as-is (a `.n8nctlrc.json` path
+ * reads its `lint` section). Auto-discovery goes through the all-in-one
+ * config loader so a user-level ~/.config/n8nctl/config.json and a
+ * project-level `.n8nctlrc.json` / legacy `.n8nlintrc.json` merge with
+ * project winning — the same precedence as every other setting.
+ */
+export function loadLintConfig(configPath?: string): LintConfig {
+  const defaultConfig: LintConfig = {
+    rulesConfig: new Map(),
+    projectRulesConfig: new Map(),
+  };
+
+  if (!configPath) {
+    const rc = loadRc();
+    if (!rc.config.lint) return defaultConfig;
+    return lintConfigFromRaw(rc.config.lint as RawLintConfig);
+  }
+
+  return loadLintConfigFromFile(configPath);
 }
 
 /** Checks if a rule is enabled in the config. Default: enabled. */

--- a/src/middleware/cli-gate.ts
+++ b/src/middleware/cli-gate.ts
@@ -1,4 +1,5 @@
 import type { Workflow, WorkflowInput } from "@/api/types.ts";
+import { loadRc } from "@/config/rc.ts";
 import { formatViolationLine } from "@/lint/write-check.ts";
 import { disposePipeline, preparePipeline, runPipeline } from "./pipeline.ts";
 import { buildMiddlewares, resolveEnabledList } from "./registry.ts";
@@ -41,10 +42,14 @@ export interface ServerMiddlewareGateOptions {
 export async function runServerMiddlewareGate(options: ServerMiddlewareGateOptions): Promise<void> {
   registerBuiltins();
   const env = options.env ?? process.env;
+  // The all-in-one config file supplies the chain and per-middleware options
+  // below env/CLI precedence (CLI flags and env vars still win).
+  const rc = loadRc({ env });
   const enabled = resolveEnabledList({
     cliValue: options.middlewares?.join(","),
     env,
     envVar: "N8N_SERVER_MIDDLEWARES",
+    fileValue: rc.config.middlewares?.server,
     fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
   });
   const filtered = options.noLint ? enabled.filter((n) => n !== "lint") : enabled;
@@ -58,7 +63,12 @@ export async function runServerMiddlewareGate(options: ServerMiddlewareGateOptio
 
   let chain: ServerMiddleware[];
   try {
-    chain = buildMiddlewares({ enabled: filtered, env, cliOpts: legacyCliOpts });
+    chain = buildMiddlewares({
+      enabled: filtered,
+      env,
+      cliOpts: legacyCliOpts,
+      fileOptions: rc.config.middlewares?.options,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Error: ${message}`);

--- a/src/middleware/client-registry.ts
+++ b/src/middleware/client-registry.ts
@@ -34,14 +34,20 @@ export interface BuildClientMiddlewaresInput {
   env?: NodeJS.ProcessEnv;
   /** Flat commander-style options bag from the CLI action. */
   cliOpts?: Record<string, unknown>;
+  /**
+   * Per-middleware option sections from `.n8nctlrc.json`
+   * (`middlewares.options`), keyed by middleware name. Lowest precedence:
+   * file < env < CLI flags.
+   */
+  fileOptions?: Record<string, Record<string, unknown>>;
 }
 
 /**
  * Resolves and builds the enabled client middlewares.
  *
- * Same precedence model as `buildMiddlewares`: env < CLI flags, with deep
- * merge per top-level key so partial CLI overrides don't wipe env-supplied
- * fields inside nested option buckets.
+ * Same precedence model as `buildMiddlewares`: config file < env < CLI
+ * flags, with deep merge per top-level key so partial CLI overrides don't
+ * wipe file/env-supplied fields inside nested option buckets.
  */
 export function buildClientMiddlewares(input: BuildClientMiddlewaresInput): ClientMiddleware[] {
   const env = input.env ?? process.env;
@@ -56,10 +62,12 @@ export function buildClientMiddlewares(input: BuildClientMiddlewaresInput): Clie
           "Did you typo --client-middleware or N8N_CLIENT_MIDDLEWARES?",
       );
     }
+    const fileSection = input.fileOptions?.[name];
+    const fromFile = fileSection ? factory.loadFromCLI(fileSection) : {};
     const fromEnv = factory.loadFromEnv(env);
     const fromCli = factory.loadFromCLI(cliOpts);
     const merged = mergeOptions(
-      fromEnv as Record<string, unknown>,
+      mergeOptions(fromFile as Record<string, unknown>, fromEnv as Record<string, unknown>),
       fromCli as Record<string, unknown>,
     );
     built.push(factory.build(merged));

--- a/src/middleware/registry.ts
+++ b/src/middleware/registry.ts
@@ -35,18 +35,24 @@ export interface BuildMiddlewaresInput {
   env?: NodeJS.ProcessEnv;
   /** Flat commander-style options bag from the CLI action. */
   cliOpts?: Record<string, unknown>;
+  /**
+   * Per-middleware option sections from `.n8nctlrc.json`
+   * (`middlewares.options`), keyed by middleware name. Merged at the lowest
+   * precedence: file < env < CLI flags. Keys mirror the CLI option names.
+   */
+  fileOptions?: Record<string, Record<string, unknown>>;
 }
 
 /**
  * Resolves and builds the enabled middlewares.
  *
- * Order: built-in default values < env < CLI flags. The factory's
- * `loadFromEnv` and `loadFromCLI` each return *partial* options; this
- * function merges them with CLI winning on overlap, then hands the merged
- * object to `build`, which enforces required fields via zod.
- *
- * Unknown middleware names throw with a friendly list so users can't
- * silently disable the pipeline by typoing a name in env.
+ * Order: built-in default values < config file < env < CLI flags. The
+ * factory's `loadFromCLI` doubles as the file-section parser (the sections
+ * use the same camelCase keys the commander options bag carries), so a
+ * factory needs no extra method to support the config file. Each loader
+ * returns *partial* options; this function merges them with CLI winning on
+ * overlap, then hands the merged object to `build`, which enforces required
+ * fields via zod.
  */
 export function buildMiddlewares(input: BuildMiddlewaresInput): ServerMiddleware[] {
   const env = input.env ?? process.env;
@@ -61,6 +67,8 @@ export function buildMiddlewares(input: BuildMiddlewaresInput): ServerMiddleware
           "Did you typo --server-middleware or N8N_SERVER_MIDDLEWARES?",
       );
     }
+    const fileSection = input.fileOptions?.[name];
+    const fromFile = fileSection ? factory.loadFromCLI(fileSection) : {};
     const fromEnv = factory.loadFromEnv(env);
     const fromCli = factory.loadFromCLI(cliOpts);
     // Deep-merge per top-level key so partial CLI overrides don't wipe
@@ -70,7 +78,7 @@ export function buildMiddlewares(input: BuildMiddlewaresInput): ServerMiddleware
     // must survive). One level of nesting is enough for current options;
     // arrays are replaced wholesale (intended: a CLI list overrides env).
     const merged = mergeOptions(
-      fromEnv as Record<string, unknown>,
+      mergeOptions(fromFile as Record<string, unknown>, fromEnv as Record<string, unknown>),
       fromCli as Record<string, unknown>,
     );
     built.push(factory.build(merged));
@@ -78,6 +86,11 @@ export function buildMiddlewares(input: BuildMiddlewaresInput): ServerMiddleware
   return built;
 }
 
+/**
+ * Merges two partial option objects with `override` winning. Kept next to
+ * buildMiddlewares; the two-arg shape composes for the file < env < CLI
+ * chain.
+ */
 function mergeOptions(
   base: Record<string, unknown>,
   override: Record<string, unknown>,
@@ -112,17 +125,21 @@ export function parseMiddlewareList(value: string | undefined): string[] {
 }
 
 /**
- * Resolves the active middleware list from CLI/env with a fallback default.
+ * Resolves the active middleware list from CLI/env/config file with a
+ * fallback default.
  *
  * Precedence:
  *   1. `cliValue` (e.g. commander's --server-middleware) when non-empty
  *   2. `env[envVar]` when non-empty
- *   3. `fallback` (typically ["lint"] for backwards compatibility)
+ *   3. `fileValue` (middlewares.server / middlewares.client in
+ *      `.n8nctlrc.json`) when non-empty
+ *   4. `fallback` (typically ["lint"] for backwards compatibility)
  */
 export function resolveEnabledList(args: {
   cliValue?: string;
   env?: NodeJS.ProcessEnv;
   envVar?: string;
+  fileValue?: string[];
   fallback: string[];
 }): string[] {
   const fromCli = parseMiddlewareList(args.cliValue);
@@ -130,5 +147,6 @@ export function resolveEnabledList(args: {
   const envVal = args.envVar ? args.env?.[args.envVar] : undefined;
   const fromEnv = parseMiddlewareList(envVal);
   if (fromEnv.length > 0) return fromEnv;
+  if (args.fileValue && args.fileValue.length > 0) return args.fileValue;
   return args.fallback;
 }

--- a/src/proxy/config.ts
+++ b/src/proxy/config.ts
@@ -58,6 +58,18 @@ export interface ProxyConfig {
    */
   middlewareCliOptions?: Record<string, unknown>;
   /**
+   * Per-middleware option sections from `.n8nctlrc.json`
+   * (`middlewares.options`), keyed by middleware name. Lowest precedence:
+   * file < env < CLI flags.
+   */
+  middlewareFileOptions?: Record<string, Record<string, unknown>>;
+  /**
+   * Server middleware list from the config file (proxy.serverMiddlewares
+   * falling back to middlewares.server). Sits between the env var and the
+   * built-in default in resolveEnabledList's precedence.
+   */
+  middlewareFileList?: string[];
+  /**
    * Tag-based scope filter (AND condition). When set, the proxy only runs
    * middleware (lint / authz / ...) and duplicate detection against workflow
    * saves whose `tags` contain every name listed here; non-matching saves
@@ -86,6 +98,17 @@ export interface ProxyConfig {
    * pick out its own keys.
    */
   clientMiddlewareCliOptions?: Record<string, unknown>;
+  /**
+   * Per-middleware option sections from `.n8nctlrc.json`
+   * (`middlewares.options`), keyed by middleware name. Lowest precedence.
+   */
+  clientMiddlewareFileOptions?: Record<string, Record<string, unknown>>;
+  /**
+   * Client middleware list from the config file (proxy.clientMiddlewares
+   * falling back to middlewares.client). Sits between the env var and the
+   * built-in default in resolveEnabledList's precedence.
+   */
+  clientMiddlewareFileList?: string[];
   /**
    * Policy applied to n8n's instance-level MCP endpoint. Absent means the path
    * is forwarded like any other, which is what a deployment that never

--- a/src/proxy/mcp/config.ts
+++ b/src/proxy/mcp/config.ts
@@ -68,8 +68,9 @@ export function parseMcpSettings(
     ).map(({ env: name }) => name);
     if (orphans.length > 0) {
       throw new Error(
-        `MCP policy is configured (${orphans.join(", ")}) but --mcp-enforce / N8N_MCP_ENFORCE is not set, ` +
-          "so the gate would be off and the policy ignored. Set it to off, warn or error.",
+        `MCP policy is configured (${orphans.join(", ")}) but --mcp-enforce / N8N_MCP_ENFORCE ` +
+          "(or proxy.mcp.enforce in .n8nctlrc.json) is not set, so the gate would be off and " +
+          "the policy ignored. Set it to off, warn or error.",
       );
     }
     return null;

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -86,6 +86,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     cliValue: config.middlewares?.join(","),
     env: process.env,
     envVar: SERVER_MIDDLEWARES_ENV_VAR,
+    fileValue: config.middlewareFileList,
     fallback: DEFAULT_SERVER_MIDDLEWARE_CHAIN,
   });
 
@@ -98,12 +99,14 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     cliValue: config.clientMiddlewares?.join(","),
     env: process.env,
     envVar: CLIENT_MIDDLEWARES_ENV_VAR,
+    fileValue: config.clientMiddlewareFileList,
     fallback: DEFAULT_CLIENT_MIDDLEWARE_CHAIN,
   });
   const clientMiddlewares = buildClientMiddlewares({
     enabled: enabledClient,
     env: process.env,
     cliOpts: config.clientMiddlewareCliOptions ?? {},
+    fileOptions: config.clientMiddlewareFileOptions,
   });
 
   const legacyCliOpts: Record<string, unknown> = {
@@ -119,6 +122,7 @@ export function startProxy(config: ProxyConfig): ProxyHandle {
     enabled,
     env: process.env,
     cliOpts: legacyCliOpts,
+    fileOptions: config.middlewareFileOptions,
   });
 
   const mcpSettings = config.mcp ?? null;

--- a/tests/cli/config-command.test.ts
+++ b/tests/cli/config-command.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+
+/**
+ * CLI integration tests for the `config show` / `config check` commands.
+ * Spawns the real CLI entry point and verifies the end-to-end behavior:
+ * file discovery, user < project merge, `${ENV_VAR}` interpolation, secret
+ * masking, and the exit-code contract of `config check`.
+ */
+
+const CLI_ENTRY = resolve("src/index.ts");
+
+let tmpDir: string;
+let xdgDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-cmd-"));
+  xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-cmd-xdg-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(xdgDir, { recursive: true, force: true });
+});
+
+function spawnConfig(
+  args: string[],
+  envOverrides: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "config", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: tmpDir,
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: xdgDir,
+      HOME: xdgDir,
+      ...envOverrides,
+    },
+  });
+  return (async () => {
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  })();
+}
+
+describe("config check", () => {
+  test("reports OK for a valid project config and prints its path", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { url: "https://x", apiKey: "${MY_KEY}" } }),
+    );
+    const { stdout, exitCode } = await spawnConfig(["check"], { MY_KEY: "v" });
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/OK project: .*\.n8nctlrc\.json/);
+  });
+
+  test("reports OK when no config file exists", async () => {
+    const { stdout, exitCode } = await spawnConfig(["check"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/No configuration file found/);
+  });
+
+  test("fails with exit code 1 on malformed JSON", async () => {
+    fs.writeFileSync(path.join(tmpDir, ".n8nctlrc.json"), "{ nope");
+    const { stderr, exitCode } = await spawnConfig(["check"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Failed to parse configuration file/);
+  });
+
+  test("fails with exit code 1 on an undefined ${VAR} reference", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { apiKey: "${NOT_SET_IN_TEST}" } }),
+    );
+    const { stderr, exitCode } = await spawnConfig(["check"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/\$\{NOT_SET_IN_TEST\}/);
+  });
+});
+
+describe("config show", () => {
+  test("shows sources, masks secrets, and merges user < project", async () => {
+    fs.mkdirSync(path.join(xdgDir, "n8nctl"), { recursive: true });
+    fs.writeFileSync(
+      path.join(xdgDir, "n8nctl", "config.json"),
+      JSON.stringify({ api: { url: "https://user", apiKey: "user-secret" } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({
+        api: { url: "https://project", apiKey: "${MY_KEY}" },
+        proxy: { enforce: "warn" },
+      }),
+    );
+
+    const { stdout, exitCode } = await spawnConfig(["show"], { MY_KEY: "interp-secret" });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      sources: { user?: string; project?: string };
+      effective: { apiURL: string; apiKey: string; proxy: { enforce?: string } };
+      file: { api?: { apiKey: string } };
+    };
+    expect(parsed.sources.user).toBeDefined();
+    expect(parsed.sources.project).toBeDefined();
+    // project wins over user
+    expect(parsed.effective.apiURL).toBe("https://project");
+    // env-interpolated value flows into the effective config but is masked
+    expect(parsed.effective.apiKey).toBe("***");
+    // masking applies to the file view too — even the user-level literal
+    expect(parsed.file.api?.apiKey).toBe("***");
+    expect(stdout).not.toContain("user-secret");
+    expect(stdout).not.toContain("interp-secret");
+    expect(parsed.effective.proxy.enforce).toBe("warn");
+  });
+
+  test("--reveal-secrets shows the effective key unmasked", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { url: "https://x", apiKey: "${MY_KEY}" } }),
+    );
+    const { stdout, exitCode } = await spawnConfig(["show", "--reveal-secrets"], {
+      MY_KEY: "s3cret",
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout) as { effective: { apiKey: string } };
+    expect(parsed.effective.apiKey).toBe("s3cret");
+  });
+
+  test("env var beats file", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { url: "https://file" } }),
+    );
+    const { stdout } = await spawnConfig(["show"], { N8N_API_URL: "https://env" });
+    const parsed = JSON.parse(stdout) as { effective: { apiURL: string } };
+    expect(parsed.effective.apiURL).toBe("https://env");
+  });
+});

--- a/tests/cli/proxy-mcp-file-config.test.ts
+++ b/tests/cli/proxy-mcp-file-config.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { resolveMcpCliOptions } from "@/cli/commands/proxy.ts";
+import { parseMcpSettings } from "@/proxy/mcp/config.ts";
+
+/**
+ * The `.n8nctlrc.json` `proxy.mcp` section feeds the same parser the flags
+ * use, folded at the lowest precedence: CLI flag > env var > config file.
+ * Exported via `resolveMcpCliOptions` — the same testable-seam pattern the
+ * middleware CLI-option extractors use.
+ */
+describe("resolveMcpCliOptions precedence", () => {
+  const file = {
+    enforce: "error" as const,
+    allowTools: ["search_workflows", "get_workflow_details"],
+    workflowTags: ["mcp"],
+    entryPathPattern: "__mcp__/*",
+    cacheTtlMs: 12_000,
+  };
+
+  test("file section supplies values the flags and env do not set", () => {
+    const merged = resolveMcpCliOptions({}, {}, file);
+    expect(merged).toEqual({
+      mcpEnforce: "error",
+      mcpAllowTools: "search_workflows,get_workflow_details",
+      mcpDenyTools: undefined,
+      mcpWorkflowTags: "mcp",
+      mcpEntryPathPattern: "__mcp__/*",
+      mcpCacheTtlMs: "12000",
+    });
+  });
+
+  test("flag beats file", () => {
+    const merged = resolveMcpCliOptions({ mcpEnforce: "warn" }, {}, file);
+    expect(merged.mcpEnforce).toBe("warn");
+    // unset fields still come from the file
+    expect(merged.mcpAllowTools).toBe("search_workflows,get_workflow_details");
+  });
+
+  test("env beats file", () => {
+    const merged = resolveMcpCliOptions({}, { N8N_MCP_ENFORCE: "off" }, file);
+    expect(merged.mcpEnforce).toBe("off");
+  });
+
+  test("flag beats env beats file", () => {
+    const merged = resolveMcpCliOptions({ mcpEnforce: "warn" }, { N8N_MCP_ENFORCE: "off" }, file);
+    expect(merged.mcpEnforce).toBe("warn");
+  });
+
+  test("no file section leaves flags and env untouched", () => {
+    const merged = resolveMcpCliOptions(
+      { mcpEnforce: "warn" },
+      { N8N_MCP_ALLOW_TOOLS: "a,b" },
+      undefined,
+    );
+    expect(merged).toEqual({ mcpEnforce: "warn", mcpAllowTools: "a,b" });
+  });
+});
+
+describe("parseMcpSettings with file-sourced options", () => {
+  test("a file policy builds gate settings when enforce comes from the file too", () => {
+    const merged = resolveMcpCliOptions(
+      {},
+      {},
+      { enforce: "error", allowTools: ["search_workflows"], workflowTags: ["mcp"] },
+    );
+    const settings = parseMcpSettings(merged, {});
+    expect(settings).not.toBeNull();
+    expect(settings!.enforce).toBe("error");
+    expect(settings!.policy.allowTools).toEqual(["search_workflows"]);
+    expect(settings!.policy.workflowTags).toEqual(["mcp"]);
+  });
+
+  test("a file policy without any enforce refuses to start (orphan check)", () => {
+    const merged = resolveMcpCliOptions({}, {}, { allowTools: ["search_workflows"] });
+    expect(() => parseMcpSettings(merged, {})).toThrow(
+      /MCP policy is configured .*--mcp-enforce \/ N8N_MCP_ENFORCE .*proxy\.mcp\.enforce/,
+    );
+  });
+});

--- a/tests/config/rc.test.ts
+++ b/tests/config/rc.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  applyRcApiSection,
+  deepMergeRc,
+  findProjectRcFile,
+  findUserRcFile,
+  interpolateEnvStrings,
+  loadRc,
+  parseRcDuration,
+  parseRcFile,
+  type RcApiSection,
+  warnLiteralSecretsInRc,
+} from "@/config/rc.ts";
+
+let tmpDir: string;
+let xdgDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rc-test-"));
+  xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), "rc-xdg-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(xdgDir, { recursive: true, force: true });
+});
+
+/** Env that isolates the loader from the developer's real user config. */
+function testEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return { XDG_CONFIG_HOME: xdgDir, HOME: xdgDir, ...overrides };
+}
+
+describe("interpolateEnvStrings", () => {
+  test("expands ${VAR} in strings, recursively", () => {
+    const env = { A: "alpha", B: "beta" };
+    const out = interpolateEnvStrings(
+      { a: "${A}", nested: { list: ["${B}", 1, true, null] } },
+      env,
+    );
+    expect(out).toEqual({ a: "alpha", nested: { list: ["beta", 1, true, null] } });
+  });
+
+  test("leaves strings without references untouched", () => {
+    expect(interpolateEnvStrings("${not-a-ref} and $ALSO_NOT", {})).toBe(
+      "${not-a-ref} and $ALSO_NOT",
+    );
+  });
+
+  test("throws on an undefined variable instead of injecting an empty string", () => {
+    expect(() => interpolateEnvStrings("${MISSING_VAR}", {}, "rc.json")).toThrow(
+      /\$\{MISSING_VAR\} \(rc\.json\)/,
+    );
+  });
+});
+
+describe("deepMergeRc", () => {
+  test("merges nested objects, replaces arrays and scalars", () => {
+    const out = deepMergeRc(
+      { api: { url: "a", timeout: "1s" }, proxy: { tags: ["x"], enforce: "warn" } },
+      { api: { timeout: "2s" }, proxy: { tags: ["y", "z"] } },
+    );
+    expect(out).toEqual({
+      api: { url: "a", timeout: "2s" },
+      proxy: { tags: ["y", "z"], enforce: "warn" },
+    });
+  });
+
+  test("override undefined values are ignored", () => {
+    expect(deepMergeRc({ a: 1 }, { a: undefined, b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe("findProjectRcFile", () => {
+  test("prefers .n8nctlrc.json over .n8nlintrc.json in the same directory", () => {
+    const lintrc = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(lintrc, "{}");
+    const ctlrc = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(ctlrc, "{}");
+    expect(findProjectRcFile(tmpDir)).toBe(ctlrc);
+  });
+
+  test("falls back to legacy .n8nlintrc.json", () => {
+    const lintrc = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(lintrc, "{}");
+    expect(findProjectRcFile(tmpDir)).toBe(lintrc);
+  });
+
+  test("nearest directory wins", () => {
+    fs.writeFileSync(path.join(tmpDir, ".n8nctlrc.json"), "{}");
+    const sub = path.join(tmpDir, "sub");
+    fs.mkdirSync(sub);
+    const child = path.join(sub, ".n8nctlrc.json");
+    fs.writeFileSync(child, "{}");
+    expect(findProjectRcFile(sub)).toBe(child);
+  });
+
+  test("returns undefined when no config exists", () => {
+    expect(findProjectRcFile(tmpDir)).toBeUndefined();
+  });
+});
+
+describe("findUserRcFile", () => {
+  test("honors XDG_CONFIG_HOME", () => {
+    expect(findUserRcFile({ XDG_CONFIG_HOME: "/custom/cfg" })).toBe(
+      path.join("/custom/cfg", "n8nctl", "config.json"),
+    );
+  });
+
+  test("falls back to $HOME/.config", () => {
+    expect(findUserRcFile({ HOME: "/home/u" })).toBe(
+      path.join("/home/u", ".config", "n8nctl", "config.json"),
+    );
+  });
+});
+
+describe("parseRcFile", () => {
+  test("parses an all-in-one file", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ api: { url: "https://x" }, middlewares: { client: ["iap-auth"] } }),
+    );
+    expect(parseRcFile(file, {})).toEqual({
+      api: { url: "https://x" },
+      middlewares: { client: ["iap-auth"] },
+    });
+  });
+
+  test("treats a legacy .n8nlintrc.json as the lint section", () => {
+    const file = path.join(tmpDir, ".n8nlintrc.json");
+    fs.writeFileSync(file, JSON.stringify({ rules: { "json-syntax": false } }));
+    const rc = parseRcFile(file, {});
+    expect(rc.lint).toEqual({ rules: { "json-syntax": false } });
+    expect(rc.api).toBeUndefined();
+  });
+
+  test("wraps JSON syntax errors with the file path", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, "{ not json");
+    expect(() => parseRcFile(file, {})).toThrow(/Failed to parse configuration file/);
+  });
+
+  test("rejects non-object sections", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ api: "https://x" }));
+    expect(() => parseRcFile(file, {})).toThrow(/Invalid "api" section/);
+  });
+
+  test("rejects non-string-array middleware lists", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ middlewares: { client: [1, 2] } }));
+    expect(() => parseRcFile(file, {})).toThrow(/middlewares\.client/);
+  });
+
+  test("rejects negative numeric proxy fields", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ proxy: { duplicateTtlMs: -1 } }));
+    expect(() => parseRcFile(file, {})).toThrow(/proxy\.duplicateTtlMs/);
+  });
+
+  test("interpolates ${VAR} during load", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ api: { apiKey: "${MY_KEY}" } }));
+    expect(parseRcFile(file, { MY_KEY: "secret" }).api?.apiKey).toBe("secret");
+  });
+});
+
+describe("loadRc", () => {
+  test("returns empty config when no files exist", () => {
+    const rc = loadRc({ env: testEnv(), cwd: tmpDir });
+    expect(rc.config).toEqual({});
+    expect(rc.sources).toEqual({});
+  });
+
+  test("merges user < project (project wins on conflict)", () => {
+    fs.mkdirSync(path.join(xdgDir, "n8nctl"), { recursive: true });
+    fs.writeFileSync(
+      path.join(xdgDir, "n8nctl", "config.json"),
+      JSON.stringify({ api: { url: "user-url", apiKey: "user-key" } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { url: "project-url" } }),
+    );
+
+    const rc = loadRc({ env: testEnv(), cwd: tmpDir });
+    expect(rc.config.api).toEqual({ url: "project-url", apiKey: "user-key" });
+    expect(rc.sources.user).toBeDefined();
+    expect(rc.sources.project).toBe(path.join(tmpDir, ".n8nctlrc.json"));
+  });
+
+  test("explicit configPath replaces the project layer and wins over user", () => {
+    fs.mkdirSync(path.join(xdgDir, "n8nctl"), { recursive: true });
+    fs.writeFileSync(
+      path.join(xdgDir, "n8nctl", "config.json"),
+      JSON.stringify({ api: { url: "user-url", timeout: "5s" } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { url: "project-url" } }),
+    );
+    const explicit = path.join(tmpDir, "other.json");
+    fs.writeFileSync(explicit, JSON.stringify({ api: { url: "explicit-url" } }));
+
+    const rc = loadRc({ env: testEnv(), cwd: tmpDir, configPath: explicit });
+    // project file is NOT read when --config is given
+    expect(rc.sources.project).toBeUndefined();
+    expect(rc.sources.explicit).toBe(explicit);
+    expect(rc.config.api).toEqual({ url: "explicit-url", timeout: "5s" });
+  });
+
+  test("N8NCTL_CONFIG acts as explicit configPath", () => {
+    const explicit = path.join(tmpDir, "via-env.json");
+    fs.writeFileSync(explicit, JSON.stringify({ api: { url: "env-url" } }));
+    const rc = loadRc({ env: testEnv({ N8NCTL_CONFIG: explicit }), cwd: tmpDir });
+    expect(rc.config.api?.url).toBe("env-url");
+  });
+
+  test("errors when an explicit config file is missing", () => {
+    expect(() =>
+      loadRc({ env: testEnv(), cwd: tmpDir, configPath: path.join(tmpDir, "nope.json") }),
+    ).toThrow(/Configuration file not found/);
+  });
+
+  test("errors on undefined ${VAR} in a config file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { apiKey: "${MISSING}" } }),
+    );
+    expect(() => loadRc({ env: testEnv(), cwd: tmpDir })).toThrow(/\$\{MISSING\}/);
+  });
+});
+
+describe("warnLiteralSecretsInRc", () => {
+  let warnings: string[];
+  const originalError = console.error;
+
+  beforeEach(() => {
+    warnings = [];
+    console.error = (msg?: unknown) => warnings.push(String(msg));
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  test("warns on a literal apiKey in a project file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { apiKey: "literal-secret" } }),
+    );
+    warnLiteralSecretsInRc(loadRc({ env: testEnv(), cwd: tmpDir }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/literal api\.apiKey/);
+  });
+
+  test("does not warn when the key comes from ${VAR}", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ api: { apiKey: "${MY_KEY}" } }),
+    );
+    warnLiteralSecretsInRc(loadRc({ env: testEnv({ MY_KEY: "x" }), cwd: tmpDir }));
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("does not warn on user-level files (not committed to git)", () => {
+    fs.mkdirSync(path.join(xdgDir, "n8nctl"), { recursive: true });
+    fs.writeFileSync(
+      path.join(xdgDir, "n8nctl", "config.json"),
+      JSON.stringify({ api: { apiKey: "literal-secret" } }),
+    );
+    warnLiteralSecretsInRc(loadRc({ env: testEnv(), cwd: tmpDir }));
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe("applyRcApiSection", () => {
+  test("applies the api section", () => {
+    const config = {
+      apiURL: "",
+      apiKey: "",
+      timeoutMs: 30_000,
+      output: "json" as "json" | "table",
+    };
+    const api: RcApiSection = { url: "u", apiKey: "k", timeout: "45s", output: "table" };
+    applyRcApiSection(config, api);
+    expect(config).toEqual({ apiURL: "u", apiKey: "k", timeoutMs: 45_000, output: "table" });
+  });
+
+  test("invalid durations leave the default untouched", () => {
+    const config = {
+      apiURL: "",
+      apiKey: "",
+      timeoutMs: 30_000,
+      output: "json" as "json" | "table",
+    };
+    applyRcApiSection(config, { timeout: "soon" });
+    expect(config.timeoutMs).toBe(30_000);
+  });
+});
+
+describe("parseRcDuration", () => {
+  test("accepts ms/s/m and plain numbers", () => {
+    expect(parseRcDuration("1000")).toBe(1000);
+    expect(parseRcDuration("30s")).toBe(30_000);
+    expect(parseRcDuration("5m")).toBe(300_000);
+    expect(parseRcDuration("250ms")).toBe(250);
+    expect(parseRcDuration("bogus")).toBeNull();
+  });
+});
+
+describe("JSON schema (schemas/n8nctlrc.schema.json)", () => {
+  test("is valid JSON and covers every documented section", () => {
+    const schemaPath = path.join(process.cwd(), "schemas", "n8nctlrc.schema.json");
+    const schema = JSON.parse(fs.readFileSync(schemaPath, "utf-8")) as {
+      properties: Record<string, unknown>;
+    };
+    for (const section of ["api", "lint", "middlewares", "proxy", "$schema"]) {
+      expect(schema.properties[section]).toBeDefined();
+    }
+    const proxyProps = (schema.properties.proxy as { properties: Record<string, unknown> })
+      .properties;
+    for (const key of [
+      "listen",
+      "upstream",
+      "enforce",
+      "logFormat",
+      "logIdentity",
+      "allowDuplicates",
+      "disableRules",
+      "serverMiddlewares",
+      "clientMiddlewares",
+      "tags",
+      "routes",
+      "duplicateTtlMs",
+      "upstreamTimeoutMs",
+    ]) {
+      expect(proxyProps[key]).toBeDefined();
+    }
+  });
+});

--- a/tests/config/rc.test.ts
+++ b/tests/config/rc.test.ts
@@ -161,6 +161,18 @@ describe("parseRcFile", () => {
     expect(() => parseRcFile(file, {})).toThrow(/proxy\.duplicateTtlMs/);
   });
 
+  test("rejects an invalid proxy.mcp.enforce", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ proxy: { mcp: { enforce: "maybe" } } }));
+    expect(() => parseRcFile(file, {})).toThrow(/proxy\.mcp\.enforce/);
+  });
+
+  test("rejects non-string arrays inside proxy.mcp", () => {
+    const file = path.join(tmpDir, ".n8nctlrc.json");
+    fs.writeFileSync(file, JSON.stringify({ proxy: { mcp: { allowTools: [1] } } }));
+    expect(() => parseRcFile(file, {})).toThrow(/proxy\.mcp\.allowTools/);
+  });
+
   test("interpolates ${VAR} during load", () => {
     const file = path.join(tmpDir, ".n8nctlrc.json");
     fs.writeFileSync(file, JSON.stringify({ api: { apiKey: "${MY_KEY}" } }));
@@ -336,8 +348,20 @@ describe("JSON schema (schemas/n8nctlrc.schema.json)", () => {
       "routes",
       "duplicateTtlMs",
       "upstreamTimeoutMs",
+      "mcp",
     ]) {
       expect(proxyProps[key]).toBeDefined();
+    }
+    const mcpProps = (proxyProps.mcp as { properties: Record<string, unknown> }).properties;
+    for (const key of [
+      "enforce",
+      "allowTools",
+      "denyTools",
+      "workflowTags",
+      "entryPathPattern",
+      "cacheTtlMs",
+    ]) {
+      expect(mcpProps[key]).toBeDefined();
     }
   });
 });

--- a/tests/lint/config-n8nctlrc.test.ts
+++ b/tests/lint/config-n8nctlrc.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { findConfigFile, loadLintConfig } from "@/lint/config.ts";
+
+/**
+ * Integration between `.n8nctlrc.json` (all-in-one) and the lint config
+ * loader: discovery order, the `lint` section, and user < project merge.
+ */
+describe("lint config via .n8nctlrc.json", () => {
+  const originalCwd = process.cwd();
+  const originalXdg = process.env.XDG_CONFIG_HOME;
+  let tmpDir: string;
+  let xdgDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-ctlrc-"));
+    xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-ctlrc-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env.XDG_CONFIG_HOME = originalXdg;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(xdgDir, { recursive: true, force: true });
+  });
+
+  function writeUserConfig(config: unknown): void {
+    fs.mkdirSync(path.join(xdgDir, "n8nctl"), { recursive: true });
+    fs.writeFileSync(path.join(xdgDir, "n8nctl", "config.json"), JSON.stringify(config));
+  }
+
+  test("findConfigFile prefers .n8nctlrc.json over .n8nlintrc.json", () => {
+    fs.writeFileSync(path.join(tmpDir, ".n8nlintrc.json"), "{}");
+    fs.writeFileSync(path.join(tmpDir, ".n8nctlrc.json"), "{}");
+    expect(findConfigFile(tmpDir)).toBe(path.join(tmpDir, ".n8nctlrc.json"));
+  });
+
+  test("auto-discovery reads the lint section of .n8nctlrc.json", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({
+        api: { url: "https://x" },
+        lint: { rules: { "schedule-trigger-frequency": ["error", { minInterval: "hourly" }] } },
+      }),
+    );
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    const rc = config.rulesConfig.get("schedule-trigger-frequency");
+    expect(rc).toBeDefined();
+    expect(rc!.severity).toBe("error");
+    expect(rc!.options).toEqual({ minInterval: "hourly" });
+  });
+
+  test("legacy .n8nlintrc.json still auto-discovers (rules at the root)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nlintrc.json"),
+      JSON.stringify({ rules: { "json-syntax": "off" } }),
+    );
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    expect(config.rulesConfig.get("json-syntax")?.enabled).toBe(false);
+  });
+
+  test("user-level lint merges under project-level (project wins)", () => {
+    writeUserConfig({
+      lint: { rules: { "json-syntax": "warning", "orphaned-node": "off" } },
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ lint: { rules: { "json-syntax": "error" } } }),
+    );
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    expect(config.rulesConfig.get("json-syntax")?.severity).toBe("error");
+    expect(config.rulesConfig.get("orphaned-node")?.enabled).toBe(false);
+  });
+
+  test("explicit --lint-config path still wins over everything", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({ lint: { rules: { "json-syntax": "off" } } }),
+    );
+    const explicit = path.join(tmpDir, "custom.json");
+    fs.writeFileSync(explicit, JSON.stringify({ rules: { "json-syntax": "error" } }));
+    process.chdir(tmpDir);
+    expect(loadLintConfig(explicit).rulesConfig.get("json-syntax")?.severity).toBe("error");
+  });
+
+  test("an explicit .n8nctlrc.json path reads its lint section", () => {
+    const subdir = path.join(tmpDir, "elsewhere");
+    fs.mkdirSync(subdir);
+    const explicit = path.join(subdir, ".n8nctlrc.json");
+    fs.writeFileSync(
+      explicit,
+      JSON.stringify({ api: { url: "https://x" }, lint: { rules: { "json-syntax": false } } }),
+    );
+    expect(loadLintConfig(explicit).rulesConfig.get("json-syntax")?.enabled).toBe(false);
+  });
+
+  test("per-project rule overrides work from the all-in-one file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".n8nctlrc.json"),
+      JSON.stringify({
+        lint: { projects: { "proj-1": { rules: { "orphaned-node": "off" } } } },
+      }),
+    );
+    process.chdir(tmpDir);
+    const config = loadLintConfig();
+    expect(config.projectRulesConfig.get("proj-1")?.get("orphaned-node")?.enabled).toBe(false);
+  });
+});

--- a/tests/middleware/file-options.test.ts
+++ b/tests/middleware/file-options.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  buildClientMiddlewares,
+  registerClientFactory,
+  resetClientRegistry,
+} from "@/middleware/client-registry.ts";
+import {
+  buildMiddlewares,
+  registerFactory,
+  resetRegistry,
+  resolveEnabledList,
+} from "@/middleware/registry.ts";
+import type { ClientMiddlewareFactory, ServerMiddlewareFactory } from "@/middleware/types.ts";
+
+/**
+ * The `.n8nctlrc.json` middleware sections (`middlewares.options` keyed by
+ * middleware name) must sit at the lowest precedence: file < env < CLI.
+ * Factories parse file sections through the same `loadFromCLI` contract.
+ */
+interface FakeOptions {
+  fromEnv?: string;
+  fromCli?: string;
+  fromFile?: string;
+}
+
+function fakeServerFactory(name: string): ServerMiddlewareFactory<FakeOptions> {
+  return {
+    name,
+    loadFromEnv: (env) => ({ fromEnv: env[`${name.toUpperCase()}_FROM_ENV`] }),
+    loadFromCLI: (opts) => {
+      const out: Partial<FakeOptions> = {};
+      const cli = opts[`${name}FromCli`];
+      if (typeof cli === "string") out.fromCli = cli;
+      const file = opts[`${name}FromFile`];
+      if (typeof file === "string") out.fromFile = file;
+      return out;
+    },
+    build: () => ({ name, evaluate: () => ({ block: false, violations: [] }) }),
+  };
+}
+
+function fakeClientFactory(name: string): ClientMiddlewareFactory<FakeOptions> {
+  return {
+    name,
+    loadFromEnv: (env) => ({ fromEnv: env[`${name.toUpperCase()}_FROM_ENV`] }),
+    loadFromCLI: (opts) => {
+      const out: Partial<FakeOptions> = {};
+      const cli = opts[`${name}FromCli`];
+      if (typeof cli === "string") out.fromCli = cli;
+      const file = opts[`${name}FromFile`];
+      if (typeof file === "string") out.fromFile = file;
+      return out;
+    },
+    build: () => ({ name, apply: () => {} }),
+  };
+}
+
+const captured: { server: unknown; client: unknown } = { server: undefined, client: undefined };
+
+function capturingServerFactory(name: string): ServerMiddlewareFactory<FakeOptions> {
+  const base = fakeServerFactory(name);
+  return {
+    ...base,
+    build: (opts) => {
+      captured.server = opts;
+      return { name, evaluate: () => ({ block: false, violations: [] }) };
+    },
+  };
+}
+
+function capturingClientFactory(name: string): ClientMiddlewareFactory<FakeOptions> {
+  const base = fakeClientFactory(name);
+  return {
+    ...base,
+    build: (opts) => {
+      captured.client = opts;
+      return { name, apply: () => {} };
+    },
+  };
+}
+
+beforeEach(() => {
+  resetRegistry();
+  resetClientRegistry();
+  registerFactory(capturingServerFactory("fake"));
+  registerClientFactory(capturingClientFactory("fake"));
+});
+afterEach(() => {
+  resetRegistry();
+  resetClientRegistry();
+});
+
+describe("buildMiddlewares with file options", () => {
+  test("file section supplies options the env and CLI do not set", () => {
+    buildMiddlewares({
+      enabled: ["fake"],
+      env: {},
+      cliOpts: {},
+      fileOptions: { fake: { fakeFromFile: "file-value" } },
+    });
+    expect(captured.server).toMatchObject({ fromFile: "file-value" });
+  });
+
+  test("env beats file", () => {
+    buildMiddlewares({
+      enabled: ["fake"],
+      env: { FAKE_FROM_ENV: "env-value" },
+      fileOptions: { fake: { fakeFromFile: "file-value" } },
+    });
+    // Different keys: both survive; verify env key present.
+    expect(captured.server).toMatchObject({ fromEnv: "env-value", fromFile: "file-value" });
+  });
+
+  test("CLI beats file for the same key", () => {
+    buildMiddlewares({
+      enabled: ["fake"],
+      env: {},
+      cliOpts: { fakeFromCli: "cli-value" },
+      fileOptions: { fake: { fakeFromCli: "file-value" } },
+    });
+    expect(captured.server).toMatchObject({ fromCli: "cli-value" });
+    expect(captured.server).not.toHaveProperty("fromFile");
+  });
+
+  test("a middleware with no file section builds as before", () => {
+    buildMiddlewares({ enabled: ["fake"], env: {}, cliOpts: {} });
+    expect(captured.server).toEqual({});
+  });
+
+  test("file sections are per-middleware: others don't see them", () => {
+    registerFactory(capturingServerFactory("other"));
+    buildMiddlewares({
+      enabled: ["fake", "other"],
+      env: {},
+      fileOptions: { fake: { fakeFromFile: "only-fake" } },
+    });
+    // captured holds the last built middleware ("other") — no file options.
+    expect(captured.server).toEqual({});
+  });
+});
+
+describe("buildClientMiddlewares with file options", () => {
+  test("file section reaches the client factory and CLI overrides it", () => {
+    buildClientMiddlewares({
+      enabled: ["fake"],
+      env: {},
+      cliOpts: { fakeFromCli: "cli" },
+      fileOptions: { fake: { fakeFromFile: "file", fakeFromCli: "file" } },
+    });
+    expect(captured.client).toMatchObject({ fromFile: "file", fromCli: "cli" });
+  });
+});
+
+describe("resolveEnabledList fileValue layer", () => {
+  test("CLI > env > file > fallback", () => {
+    const args = {
+      env: { N8N_SERVER_MIDDLEWARES: "env-mw" },
+      envVar: "N8N_SERVER_MIDDLEWARES",
+      fileValue: ["file-mw"],
+      fallback: ["fallback-mw"],
+    };
+    expect(resolveEnabledList({ ...args, cliValue: "cli-mw" })).toEqual(["cli-mw"]);
+    expect(resolveEnabledList({ ...args, cliValue: undefined })).toEqual(["env-mw"]);
+    expect(resolveEnabledList({ ...args, cliValue: undefined, env: {} })).toEqual(["file-mw"]);
+    expect(resolveEnabledList({ ...args, cliValue: undefined, env: {}, fileValue: [] })).toEqual([
+      "fallback-mw",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an all-in-one configuration file, `.n8nctlrc.json`, that covers API connection, lint, middleware, and proxy settings — extending the config-file story beyond the lint-only `.n8nlintrc.json`. The filename is chosen with the planned `n8nctl` rename in mind, so it will not need a second migration.

Two placements are read and merged:

- **User-level**: `$XDG_CONFIG_HOME/n8nctl/config.json` (default `~/.config/n8nctl/config.json`) — the right home for personal values such as API keys
- **Project-level**: `.n8nctlrc.json` discovered by walking up from the working directory — the right home for settings a team commits to the repository

Precedence follows the convention operators already expect:

```
built-in defaults < user file < project file < environment variables < CLI flags
```

Environment variables keep winning over files, so existing direnv- and CI-driven setups behave byte-identically. An explicit file (`--config` flag / `N8NCTL_CONFIG`) replaces the project layer.

What the file covers:

- **`api`**: `url` / `apiKey` / `timeout` / `output` — folded into `resolveConfig` below env and flags
- **`lint`**: the exact shape of the legacy `.n8nlintrc.json`, nested under a `lint` key; auto-discovery goes through the rc loader, and the legacy filename keeps working unchanged (its whole content is treated as the `lint` section; within one directory `.n8nctlrc.json` wins)
- **`middlewares`**: `client` / `server` chains and per-middleware `options` sections. Sections are parsed through the existing `loadFromCLI` contract, so every middleware factory — all 13 builtins — supports the file with zero per-factory code, and secret-carrying restrictions hold (e.g. `api-key-inject` still only accepts an env-var reference, never a raw key)
- **`proxy`**: defaults for `listen`, `upstream`, `enforce`, `log-format`, `disable-rule`, chain lists, `tags`, `routes`, TTLs, and the full `--mcp-*` family via `proxy.mcp`. `parseMcpSettings` remains the single validator, so the orphan-policy check (policy without enforce refuses to start) covers file-sourced policy too, naming `proxy.mcp.enforce` in its message

DX around the file:

- String values support `${ENV_VAR}` interpolation, so secrets stay in the environment while the rest is versioned. Referencing an undefined variable is an **error**, not a silent empty string — the failure the user would see downstream ("API URL is required") no longer points at the file that caused it
- A literal `api.apiKey` in a project-level file triggers a warning: secrets committed to git leak through history
- `n8n-cli config check` — CI-safe validation (JSON syntax, section shape, `${VAR}` resolution; exit 0/1)
- `n8n-cli config show` — the effective merged configuration with its sources, secrets masked (`--reveal-secrets` to unmask)
- `schemas/n8nctlrc.schema.json` ships in the repo; the `$schema` line enables editor completion and validation

## Motivation

Configuration today is split across three surfaces that don't compose: `.n8nlintrc.json` for lint, a dozen `N8N_*` environment variables for API and middleware settings, and ~60 CLI flags on the proxy command. A team deploying the proxy stack (gateway auth, authz, lint policy) cannot express that deployment in version control without shell wrappers around every invocation. The egress middleware path also made API-key-less setups common (`N8N_CLIENT_MIDDLEWARES` supplies credentials), which pushed more and more of the configuration into env vars that no repository records.

## Test plan

- [x] `make quality-gate` (generate-schemas, typecheck, lint, check-third-party-licenses, `bun test`) — 1843 pass
- [x] `make test-integration` (CLI → proxy → mock stack) — 128 pass
- [x] `make build`
- [x] Discovery: walk-up finds `.n8nctlrc.json` (preferred) or legacy `.n8nlintrc.json`; nearest directory wins
- [x] Precedence: user < project for every section; env beats file; CLI flags beat env; explicit `--config` replaces the project layer; `N8NCTL_CONFIG` equivalent
- [x] Interpolation: `${VAR}` expansion in strings/arrays/objects, undefined variable errors with the file path, non-reference strings untouched
- [x] Legacy compatibility: `.n8nlintrc.json` auto-discovery, explicit `--lint-config` paths, per-project rule overrides — existing tests unchanged and passing
- [x] Middleware options: file < env < CLI per option, per-middleware isolation, chain lists via `resolveEnabledList` file layer
- [x] `proxy.mcp`: flag > env > file, orphan-policy check on file-sourced policy, gate starts from file config (live spawn verification)
- [x] `config check` exit-code contract (0 valid/absent, 1 malformed / unresolved `${VAR}`), `config show` masking (no secret material in output)
- [x] Warnings: literal `apiKey` in project file warns once; `${VAR}` and user-level placement do not warn
