### PR TITLE
fix(mcp): attach folder assignments through IAP and the agent gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
       - name: Run tests
         run: bun test
 
-  # Named gate for the CLI → proxy → mock n8n hop. `bun test` above already
-  # includes these files; this job exists so a contract break between the CLI
-  # HTTP client and the proxy shows up as its own required check, not a line
-  # buried in the unit suite.
+  # Named gate for the CLI → [IAP] → proxy → mock n8n hop, including
+  # `import --mcp` folder reads. `bun test` above already includes these
+  # files; this job exists so a contract break between the CLI HTTP client
+  # (REST, webhook, MCP) and the proxy shows up as its own required check,
+  # not a line buried in the unit suite.
   integration:
     name: Integration
     runs-on: ubuntu-latest
@@ -93,7 +94,7 @@ jobs:
       - name: Generate schemas
         run: bun run generate-schemas
 
-      - name: Run CLI → proxy → mock n8n tests
+      - name: Run CLI → [IAP] → proxy → mock n8n tests
         run: bun test tests/integration/
 
   licenses:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ bun test tests/lint/rules/some-rule.test.ts
 bun test tests/integration/cli-through-proxy.test.ts
 ```
 
-`tests/integration/` stands up the full hop `CLI → proxy → mock n8n` in-process (ephemeral ports, no Docker). CI runs it twice on purpose: inside the Test job (`bun test`) and as a dedicated Integration job (`bun test tests/integration/`) that `build` waits on, so a contract break between the CLI HTTP client and the proxy is a required check of its own.
+`tests/integration/` stands up the full hop `CLI → proxy → mock n8n` in-process (ephemeral ports, no Docker), including an IAP stand-in in front of the proxy for `import --mcp` folder reads. CI runs it twice on purpose: inside the Test job (`bun test`) and as a dedicated Integration job (`bun test tests/integration/`) that `build` waits on, so a contract break between the CLI HTTP client (REST, webhook, MCP) and the proxy is a required check of its own.
 
 ## Type Checking
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ n8n-cli import [options]
 | `--cleanup-subfiles` | Delete orphan external files |
 | `--tags <tags>` | Filter by tags (comma-separated, AND condition) |
 | `--mcp` | Attach folder assignments to imported files by calling n8n's MCP server (also enabled by `--mcp-token` / `N8N_MCP_TOKEN` / `N8N_MCP=1`) |
-| `--mcp-token <token>` | MCP access token for the folder lookup (env: `N8N_MCP_TOKEN`). Without a token, MCP calls rely on an n8n-cli proxy injecting the token for `/mcp-server/*` |
+| `--mcp-token <token>` | MCP access token for the folder lookup (env: `N8N_MCP_TOKEN`). Without a token, MCP calls rely on an n8n-cli proxy injecting the token for `/mcp-server/*`. MCP requests use the same client middleware chain as REST (`iap-auth`, `impersonator-token`, …) so they can reach an authenticating gateway in front of that proxy |
 | `--mcp-strict` | Fail the import when the MCP folder lookup fails, instead of warning and continuing without folder information |
 
 ### `folder`
@@ -1353,6 +1353,8 @@ Four things happen, and only the first is cosmetic:
 3. **`tools/call` naming a workflow outside the scope is refused**, with an MCP tool result carrying `isError: true` and the reason — which tag is missing, or which trigger n8n would have entered it through. The agent is told *why* rather than seeing a transport failure.
 4. **`search_workflows` is narrowed rather than refused**, so that what an agent can see and what it can run are the same set. Its results are filtered on the way back against the same policy that governs `tools/call` — by tag, by entry path, or both. Where the policy has tags, they are also merged into the request's own `tags` argument (an AND, the same semantics), which saves n8n from serving rows that would be dropped anyway.
 
+The gate is for agents. `n8n-cli import --mcp` is not. The CLI's egress chain (`iap-auth`, `impersonator-token`) presents a Cloud Run invoker Bearer plus `X-Impersonator-Id-Token`. `oauth-verify` must accept that Bearer as a trusted principal, then `impersonator-verify` rewrites `auth.effective.layer` to `impersonator`. Only then does the gate skip the allowlist and search-narrowing for folder-read verbs (`search_workflows`, `get_workflow_details`, `search_folders`). A header with no verifier does not count; `execute_workflow` stays gated. An agent session with only an MCP Bearer never takes this path, so a production allowlist that omits `get_workflow_details` still hides that verb from agents. Without the verified impersonator, `import --mcp` against that same proxy writes JSON with no `parentFolderId` / `folder` even though the REST import succeeded.
+
 Everything else on the path — `initialize`, notifications, the server-to-client `GET` stream, session teardown — is forwarded untouched, and both `application/json` and `text/event-stream` (Streamable HTTP) replies are handled.
 
 | Flag | Env | Description |
@@ -1780,14 +1782,19 @@ N8N_CLIENT_MIDDLEWARES="bearer-token-inject" \
 N8N_BEARER_TOKEN_INJECT_RULES='[{"pathPrefix":"/mcp-server/","tokenEnvVar":"N8N_MCP_TOKEN"}]' \
 n8n-cli proxy --upstream https://n8n.internal.example.com ...
 
-# CLI side
-N8N_API_URL=https://proxy.internal.example.com n8n-cli import --mcp --yaml
+# CLI side — same IAP egress as REST. Do not put N8N_MCP_TOKEN here; the proxy injects it.
+N8N_API_URL=https://proxy.internal.example.com \
+N8N_CLIENT_MIDDLEWARES="iap-auth,impersonator-token" \
+n8n-cli import --mcp --yaml
 ```
 
 `/mcp-server/*` is transparently forwarded (POST JSON-RPC and SSE streams)
 and never passes the proxy's server-middlewares, so the proxy port itself
 must sit behind an authenticating ingress — anyone who can reach the proxy
-can reach n8n's MCP server with the injected token.
+can reach n8n's MCP server with the injected token. The CLI's MCP client
+uses the same egress middleware chain as REST, so `import --mcp` reaches that
+ingress; without it, REST import succeeds and folder assignments silently
+disappear.
 
 ### Commands
 
@@ -1868,9 +1875,10 @@ an all-in-one alternative to the environment variables below, with precedence
 When n8n sits behind a gateway that authenticates callers per request — for example
 the [`proxy`](#proxy) subcommand deployed in front of it, or an identity-aware proxy —
 point `N8N_API_URL` at the gateway and enable the egress middlewares it expects.
-They run on every request the CLI makes — API calls and the webhook calls behind
-`test` / `webhook call` alike — so ordinary commands (`apply`, `import`,
-`workflow ...`) work unchanged:
+They run on every request the CLI makes — REST API calls, webhook calls behind
+`test` / `webhook call`, and MCP calls behind `import --mcp` alike — so ordinary
+commands (`apply`, `import`, `workflow ...`) work unchanged, including folder
+lookups that sit outside `/api/v1`:
 
 ```bash
 export N8N_API_URL="https://gateway.example.com"
@@ -2021,7 +2029,9 @@ webhook token, an MCP token is a general-purpose credential for the instance, an
 server-middleware chain — anyone who can open a connection to the proxy's port
 gets the token attached on their behalf. Deploy the proxy behind IAP (or an
 equivalent ingress that authenticates every request) and do not expose its port
-directly.
+directly. Callers of that ingress — including `import --mcp` — must send the
+gateway credential via `N8N_CLIENT_MIDDLEWARES`; the CLI's MCP client shares
+that chain with REST and webhook calls.
 
 ### CLAUDE.md Integration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-cli",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/api/mcp-client.ts
+++ b/src/api/mcp-client.ts
@@ -1,3 +1,6 @@
+import { runClientPipeline } from "@/middleware/client-pipeline.ts";
+import type { ClientMiddleware } from "@/middleware/types.ts";
+
 /**
  * Minimal MCP (Model Context Protocol) client for n8n's instance-level MCP
  * server.
@@ -16,6 +19,14 @@
  *     token on its egress (`bearer-token-inject` middleware). The CLI sends
  *     no Authorization header at all in this mode.
  *
+ * The URL lives outside `/api/v1`, so this client does not go through
+ * `Client` — but it leaves the machine through the same door. Without the
+ * egress middleware chain, pointing `N8N_API_URL` at an authenticating
+ * gateway (IAP in front of the proxy) would leave every MCP call as an
+ * unauthenticated request: REST import would succeed while folder
+ * assignments silently disappeared. That is the same seam `callWebhook`
+ * already uses.
+ *
  * Only what n8n-cli needs is implemented: `initialize`, then `tools/call`
  * for the folder-reading tools (`search_workflows`, `get_workflow_details`,
  * `search_folders`).
@@ -30,6 +41,14 @@ export interface McpClientOptions {
   /** MCP access token. Omit in proxy mode — the proxy injects it. */
   token?: string;
   timeoutMs?: number;
+  /**
+   * Egress middlewares, in order. Same chain the REST client and webhook
+   * calls use (`iap-auth`, `impersonator-token`, …). Proxy mode still
+   * sends no MCP Authorization of its own — the chain authenticates the
+   * hop to the gateway; the proxy injects the application token further
+   * downstream.
+   */
+  clientMiddlewares?: ClientMiddleware[];
   /** Override for tests. */
   fetchImpl?: typeof fetch;
 }
@@ -77,6 +96,7 @@ export class McpClient {
   private readonly endpointUrl: string;
   private readonly token?: string;
   private readonly timeoutMs: number;
+  private readonly clientMiddlewares: ClientMiddleware[];
   private readonly fetchImpl: typeof fetch;
   private sessionId?: string;
   private initialized = false;
@@ -85,6 +105,7 @@ export class McpClient {
     this.endpointUrl = opts.endpointUrl;
     this.token = opts.token;
     this.timeoutMs = opts.timeoutMs ?? 30_000;
+    this.clientMiddlewares = opts.clientMiddlewares ?? [];
     this.fetchImpl = opts.fetchImpl ?? fetch;
   }
 
@@ -140,26 +161,47 @@ export class McpClient {
     this.initialized = true;
   }
 
-  /** Sends one JSON-RPC request and returns its `result`. */
   /**
    * Sends a JSON-RPC notification (no id, no response expected). Servers
    * answer 202 or an empty body; anything readable is discarded.
    */
   private async notify(method: string, params: Record<string, unknown>): Promise<void> {
+    await this.postJson({ jsonrpc: "2.0", method, params });
+  }
+
+  /**
+   * POSTs one JSON-RPC envelope, running the egress middleware chain before
+   * fetch so MCP calls authenticate to a gateway the same way REST does.
+   * Middleware failures abort without sending. Transport failures become
+   * `McpError`.
+   */
+  private async postJson(body: unknown): Promise<Response> {
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...(this.sessionId ? { "Mcp-Session-Id": this.sessionId } : {}),
+      ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+    });
+
+    if (this.clientMiddlewares.length > 0) {
+      await runClientPipeline(this.clientMiddlewares, headers, {
+        method: "POST",
+        pathname: new URL(this.endpointUrl).pathname,
+        upstreamUrl: this.endpointUrl,
+      });
+    }
+
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
-      await this.fetchImpl(this.endpointUrl, {
+      return await this.fetchImpl(this.endpointUrl, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json, text/event-stream",
-          ...(this.sessionId ? { "Mcp-Session-Id": this.sessionId } : {}),
-          ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
-        },
-        body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+        headers,
+        body: JSON.stringify(body),
         signal: controller.signal,
       });
+    } catch (err) {
+      throw new McpError(`MCP request failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       clearTimeout(timer);
     }
@@ -170,74 +212,45 @@ export class McpClient {
     params: Record<string, unknown>,
   ): Promise<NonNullable<JsonRpcResponse["result"]>> {
     const id = nextRequestId++;
-    const body = { jsonrpc: "2.0", id, method, params };
+    const resp = await this.postJson({ jsonrpc: "2.0", id, method, params });
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const sessionId = resp.headers.get("Mcp-Session-Id");
+    if (sessionId) this.sessionId = sessionId;
 
-    try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        // Echo the session the server assigned at initialize, if any.
-        ...(this.sessionId ? { "Mcp-Session-Id": this.sessionId } : {}),
-        ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
-      };
+    const text = await resp.text();
 
-      let resp: Response;
-      try {
-        resp = await this.fetchImpl(this.endpointUrl, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        });
-      } catch (err) {
-        throw new McpError(
-          `MCP request failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      const sessionId = resp.headers.get("Mcp-Session-Id");
-      if (sessionId) this.sessionId = sessionId;
-
-      const text = await resp.text();
-
-      if (resp.status === 401 || resp.status === 403) {
-        throw new McpError(
-          `MCP request unauthorized (HTTP ${resp.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
-          resp.status,
-        );
-      }
-      if (!resp.ok) {
-        throw new McpError(
-          `MCP request failed (HTTP ${resp.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
-          resp.status,
-        );
-      }
-
-      // Streamable HTTP may answer with plain JSON or an SSE stream containing
-      // the response. Handle the SSE envelope if it appears.
-      const payload = extractJsonRpcPayload(text);
-
-      if (!payload || typeof payload !== "object") {
-        throw new McpError(`MCP response is not JSON-RPC: ${text.slice(0, 200)}`);
-      }
-      const rpcResp = payload as JsonRpcResponse;
-      if (rpcResp.error) {
-        throw new McpError(
-          rpcResp.error.message || "MCP error",
-          rpcResp.error.code,
-          rpcResp.error.data,
-        );
-      }
-      if (rpcResp.result === undefined) {
-        throw new McpError("MCP response carries no result");
-      }
-      return rpcResp.result;
-    } finally {
-      clearTimeout(timer);
+    if (resp.status === 401 || resp.status === 403) {
+      throw new McpError(
+        `MCP request unauthorized (HTTP ${resp.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+        resp.status,
+      );
     }
+    if (!resp.ok) {
+      throw new McpError(
+        `MCP request failed (HTTP ${resp.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+        resp.status,
+      );
+    }
+
+    // Streamable HTTP may answer with plain JSON or an SSE stream containing
+    // the response. Handle the SSE envelope if it appears.
+    const payload = extractJsonRpcPayload(text);
+
+    if (!payload || typeof payload !== "object") {
+      throw new McpError(`MCP response is not JSON-RPC: ${text.slice(0, 200)}`);
+    }
+    const rpcResp = payload as JsonRpcResponse;
+    if (rpcResp.error) {
+      throw new McpError(
+        rpcResp.error.message || "MCP error",
+        rpcResp.error.code,
+        rpcResp.error.data,
+      );
+    }
+    if (rpcResp.result === undefined) {
+      throw new McpError("MCP response carries no result");
+    }
+    return rpcResp.result;
   }
 }
 

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -112,6 +112,10 @@ export function registerImportCommand(parent: Command): void {
           endpointUrl: deriveMcpEndpointUrl(ctx.config.apiURL),
           ...(mcpSettings.token ? { token: mcpSettings.token } : {}),
           timeoutMs: ctx.config.timeoutMs,
+          // Same egress chain as REST / webhook: IAP in front of the proxy
+          // must see MCP calls too, or folder lookups 403 while import itself
+          // succeeds and the assignment silently disappears.
+          clientMiddlewares: ctx.clientMiddlewares,
         });
         executor.setFolderSource(new McpFolderSource(mcpClient, ctx.folderService));
         if (mcpSettings.mode === "proxy") {

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -34,9 +34,10 @@ export interface GlobalContext {
   folderService: FolderService;
   /**
    * The egress chain the API client uses, exposed so commands that reach
-   * outside `/api/v1` — webhook calls — send the same credentials. Without it
-   * those would be the only unauthenticated requests the CLI makes, and a
-   * gateway would reject them while every other command worked.
+   * outside `/api/v1` — webhook calls and MCP folder lookups — send the same
+   * credentials. Without it those would be the only unauthenticated requests
+   * the CLI makes, and a gateway would reject them while every other command
+   * worked.
    */
   clientMiddlewares: ClientMiddleware[];
 }

--- a/src/proxy/mcp/gate.ts
+++ b/src/proxy/mcp/gate.ts
@@ -14,12 +14,19 @@
  *   4. `search_workflows` results are filtered against that same policy, so the
  *      set an agent can see is the set it can run.
  *
+ * A verified impersonator (the CLI's `impersonator-token`) is an operator, not
+ * an agent. Folder-read tools (`search_workflows`, `get_workflow_details`,
+ * `search_folders`) skip the allowlist and the search filter for that caller,
+ * because `import --mcp` has to attach assignments REST cannot report.
+ * `execute_workflow` and other mutating tools stay gated.
+ *
  * Everything else on the MCP path — `initialize`, `notifications/*`, the
  * server-to-client `GET` stream, session teardown — is forwarded untouched.
  */
 
 import type { Workflow } from "@/api/types.ts";
 import { mcpToolAccessLevel } from "@/middleware/builtin/project-role/mcp-tools.ts";
+import { runPipeline } from "@/middleware/pipeline.ts";
 import type { ServerMiddleware, ServerMiddlewareContext } from "@/middleware/types.ts";
 import type { EnforceLevel } from "../config.ts";
 import {
@@ -49,6 +56,7 @@ import {
 } from "./jsonrpc.ts";
 import {
   hasWorkflowScope,
+  isMcpFolderReadTool,
   isToolAllowed,
   type McpPolicy,
   scanForWorkflowIds,
@@ -129,9 +137,11 @@ export async function handleMcpRequest(
     if (answered) return answered;
   }
 
+  const operatorFolderLookup = await callerIsImpersonatedOperator(req, deps);
+
   const refusals: JsonRpcMessage[] = [];
   for (const message of parsed.messages) {
-    const refusal = await refuse(message, deps, req, reqLog);
+    const refusal = await refuse(message, deps, req, reqLog, operatorFolderLookup);
     if (refusal) refusals.push(refusal);
   }
 
@@ -141,8 +151,12 @@ export async function handleMcpRequest(
   // the result. Without this the agent still sees the name and description of
   // every workflow the token's owner can read, which is the one part of the
   // listing surface n8n gives no way to close.
+  //
+  // An impersonated CLI (`import --mcp`) is not an agent: it needs the
+  // unfiltered listing to attach folder assignments, which REST cannot
+  // report. Do not shrink the search for that caller.
   const narrowedJSON =
-    refusals.length === 0 && deps.enforce === "error"
+    refusals.length === 0 && deps.enforce === "error" && !operatorFolderLookup
       ? narrowSearchArguments(parsed, deps.policy)
       : null;
 
@@ -175,9 +189,10 @@ export async function handleMcpRequest(
 
   const listsTools = parsed.messages.some((m) => m.method === "tools/list");
   const tools = listsTools && (filtersTools(deps.policy) || publishesEntryTool(deps.policy));
-  const searchIds = hasWorkflowScope(deps.policy)
-    ? searchCallIds(parsed.messages)
-    : new Set<string | number>();
+  const searchIds =
+    hasWorkflowScope(deps.policy) && !operatorFolderLookup
+      ? searchCallIds(parsed.messages)
+      : new Set<string | number>();
   if (!tools && searchIds.size === 0) return response;
 
   return filterResponse(response, deps, { tools, searchIds }, reqLog);
@@ -304,6 +319,41 @@ function filtersTools(policy: McpPolicy): boolean {
 }
 
 /**
+ * Authorization middlewares that must not run on the operator-identity probe.
+ * They authorize a *workflow*, and this probe has none.
+ */
+const MCP_OPERATOR_PROBE_SKIP = new Set(["project-role", "authz"]);
+
+/**
+ * True when a verified human is on the other end of this MCP call.
+ *
+ * `import --mcp` sends `impersonator-token` on every request. Agents talking
+ * to the same `/mcp-server/` do not. The agent policy must not strip folder
+ * assignments from the operator path: REST cannot report `parentFolderId`.
+ *
+ * Only identity-populating middlewares run. `project-role` and `authz` need a
+ * workflow this probe does not have — they would deny the lookup itself
+ * (or hit Zeus on every `initialize`). A header without a verifier does
+ * not count: `auth.effective.layer === "impersonator"` is written only by
+ * `impersonator-verify` after a trusted bearer has cleared `oauth-verify`.
+ */
+async function callerIsImpersonatedOperator(req: Request, deps: McpGateDeps): Promise<boolean> {
+  const chain = (deps.middlewares ?? []).filter(
+    (m) => !m.readsWorkflowBody && !MCP_OPERATOR_PROBE_SKIP.has(m.name),
+  );
+  if (chain.length === 0) return false;
+  const ctx: ServerMiddlewareContext = {
+    workflow: null,
+    request: req,
+    mode: "proxy",
+    action: "read",
+  };
+  const verdict = await runPipeline(chain, ctx);
+  if (verdict.block) return false;
+  return ctx.auth?.effective?.layer === "impersonator";
+}
+
+/**
  * Decides whether a single JSON-RPC message is refused, returning the reply to
  * send in its place, or null to let it through.
  */
@@ -312,10 +362,18 @@ async function refuse(
   deps: McpGateDeps,
   req: Request,
   reqLog: Logger,
+  operatorFolderLookup: boolean,
 ): Promise<JsonRpcMessage | null> {
   const tool = toolCallName(message);
   if (tool === null) return null;
   const rpc = typeof message.method === "string" ? message.method : undefined;
+
+  // Operators (verified impersonator) reading folder assignments: skip the
+  // agent allowlist and workflow-tag scope. execute_workflow and friends
+  // still go through the rest of this function.
+  if (operatorFolderLookup && isMcpFolderReadTool(tool)) {
+    return null;
+  }
 
   if (!isToolAllowed(deps.policy, tool)) {
     log(reqLog, deps, `tool "${tool}" is not exposed by this proxy`, {

--- a/src/proxy/mcp/policy.ts
+++ b/src/proxy/mcp/policy.ts
@@ -105,6 +105,25 @@ export function isToolAllowed(policy: McpPolicy, name: string): boolean {
 }
 
 /**
+ * MCP tools `import --mcp` uses to read workflow→folder assignments.
+ *
+ * The agent gate withholds these on purpose (`get_workflow_details` is
+ * huge; `search_workflows` is narrowed to tagged workflows). A human
+ * CLI talking through the same proxy still needs the unfiltered listing
+ * — REST cannot report `parentFolderId`. Callers that have a verified
+ * impersonator identity are operators, not agents.
+ */
+const MCP_FOLDER_READ_TOOLS = new Set([
+  "search_workflows",
+  "get_workflow_details",
+  "search_folders",
+]);
+
+export function isMcpFolderReadTool(name: string): boolean {
+  return MCP_FOLDER_READ_TOOLS.has(name);
+}
+
+/**
  * The workflow id a `tools/call` targets.
  *
  * Returns `undefined` when the tool is not known to target a workflow (nothing

--- a/tests/api/mcp-client.test.ts
+++ b/tests/api/mcp-client.test.ts
@@ -5,6 +5,7 @@ import {
   McpClient,
   McpError,
 } from "../../src/api/mcp-client.ts";
+import type { ClientMiddleware } from "../../src/middleware/types.ts";
 
 /**
  * The MCP client is the only bridge to workflow folder assignments — the
@@ -22,7 +23,7 @@ type Handler = (input: {
 
 function clientWithHandler(
   handler: Handler,
-  token?: string,
+  opts: { token?: string; clientMiddlewares?: ClientMiddleware[] } = {},
 ): {
   client: McpClient;
   requests: Array<{ headers: Record<string, string>; body: Record<string, unknown> }>;
@@ -40,7 +41,8 @@ function clientWithHandler(
 
   const client = new McpClient({
     endpointUrl: "https://n8n.example.com/mcp-server/http",
-    ...(token ? { token } : {}),
+    ...(opts.token ? { token: opts.token } : {}),
+    ...(opts.clientMiddlewares ? { clientMiddlewares: opts.clientMiddlewares } : {}),
     fetchImpl,
   });
   return { client, requests };
@@ -132,7 +134,7 @@ describe("McpClient transport", () => {
   test("direct mode sends the Bearer token; proxy mode sends no Authorization at all", async () => {
     const direct = clientWithHandler(
       ({ body }) => rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),
-      "mcp-secret",
+      { token: "mcp-secret" },
     );
     await direct.client.searchWorkflows();
     expect(direct.requests[0]?.headers.authorization).toBe("Bearer mcp-secret");
@@ -212,5 +214,67 @@ describe("McpClient transport", () => {
     );
     const result = await client.searchWorkflows();
     expect(result.data[0]?.id).toBe("wf-sse");
+  });
+
+  test("egress middlewares run before fetch on initialize, notify, and tool calls", async () => {
+    const saw: string[] = [];
+    const iap: ClientMiddleware = {
+      name: "iap-auth",
+      apply(headers, ctx) {
+        headers.set("Proxy-Authorization", "Bearer iap-id-token");
+        saw.push(`${ctx.method} ${ctx.pathname}`);
+      },
+    };
+    const { client, requests } = clientWithHandler(
+      ({ body }) => rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),
+      { clientMiddlewares: [iap] },
+    );
+
+    await client.searchWorkflows();
+
+    // initialize → notifications/initialized → tools/call
+    expect(saw).toEqual([
+      "POST /mcp-server/http",
+      "POST /mcp-server/http",
+      "POST /mcp-server/http",
+    ]);
+    expect(requests).toHaveLength(3);
+    for (const req of requests) {
+      expect(req.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+      // Proxy mode: the CLI still sends no MCP Authorization. The gateway
+      // token rides a different header so the proxy can inject the app token.
+      expect(req.headers.authorization).toBeUndefined();
+    }
+  });
+
+  test("direct mode keeps the MCP Bearer token while middlewares add other headers", async () => {
+    const iap: ClientMiddleware = {
+      name: "iap-auth",
+      apply(headers) {
+        headers.set("Proxy-Authorization", "Bearer iap-id-token");
+      },
+    };
+    const { client, requests } = clientWithHandler(
+      ({ body }) => rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),
+      { token: "mcp-secret", clientMiddlewares: [iap] },
+    );
+    await client.searchWorkflows();
+    expect(requests[0]?.headers.authorization).toBe("Bearer mcp-secret");
+    expect(requests[0]?.headers["proxy-authorization"]).toBe("Bearer iap-id-token");
+  });
+
+  test("a middleware that throws aborts the call instead of sending it unauthenticated", async () => {
+    const boom: ClientMiddleware = {
+      name: "boom",
+      apply() {
+        throw new Error("no credentials");
+      },
+    };
+    const { client, requests } = clientWithHandler(
+      ({ body }) => rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),
+      { clientMiddlewares: [boom] },
+    );
+    await expect(client.searchWorkflows()).rejects.toThrow("no credentials");
+    expect(requests).toHaveLength(0);
   });
 });

--- a/tests/integration/cli-folders.test.ts
+++ b/tests/integration/cli-folders.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { registerFactory } from "@/middleware/registry.ts";
+import type { ServerMiddleware, ServerMiddlewareFactory } from "@/middleware/types.ts";
+import { startIapGate } from "./helpers/iap-gate.ts";
 import { withStack } from "./helpers/stack.ts";
 import { cleanWorkflow } from "./helpers/workflows.ts";
 
@@ -13,9 +16,29 @@ import { cleanWorkflow } from "./helpers/workflows.ts";
  * The scenarios here prove the three deployment shapes: the CLI holding an
  * MCP token, a proxy injecting one (the CLI has none), and no MCP at all.
  * Apply's folder moves ride the PATCH endpoint the same way.
+ *
+ * A fourth hop — IAP in front of the proxy — is required to catch the
+ * production failure mode: REST import succeeding while MCP 403s because
+ * `McpClient` skipped the CLI's egress chain. Without that front door the
+ * proxy-inject test stays green even when MCP never authenticates.
  */
 
 const MCP_TOKEN_VAR = "N8N_TEST_MCP_TOKEN";
+const IAP_TOKEN = "iap-id-token";
+const IAP_TOKEN_VAR = "TEST_IAP_ID_TOKEN";
+
+/** CLI env for talking through the IAP gate. No MCP token — the proxy injects it. */
+function cliIapEnv(): Record<string, string> {
+  return {
+    N8N_MCP_TOKEN: "",
+    N8N_CLIENT_MIDDLEWARES: "iap-auth",
+    N8N_IAP_AUTH_TOKEN_SOURCE: "env",
+    N8N_IAP_AUTH_TOKEN_ENV_VAR: IAP_TOKEN_VAR,
+    [IAP_TOKEN_VAR]: IAP_TOKEN,
+    N8N_IAP_AUTH_HEADER_NAME: "proxy-authorization",
+    N8N_IAP_AUTH_AUDIENCE: "https://example.com/gateway",
+  };
+}
 
 function seed() {
   return {
@@ -124,6 +147,217 @@ describe("CLI → proxy → mock n8n: folder assignments via MCP", () => {
           { N8N_MCP_TOKEN: "" },
         );
         expect(exitCode).toBe(1);
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("CLI → IAP → proxy → mock n8n: folder assignments via MCP", () => {
+  function proxyInjectingMcp() {
+    return {
+      ...seed(),
+      clientMiddlewares: ["bearer-token-inject"],
+      clientMiddlewareCliOptions: {
+        bearerTokenInjectRules: JSON.stringify([
+          { pathPrefix: "/mcp-server/", tokenEnvVar: MCP_TOKEN_VAR },
+        ]),
+      },
+      proxyEnv: { [MCP_TOKEN_VAR]: "mcp-secret" },
+    };
+  }
+
+  test("the IAP front door rejects the CLI when egress middlewares are off", async () => {
+    await withStack(proxyInjectingMcp(), async (stack) => {
+      const gate = startIapGate({ upstream: stack.proxyUrl, token: IAP_TOKEN });
+      try {
+        const { exitCode, stderr } = await stack.runCli(
+          ["workflow", "list"],
+          { N8N_MCP_TOKEN: "" },
+          { apiUrl: gate.url },
+        );
+        expect(exitCode).toBe(1);
+        expect(stderr).toMatch(/403|Forbidden|Invalid IAP/i);
+        expect(gate.captured.some((r) => r.hasIap)).toBe(false);
+      } finally {
+        await gate.stop();
+      }
+    });
+  });
+
+  test("CLI iap-auth + proxy MCP inject writes parentFolderId and folder on JSON import", async () => {
+    const dir = tmpDir();
+    try {
+      await withStack(proxyInjectingMcp(), async (stack) => {
+        const gate = startIapGate({ upstream: stack.proxyUrl, token: IAP_TOKEN });
+        try {
+          const { exitCode, stderr } = await stack.runCli(
+            ["import", "-d", dir, "--no-yaml", "--no-ts", "--mcp", "--ids", "wf-a"],
+            cliIapEnv(),
+            { apiUrl: gate.url },
+          );
+          expect(exitCode).toBe(0);
+          expect(stderr).not.toContain("folder information unavailable");
+
+          const mcpAtGate = gate.captured.filter((r) => r.pathname === "/mcp-server/http");
+          expect(mcpAtGate.length).toBeGreaterThan(0);
+          expect(mcpAtGate.every((r) => r.hasIap)).toBe(true);
+          // IAP-only: the CLI has not minted an impersonator header yet.
+          expect(mcpAtGate.every((r) => r.hasImpersonator)).toBe(false);
+          // Proxy mode: the CLI must not carry an MCP Authorization through IAP.
+          expect(mcpAtGate.every((r) => r.authorization === undefined)).toBe(true);
+
+          const mcpAtMock = stack.mock.captured.filter((r) => r.pathname === "/mcp-server/http");
+          expect(mcpAtMock.length).toBeGreaterThan(0);
+          for (const req of mcpAtMock) {
+            expect(req.headers.authorization).toBe("Bearer mcp-secret");
+            expect(req.headers["proxy-authorization"]).toBeUndefined();
+          }
+
+          const written = JSON.parse(
+            fs.readFileSync(path.join(dir, "alpha__wf-a.json"), "utf-8"),
+          ) as { parentFolderId?: string | null; folder?: string | null };
+          expect(written.parentFolderId).toBe("fold-2");
+          expect(written.folder).toBe("Reporting/Daily");
+        } finally {
+          await gate.stop();
+        }
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Stands in for impersonator-verify: any request carrying the CLI's
+ * impersonator header is a verified human. Agents do not send that header.
+ */
+function impersonatorPresenceFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "impersonator-presence",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "impersonator-presence",
+      evaluate(ctx) {
+        if (ctx.request?.headers.get("x-impersonator-id-token")) {
+          ctx.auth = { effective: { email: "operator@example.com", layer: "impersonator" } };
+        }
+        return { block: false, violations: [] };
+      },
+    }),
+  };
+}
+
+describe("CLI → IAP → gated proxy → mock n8n: operator folder reads", () => {
+  const IMPERSONATOR_VAR = "TEST_IMPERSONATOR_TOKEN";
+
+  function productionLikeProxy() {
+    return {
+      ...seed(),
+      clientMiddlewares: ["bearer-token-inject"],
+      clientMiddlewareCliOptions: {
+        bearerTokenInjectRules: JSON.stringify([
+          { pathPrefix: "/mcp-server/", tokenEnvVar: MCP_TOKEN_VAR },
+        ]),
+      },
+      proxyEnv: { [MCP_TOKEN_VAR]: "mcp-secret" },
+      middlewares: ["impersonator-presence"],
+      mcp: {
+        enforce: "error" as const,
+        policy: {
+          // Production agent allowlist: no get_workflow_details.
+          allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+          denyTools: [],
+          workflowTags: ["mcp"],
+        },
+        cacheTtlMs: 60_000,
+      },
+    };
+  }
+
+  function cliOperatorEnv(): Record<string, string> {
+    return {
+      ...cliIapEnv(),
+      N8N_CLIENT_MIDDLEWARES: "iap-auth,impersonator-token",
+      N8N_IMPERSONATOR_TOKEN_SOURCE: "env",
+      N8N_IMPERSONATOR_TOKEN_ENV_VAR: IMPERSONATOR_VAR,
+      N8N_IMPERSONATOR_TOKEN_AUDIENCE: "https://example.com/impersonator",
+      [IMPERSONATOR_VAR]: "user-tok",
+    };
+  }
+
+  test("agent MCP policy does not strip folder assignments from an impersonated import --mcp", async () => {
+    registerFactory(impersonatorPresenceFactory());
+    const dir = tmpDir();
+    try {
+      await withStack(productionLikeProxy(), async (stack) => {
+        const gate = startIapGate({ upstream: stack.proxyUrl, token: IAP_TOKEN });
+        try {
+          const { exitCode, stderr } = await stack.runCli(
+            ["import", "-d", dir, "--no-yaml", "--no-ts", "--mcp", "--ids", "wf-a"],
+            cliOperatorEnv(),
+            { apiUrl: gate.url },
+          );
+          expect(exitCode).toBe(0);
+          expect(stderr).not.toContain("folder information unavailable");
+          expect(stderr).not.toContain("Unknown tool");
+
+          const mcpAtGate = gate.captured.filter((r) => r.pathname === "/mcp-server/http");
+          expect(mcpAtGate.length).toBeGreaterThan(0);
+          expect(mcpAtGate.every((r) => r.hasIap)).toBe(true);
+          expect(mcpAtGate.every((r) => r.hasImpersonator)).toBe(true);
+
+          const written = JSON.parse(
+            fs.readFileSync(path.join(dir, "alpha__wf-a.json"), "utf-8"),
+          ) as { parentFolderId?: string | null; folder?: string | null };
+          // wf-a is not mcp-tagged. An agent search would omit it; the
+          // operator path must still attach the assignment REST cannot report.
+          expect(written.parentFolderId).toBe("fold-2");
+          expect(written.folder).toBe("Reporting/Daily");
+        } finally {
+          await gate.stop();
+        }
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the same gated proxy strips folder assignments when the CLI is not impersonated", async () => {
+    registerFactory(impersonatorPresenceFactory());
+    const dir = tmpDir();
+    try {
+      await withStack(productionLikeProxy(), async (stack) => {
+        const gate = startIapGate({ upstream: stack.proxyUrl, token: IAP_TOKEN });
+        try {
+          const { exitCode, stderr } = await stack.runCli(
+            ["import", "-d", dir, "--no-yaml", "--no-ts", "--mcp", "--ids", "wf-a"],
+            cliIapEnv(),
+            { apiUrl: gate.url },
+          );
+          expect(exitCode).toBe(0);
+          // Search is on the allowlist so MCP itself succeeds; the agent
+          // policy then omits untagged wf-a and refuses get_workflow_details.
+          // That is silent — REST still writes the file — which is why this
+          // used to ship as "import worked".
+          expect(stderr).not.toMatch(/403|Invalid IAP/i);
+
+          const mcpAtGate = gate.captured.filter((r) => r.pathname === "/mcp-server/http");
+          expect(mcpAtGate.length).toBeGreaterThan(0);
+          expect(mcpAtGate.every((r) => r.hasIap)).toBe(true);
+          expect(mcpAtGate.every((r) => r.hasImpersonator)).toBe(false);
+
+          const written = JSON.parse(
+            fs.readFileSync(path.join(dir, "alpha__wf-a.json"), "utf-8"),
+          ) as { parentFolderId?: string | null; folder?: string | null };
+          expect(written.parentFolderId).toBeUndefined();
+          expect(written.folder).toBeUndefined();
+        } finally {
+          await gate.stop();
+        }
       });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/tests/integration/helpers/iap-gate.ts
+++ b/tests/integration/helpers/iap-gate.ts
@@ -1,0 +1,90 @@
+/**
+ * A stand-in for Google IAP in front of the n8n-cli proxy.
+ *
+ * Production folder-read looks like:
+ *
+ *   CLI (iap-auth) → IAP → proxy (bearer-token-inject on /mcp-server/) → n8n MCP
+ *
+ * The existing CLI→proxy→mock stack never had this front door, so
+ * `import --mcp` could succeed in CI while MCP calls 403'd against a real
+ * IAP-protected proxy. This gate is the missing hop: HTML 403 unless
+ * `Proxy-Authorization` carries the expected id_token, then the request is
+ * forwarded with that hop-by-hop header stripped — the same split IAP
+ * documents.
+ */
+
+export interface IapGateCapture {
+  method: string;
+  pathname: string;
+  hasIap: boolean;
+  hasImpersonator: boolean;
+  authorization?: string;
+}
+
+export interface IapGate {
+  port: number;
+  url: string;
+  captured: IapGateCapture[];
+  stop: () => Promise<void>;
+}
+
+export function startIapGate(opts: {
+  upstream: string;
+  token: string;
+  /** Header IAP authenticates on. Default matches N8N_IAP_AUTH_HEADER_NAME=proxy-authorization. */
+  headerName?: string;
+}): IapGate {
+  const headerName = opts.headerName ?? "proxy-authorization";
+  const captured: IapGateCapture[] = [];
+  const upstream = opts.upstream.replace(/\/+$/, "");
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const provided = req.headers.get(headerName);
+      const hasIap = provided === `Bearer ${opts.token}`;
+      const authorization = req.headers.get("authorization") ?? undefined;
+      captured.push({
+        method: req.method,
+        pathname: url.pathname,
+        hasIap,
+        hasImpersonator: Boolean(req.headers.get("x-impersonator-id-token")),
+        ...(authorization ? { authorization } : {}),
+      });
+
+      if (!hasIap) {
+        // Google IAP answers HTML, not JSON — that is what the production
+        // failure looked like (`MCP request unauthorized (HTTP 403): <html>…`).
+        return new Response(
+          "<html><head><title>403 Forbidden</title></head><body>Invalid IAP credentials.</body></html>",
+          { status: 403, headers: { "content-type": "text/html; charset=UTF-8" } },
+        );
+      }
+
+      const headers = new Headers(req.headers);
+      headers.delete(headerName);
+      headers.delete("host");
+      headers.delete("content-length");
+      headers.delete("transfer-encoding");
+      headers.delete("connection");
+
+      const target = `${upstream}${url.pathname}${url.search}`;
+      const body =
+        req.method === "GET" || req.method === "HEAD" ? undefined : await req.arrayBuffer();
+      return fetch(target, {
+        method: req.method,
+        headers,
+        body,
+        redirect: "manual",
+      });
+    },
+  });
+
+  return {
+    port: server.port!,
+    url: `http://127.0.0.1:${server.port}`,
+    captured,
+    stop: () => server.stop(true),
+  };
+}

--- a/tests/integration/helpers/stack.ts
+++ b/tests/integration/helpers/stack.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { EnforceLevel } from "@/proxy/config.ts";
+import type { McpGateSettings } from "@/proxy/mcp/config.ts";
 import { type ProxyHandle, startProxy } from "@/proxy/server.ts";
 import { type N8nMock, type N8nMockOptions, startN8nMock } from "./n8n-mock.ts";
 
@@ -15,7 +16,11 @@ export interface Stack {
   mock: N8nMock;
   proxy: ProxyHandle;
   proxyUrl: string;
-  runCli: (args: string[], env?: Record<string, string>) => Promise<CliResult>;
+  runCli: (
+    args: string[],
+    env?: Record<string, string>,
+    opts?: { apiUrl?: string },
+  ) => Promise<CliResult>;
   stop: () => Promise<void>;
 }
 
@@ -32,6 +37,8 @@ export interface StackOptions extends N8nMockOptions {
    * API key. Restored when the stack stops.
    */
   proxyEnv?: Record<string, string>;
+  /** MCP gate policy. Absent = transparent `/mcp-server/` forward. */
+  mcp?: McpGateSettings;
 }
 
 /**
@@ -64,6 +71,7 @@ export async function startStack(opts: StackOptions = {}): Promise<Stack> {
       ...(opts.clientMiddlewareCliOptions
         ? { clientMiddlewareCliOptions: opts.clientMiddlewareCliOptions }
         : {}),
+      ...(opts.mcp ? { mcp: opts.mcp } : {}),
     });
     await waitReady(proxy.port);
   } catch (err) {
@@ -79,7 +87,7 @@ export async function startStack(opts: StackOptions = {}): Promise<Stack> {
     mock,
     proxy,
     proxyUrl,
-    runCli: (args, env) => runCli(proxyUrl, args, env),
+    runCli: (args, env, opts) => runCli(opts?.apiUrl ?? proxyUrl, args, env),
     stop: async () => {
       await proxy.stop();
       await mock.stop();

--- a/tests/proxy/proxy.mcp-gate.test.ts
+++ b/tests/proxy/proxy.mcp-gate.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { IdTokenVerifier, VerifiedClaim } from "@/middleware/auth/types.ts";
+import { ImpersonatorVerifyMiddleware } from "@/middleware/builtin/impersonator-verify/middleware.ts";
+import { OAuthVerifyMiddleware } from "@/middleware/builtin/oauth-verify/middleware.ts";
 import { registerFactory } from "@/middleware/registry.ts";
 import type { ServerMiddleware, ServerMiddlewareFactory } from "@/middleware/types.ts";
 import type { EnforceLevel } from "@/proxy/config.ts";
@@ -1034,5 +1037,245 @@ describe("MCP gate: identity logging opt-in", () => {
     expect(line.identity).toBe("user@example.com");
     expect(line.identitySource).toBe("impersonator-verify");
     expect(line.identityVerified).toBe(true);
+  });
+});
+
+describe("MCP gate: impersonated CLI folder lookups", () => {
+  test("an agent still cannot call get_workflow_details when it is off the allowlist", async () => {
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+    );
+    const reply = await call("tools/call", {
+      name: "get_workflow_details",
+      arguments: { workflowId: "wf-internal" },
+    });
+    expect(reply.error).toMatchObject({ message: "Unknown tool: get_workflow_details" });
+  });
+
+  test("a verified impersonator can call get_workflow_details even when it is off the allowlist", async () => {
+    registerFactory(identityStubFactory());
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+      "error",
+      { middlewares: ["identity-stub"] },
+    );
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      { "x-impersonator-email": "operator@example.com" },
+    );
+    expect(reply.error).toBeUndefined();
+    expect((reply.result as { content: Array<{ text: string }> }).content[0]?.text).toBe(
+      "ran get_workflow_details",
+    );
+  });
+
+  test("a verified impersonator sees unfiltered search_workflows results", async () => {
+    registerFactory(identityStubFactory());
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+      "error",
+      { middlewares: ["identity-stub"] },
+    );
+    const reply = await call(
+      "tools/call",
+      { name: "search_workflows", arguments: {} },
+      { "x-impersonator-email": "operator@example.com" },
+    );
+    const result = reply.result as {
+      structuredContent?: { data?: Array<{ id: string }>; count?: number };
+    };
+    const ids = (result.structuredContent?.data ?? []).map((w) => w.id);
+    expect(ids).toContain("wf-internal");
+    expect(ids).toContain("wf-open");
+    expect(result.structuredContent?.count).toBe(WORKFLOWS.length);
+  });
+
+  test("execute_workflow stays gated for an impersonator", async () => {
+    registerFactory(identityStubFactory());
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+      "error",
+      { middlewares: ["identity-stub"] },
+    );
+    const reply = await call(
+      "tools/call",
+      { name: "execute_workflow", arguments: { workflowId: "wf-internal" } },
+      { "x-impersonator-email": "operator@example.com" },
+    );
+    const result = reply.result as { isError?: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Not available over MCP/);
+  });
+
+  test("a spoofed impersonator header does not bypass the allowlist without a verifier", async () => {
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+    );
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      { "x-impersonator-id-token": "forged", "x-impersonator-email": "operator@example.com" },
+    );
+    expect(reply.error).toMatchObject({ message: "Unknown tool: get_workflow_details" });
+  });
+
+  test("authz that would deny a bodyless probe does not strip operator folder reads", async () => {
+    registerFactory(identityStubFactory());
+    registerFactory(blockingAuthzFactory());
+    start(
+      policy({
+        allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+        workflowTags: ["mcp"],
+      }),
+      "error",
+      { middlewares: ["identity-stub", "blocking-authz"] },
+    );
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      { "x-impersonator-email": "operator@example.com" },
+    );
+    expect(reply.error).toBeUndefined();
+    expect((reply.result as { content: Array<{ text: string }> }).content[0]?.text).toBe(
+      "ran get_workflow_details",
+    );
+  });
+});
+
+const PROXY_AUD = "https://n8n-proxy.example.run.app";
+const SA_EMAIL = "n8n-proxy-caller@example.com";
+const USER_AUD = "example-oauth-client.apps.example.com";
+const AGENT_ALLOWLIST = {
+  allowTools: ["search_workflows", "execute_workflow", "get_workflow_entry"],
+  workflowTags: ["mcp"],
+};
+
+function staticVerifier(tokens: Record<string, VerifiedClaim>): IdTokenVerifier {
+  return {
+    verify: async (token) => tokens[token] ?? null,
+  };
+}
+
+/** Production identity pair, with in-process verifiers instead of tokeninfo. */
+function productionIdentityFactories(): void {
+  registerFactory({
+    name: "oauth-verify-test",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: () =>
+      new OAuthVerifyMiddleware({
+        enforce: "deny",
+        expectedAudiences: [PROXY_AUD],
+        trustedPrincipals: [SA_EMAIL],
+        verifier: staticVerifier({
+          "sa-tok": { email: SA_EMAIL, emailVerified: true, aud: PROXY_AUD },
+        }),
+      }),
+  });
+  registerFactory({
+    name: "impersonator-verify-test",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: () =>
+      new ImpersonatorVerifyMiddleware({
+        enforce: "deny",
+        requirement: "require",
+        expectedAudiences: [USER_AUD],
+        verifier: staticVerifier({
+          "user-tok": {
+            email: "operator@example.com",
+            emailVerified: true,
+            aud: USER_AUD,
+            iss: "https://accounts.google.com",
+          },
+        }),
+      }),
+  });
+}
+
+function blockingAuthzFactory(): ServerMiddlewareFactory<object> {
+  return {
+    name: "blocking-authz",
+    loadFromEnv: () => ({}),
+    loadFromCLI: () => ({}),
+    build: (): ServerMiddleware => ({
+      name: "authz",
+      evaluate: () => ({
+        block: true,
+        violations: [
+          {
+            rule: "authz-denied",
+            severity: "error",
+            message: "authz would deny a probe with no workflow",
+          },
+        ],
+        denial: { status: 403, error: "workflow_authz_denied", message: "authz blocked" },
+      }),
+    }),
+  };
+}
+
+describe("MCP gate: production oauth-verify + impersonator-verify folder lookups", () => {
+  const cliHeaders = {
+    authorization: "Bearer sa-tok",
+    "x-impersonator-id-token": "user-tok",
+  };
+
+  test("the CLI's Cloud Run bearer + impersonator token unlocks get_workflow_details", async () => {
+    productionIdentityFactories();
+    start(policy(AGENT_ALLOWLIST), "error", {
+      middlewares: ["oauth-verify-test", "impersonator-verify-test"],
+    });
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      cliHeaders,
+    );
+    expect(reply.error).toBeUndefined();
+    expect((reply.result as { content: Array<{ text: string }> }).content[0]?.text).toBe(
+      "ran get_workflow_details",
+    );
+  });
+
+  test("an MCP Bearer that is not a trusted Cloud Run token stays on the agent allowlist", async () => {
+    productionIdentityFactories();
+    start(policy(AGENT_ALLOWLIST), "error", {
+      middlewares: ["oauth-verify-test", "impersonator-verify-test"],
+    });
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      { authorization: "Bearer mcp-secret" },
+    );
+    expect(reply.error).toMatchObject({ message: "Unknown tool: get_workflow_details" });
+  });
+
+  test("a trusted Cloud Run bearer without an impersonator token stays on the agent allowlist", async () => {
+    productionIdentityFactories();
+    start(policy(AGENT_ALLOWLIST), "error", {
+      middlewares: ["oauth-verify-test", "impersonator-verify-test"],
+    });
+    const reply = await call(
+      "tools/call",
+      { name: "get_workflow_details", arguments: { workflowId: "wf-internal" } },
+      { authorization: "Bearer sa-tok" },
+    );
+    expect(reply.error).toMatchObject({ message: "Unknown tool: get_workflow_details" });
   });
 });


### PR DESCRIPTION
## Summary

`import --mcp` through the n8n-cli proxy now actually attaches folder assignments (`parentFolderId` / `folder`). Two hops were missing from the existing CLI → proxy → mock stack, and both had to fail in the same way production did before the path was real.

The public REST API never returns which folder a workflow sits in, so import reads that assignment over n8n's instance-level MCP server. That MCP call left the machine through a raw `fetch`, while REST and webhook already ran `ctx.clientMiddlewares` (`iap-auth`, `impersonator-token`). Against an authenticating gateway the REST import succeeded and MCP 403'd with IAP HTML — JSON was written with no folder keys. The CLI still sends **no** MCP `Authorization` in proxy mode; the proxy injects the token on `/mcp-server/*`.

Fixing IAP is not enough on its own. Production n8n-proxy gates MCP for agents (`N8N_MCP_ALLOW_TOOLS=search_workflows,get_workflow_entry,execute_workflow`, no `get_workflow_details`, search narrowed to in-policy workflows). The same CLI talking through that gate still got a successful REST import and JSON with no folder keys: search omitted the untagged workflow and `get_workflow_details` came back `Unknown tool`. A verified impersonator (`oauth-verify` trusted Cloud Run bearer + `impersonator-verify`) is an operator, not an agent, so folder-read verbs (`search_workflows`, `get_workflow_details`, `search_folders`) skip the allowlist and the search filter for that caller. `execute_workflow` stays gated. A spoofed `X-Impersonator-Id-Token` without a verifier does not count.

The operator-identity probe runs only identity-populating middlewares. `project-role` and `authz` need a workflow this probe does not have — they would deny the lookup itself, or hit Zeus on every `initialize`.

**Deploy:** live `import --mcp` against current n8n-proxy also needs this proxy binary. The CLI IAP fix alone cannot attach folders while production still serves the old gate.

Bump to 2.23.0.

## Motivation

#82 added folder membership as code, with `import --mcp` as the only read path for a write-only REST field. The proxy already had bearer-token-inject for `/mcp-server/*` and the CLI already had IAP egress for webhook. Neither was wired to MCP, and the existing integration tests never stood an IAP front door or a production-like agent allowlist in front of the proxy — so token-inject stayed green while production wrote JSON with no `parentFolderId` / `folder`. Teams using n8n-workflows' folder-as-code import cannot place files until this hop is the same one REST already takes, and until the agent gate does not strip operator folder reads.

## Test plan

- [x] `make quality-gate` (generate-schemas, typecheck, lint, check-third-party-licenses, `bun test`) — 1955 pass
- [x] `bun test tests/integration` — CLI → [IAP] → proxy → mock, including `import --mcp` folder reads
- [x] `make build` + size-check
- [x] MCP egress: middlewares run on initialize / notify / tool call; proxy mode still has no MCP Bearer; a middleware throw sends nothing
- [x] IAP stand-in rejects the CLI with no egress (HTML 403, the production failure); `iap-auth` + proxy inject writes `parentFolderId` / `folder` on JSON; MCP through IAP carries no MCP `Authorization`
- [x] Production-like agent gate + impersonated CLI attaches folders for an untagged workflow; the same gated proxy strips them when the CLI is not impersonated (REST succeeds, search withholds the row, `get_workflow_details` is unknown — silent missing keys)
- [x] Real `oauth-verify` + `impersonator-verify`: Cloud Run Bearer + impersonator token unlocks `get_workflow_details`; MCP Bearer does not; SA Bearer without impersonator does not; spoofed header without a verifier does not; `authz` that would deny a bodyless probe does not strip operator folder reads; `execute_workflow` stays gated