### PR TITLE
fix(import): look up folder assignments by name when search hits the 200 cap

### DIFF
--- a/src/api/mcp-client.ts
+++ b/src/api/mcp-client.ts
@@ -124,12 +124,13 @@ export class McpClient {
 
   /** SearchWorkflows calls n8n's `search_workflows` tool. */
   async searchWorkflows(
-    args: { limit?: number; projectId?: string; sortBy?: string } = {},
+    args: { limit?: number; projectId?: string; sortBy?: string; query?: string } = {},
   ): Promise<{ data: Array<Record<string, unknown>>; count?: number }> {
     const result = await this.callTool<Record<string, unknown>>("search_workflows", {
       limit: args.limit ?? 200,
       ...(args.projectId ? { projectId: args.projectId } : {}),
       ...(args.sortBy ? { sortBy: args.sortBy } : {}),
+      ...(args.query ? { query: args.query } : {}),
     });
     const data = Array.isArray(result.data) ? result.data : [];
     return { data, count: typeof result.count === "number" ? result.count : undefined };

--- a/src/importer/folder-source.ts
+++ b/src/importer/folder-source.ts
@@ -11,8 +11,13 @@ import { workflowProjectId } from "@/common/project-id.ts";
  * The public REST API never returns which folder a workflow sits in
  * (`parentFolderId` is `writeOnly` in n8n's schema), so `import` can only
  * attach folder assignments when an MCP connection is available: the MCP
- * `search_workflows` tool does include `parentFolderId` per workflow, and
- * `get_workflow_details` fills gaps for workflows the search does not cover.
+ * `search_workflows` tool does include `parentFolderId` per workflow.
+ *
+ * The tool's max `limit` is 200 and it has no cursor, so a bulk listing
+ * misses older workflows on a large instance. `get_workflow_details` also
+ * cannot fill those gaps: n8n refuses it unless `settings.availableInMCP` is
+ * on, which most as-code workflows are not. Name-filtered `search_workflows`
+ * is the fallback that still returns `parentFolderId`.
  */
 export interface FolderInfo {
   /**
@@ -33,37 +38,67 @@ export class McpFolderSource {
   /**
    * Builds the folder info for the given remote workflows.
    *
-   * `search_workflows` is the bulk path (one paginated walk for the whole
-   * instance); `get_workflow_details` is the per-workflow fallback for
-   * workflows the search did not cover. Folder ID → path resolution happens
-   * through the REST folders API per distinct owning project, so imported
-   * files can carry human-readable `folder:` paths instead of opaque IDs.
+   * `search_workflows` is the bulk path (one listing, max 200, newest first).
+   * Workflows outside that window are looked up by name — still via search,
+   * because that is the MCP tool that returns `parentFolderId` for workflows
+   * that are not MCP-enabled. `get_workflow_details` is a last resort and
+   * only records a folder when n8n actually names one: a `null` from details
+   * is indistinguishable from "not loaded", so it must not become "root".
+   * Folder ID → path resolution happens through the REST folders API per
+   * distinct owning project, so imported files can carry human-readable
+   * `folder:` paths instead of opaque IDs.
    */
   async buildFolderInfo(workflows: Workflow[]): Promise<FolderInfo> {
     const folderByWorkflow = new Map<string, string | null>();
     const wanted = new Set(workflows.map((w) => w.id).filter((id): id is string => !!id));
-
-    // Bulk: one search over the instance. The tool takes a `limit` (max 200)
-    // but no pagination cursor, so beyond 200 workflows the per-workflow
-    // fallback below fills the gaps.
-    const resp = await this.mcp.searchWorkflows({ limit: 200 });
-    for (const item of resp.data) {
-      const id = typeof item.id === "string" ? item.id : undefined;
-      if (!id) continue;
-      folderByWorkflow.set(
-        id,
-        typeof item.parentFolderId === "string" ? item.parentFolderId : null,
-      );
+    const nameById = new Map<string, string>();
+    for (const w of workflows) {
+      if (w.id && w.name) nameById.set(w.id, w.name);
     }
 
-    // Fallback: ask for details on workflows the search did not cover.
+    const recordHits = (items: Array<Record<string, unknown>>): void => {
+      for (const item of items) {
+        const id = typeof item.id === "string" ? item.id : undefined;
+        if (!id || !wanted.has(id) || folderByWorkflow.has(id)) continue;
+        // n8n < 2.37.0 returns search hits without parentFolderId. Missing
+        // is unknown, not root — writing null would flatten UI folders.
+        if (!Object.hasOwn(item, "parentFolderId")) continue;
+        folderByWorkflow.set(
+          id,
+          typeof item.parentFolderId === "string" ? item.parentFolderId : null,
+        );
+      }
+    };
+
+    // Bulk: one search over the instance. The tool takes a `limit` (max 200)
+    // and no pagination cursor, so this only covers the most recently updated
+    // slice. Hits for workflows we are not importing are ignored.
+    const resp = await this.mcp.searchWorkflows({ limit: 200 });
+    recordHits(resp.data);
+
+    // Name-filtered search: n8n matches on name/description, still returns
+    // parentFolderId, and is not gated on availableInMCP.
+    for (const id of wanted) {
+      if (folderByWorkflow.has(id)) continue;
+      const name = nameById.get(id)?.trim();
+      if (!name) continue;
+      try {
+        const named = await this.mcp.searchWorkflows({ limit: 200, query: name });
+        recordHits(named.data);
+      } catch {
+        // Same degrade as details: unknown, not root.
+      }
+    }
+
+    // Last resort for MCP-enabled workflows the name search still missed.
+    // Only a concrete folder id is trusted — details often emits null when
+    // the parentFolder relation was not loaded.
     for (const id of wanted) {
       if (folderByWorkflow.has(id)) continue;
       try {
         const details = await this.mcp.getWorkflowDetails(id);
-        const workflow = details.workflow;
-        const parentFolderId = workflow?.parentFolderId;
-        folderByWorkflow.set(id, typeof parentFolderId === "string" ? parentFolderId : null);
+        const parentFolderId = details.workflow?.parentFolderId;
+        if (typeof parentFolderId === "string") folderByWorkflow.set(id, parentFolderId);
       } catch {
         // Leave unresolvable workflows out of the map — the writer treats an
         // absent entry as "folder unknown", not as "project root".

--- a/tests/api/mcp-client.test.ts
+++ b/tests/api/mcp-client.test.ts
@@ -131,6 +131,17 @@ describe("McpClient transport", () => {
     expect(params.name).toBe("search_workflows");
   });
 
+  test("searchWorkflows forwards a name query", async () => {
+    const { client, requests } = clientWithHandler(({ body }) =>
+      rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),
+    );
+    await client.searchWorkflows({ query: "勉強会進行", limit: 50 });
+    const call = requests.find((r) => r.body.method === "tools/call");
+    const params = call?.body.params as { name: string; arguments: Record<string, unknown> };
+    expect(params.arguments.query).toBe("勉強会進行");
+    expect(params.arguments.limit).toBe(50);
+  });
+
   test("direct mode sends the Bearer token; proxy mode sends no Authorization at all", async () => {
     const direct = clientWithHandler(
       ({ body }) => rpcResult(body.id, { structuredContent: { data: [], count: 0 } }),

--- a/tests/importer/folder-source.test.ts
+++ b/tests/importer/folder-source.test.ts
@@ -45,6 +45,7 @@ function fakeFolderService(folders: Folder[]): FolderService {
 /** In-memory MCP tool server for the folder-reading tools. */
 function fakeMcpClient(state: {
   search?: Array<Record<string, unknown>>;
+  extraSearch?: Array<Record<string, unknown>>;
   details?: Record<string, Record<string, unknown>>;
   fail?: boolean;
 }): McpClient {
@@ -59,8 +60,18 @@ function fakeMcpClient(state: {
     if (body.method === "initialize") {
       result = { protocolVersion: "2025-06-18" };
     } else if (body.params?.name === "search_workflows") {
+      const query = body.params.arguments?.query;
+      let data = state.search ?? [];
+      if (typeof query === "string" && query.length > 0) {
+        const pool = [...data, ...(state.extraSearch ?? [])];
+        data = pool.filter((item) => {
+          const id = String(item.id ?? "");
+          const name = String(item.name ?? "");
+          return id === query || name.includes(query);
+        });
+      }
       result = {
-        structuredContent: { data: state.search ?? [], count: (state.search ?? []).length },
+        structuredContent: { data, count: data.length },
       };
     } else if (body.params?.name === "get_workflow_details") {
       const wf = state.details?.[String(body.params.arguments?.workflowId ?? "")];
@@ -128,11 +139,36 @@ describe("McpFolderSource.buildFolderInfo", () => {
     expect(info.folderByWorkflow.get("wf1")).toBe("fold1");
     expect(info.folderByWorkflow.get("wf2")).toBeNull(); // root, explicitly
     expect(info.pathById.get("fold1")).toBe("Reporting");
-    // A folder the API no longer lists keeps its ID as the addressable path.
+    expect(info.folderByWorkflow.get("wf3")).toBe("fold-deleted");
     expect(info.pathById.get("fold-deleted")).toBe("fold-deleted");
   });
 
-  test("workflows the search did not cover fall back to get_workflow_details", async () => {
+  test("a search hit without parentFolderId is unknown, not the project root", async () => {
+    const mcp = fakeMcpClient({
+      search: [{ id: "wf1", name: "wf-wf1" }],
+    });
+    const source = new McpFolderSource(mcp, fakeFolderService([]));
+    const info = await source.buildFolderInfo([remoteWorkflow("wf1")]);
+    expect(info.folderByWorkflow.has("wf1")).toBe(false);
+  });
+
+  test("workflows the bulk search did not cover are looked up by name", async () => {
+    const mcp = fakeMcpClient({
+      search: [{ id: "wf1", parentFolderId: "fold1" }],
+      extraSearch: [{ id: "wf2", name: "wf-wf2", parentFolderId: "fold1" }],
+    });
+    const source = new McpFolderSource(
+      mcp,
+      fakeFolderService([{ id: "fold1", name: "Reporting", parentFolderId: null }]),
+    );
+
+    const info = await source.buildFolderInfo([remoteWorkflow("wf1"), remoteWorkflow("wf2")]);
+
+    expect(info.folderByWorkflow.get("wf1")).toBe("fold1");
+    expect(info.folderByWorkflow.get("wf2")).toBe("fold1");
+  });
+
+  test("workflows the search did not cover fall back to get_workflow_details when it names a folder", async () => {
     const mcp = fakeMcpClient({
       search: [{ id: "wf1", parentFolderId: "fold1" }],
       details: { wf2: { id: "wf2", parentFolderId: "fold1" } },
@@ -146,6 +182,17 @@ describe("McpFolderSource.buildFolderInfo", () => {
 
     expect(info.folderByWorkflow.get("wf1")).toBe("fold1");
     expect(info.folderByWorkflow.get("wf2")).toBe("fold1");
+  });
+
+  test("get_workflow_details returning null is not treated as the project root", async () => {
+    const mcp = fakeMcpClient({
+      search: [],
+      details: { "wf-missing": { id: "wf-missing", parentFolderId: null } },
+    });
+    const source = new McpFolderSource(mcp, fakeFolderService([]));
+
+    const info = await source.buildFolderInfo([remoteWorkflow("wf-missing")]);
+    expect(info.folderByWorkflow.has("wf-missing")).toBe(false);
   });
 
   test("a workflow no MCP tool can resolve is simply absent from the map", async () => {


### PR DESCRIPTION
## Summary
- `search_workflows` has no cursor and maxes at 200, so `import --mcp` missed older workflows
- Name-filtered search is the fallback that still returns `parentFolderId` (n8n 2.37+); `get_workflow_details` is refused unless `availableInMCP` is on
- Hits without `parentFolderId` stay unknown so older n8n cannot flatten UI folders to root

## Test plan
- [x] `bun test tests/importer/folder-source.test.ts tests/api/mcp-client.test.ts`
- [ ] Live `import --mcp` against n8n 2.37+ attaches `parentFolderId` / `folder` for a workflow outside the newest 200


Made with [Cursor](https://cursor.com)